### PR TITLE
Ignore all files and directories starting with a dot

### DIFF
--- a/src/fdc/DirAsDSK.cc
+++ b/src/fdc/DirAsDSK.cc
@@ -706,15 +706,15 @@ void DirAsDSK::addNewHostFiles(const string& hostSubDir, unsigned msxDirSector)
 
 	for (auto& hostName : hostNames) {
 		try {
+			if (StringOp::startsWith(hostName, '.')) {
+				continue;
+			}
 			string fullHostName = hostDir + hostSubDir + hostName;
 			FileOperations::Stat fst;
 			if (!FileOperations::getStat(fullHostName, fst)) {
 				throw MSXException("Error accessing " + fullHostName);
 			}
 			if (FileOperations::isDirectory(fst)) {
-				if ((hostName == "..") || (hostName == ".")) {
-					continue;
-				}
 				addNewDirectory(hostSubDir, hostName, msxDirSector, fst);
 			} else if (FileOperations::isRegularFile(fst)) {
 				addNewHostFile(hostSubDir, hostName, msxDirSector, fst);


### PR DESCRIPTION
When using a git repository as disk (with the dirAsDisk) it shows all hidden .git files/directories in my emulated MSX as normal files/directories. These files are using a lot of the 700K disk space :(

This fix will ignore all files and directories starting with a dot.
