### PR TITLE
Added HB-4100 extension file (64Kb RAM expansion)

### DIFF
--- a/share/extensions/Sharp_HB-4100.xml
+++ b/share/extensions/Sharp_HB-4100.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<!DOCTYPE msxconfig SYSTEM 'msxconfig2.dtd'>
+<msxconfig>
+    <info>
+        <name>Expansão de Memória RAM 64Kb</name>
+        <manufacturer>Sharp</manufacturer>
+        <code>HB-4100</code>
+        <release_year>1987</release_year>
+        <description>Sharp 64Kb expansion RAM cartridge</description>
+        <type>RAM expansion</type>
+    </info>
+    <devices>
+        <primary slot="any">
+            <secondary slot="any">
+                <RAM id="HB-4100">
+                    <mem base="0x0000" size="0x10000"/>
+                </RAM>
+            </secondary>
+        </primary>
+    </devices>
+</msxconfig>


### PR DESCRIPTION
The [HB-4100](https://www.msx.org/wiki/Sharp-Epcom_HB-4100) is a 64KiB memory expansion cartridge used by HB-MCP (a CP/M 2.2 version) as RAMDISK and by MT-BASE (a dutch database manager and sold in Brazil by Sharp as HOTDATA).