### PR TITLE
Typo fix

### DIFF
--- a/share/machines/Sanyo_MPC-2.xml
+++ b/share/machines/Sanyo_MPC-2.xml
@@ -10,7 +10,7 @@
     <type>MSX</type>
   </info>
 
-  <!-- This config is based on Alexandre Souzo's machine with serial number 11248522
+  <!-- This config is based on Alexandre Souza's machine with serial number 11248522
 
        Z80 scf: 01ED09ED01FC09FC (turboR)
        Z80 cpl: 3AFF12D7 (standard)


### PR DESCRIPTION
If you go to http://tabajara-labs.blogspot.com/2018/06/esmiuncando-o-msx-kibe-ax-230-da-al.html, it clearly says that his name is "Alexandre Souza" with an "A" at the end instead of an "O".