### PR TITLE
compile: Add advisory note against using Xcode 10.

### DIFF
--- a/doc/manual/compile.html
+++ b/doc/manual/compile.html
@@ -191,6 +191,13 @@ GCW Zero toolchain. This toolchain is for x86 Linux; if you have an x86 machine 
 Install Xcode from Apple, which you can find in the Mac App Store. The openMSX build is not done inside the Xcode IDE, but it uses the SDK and command line tools that are provided by Xcode.
 </p>
 
+<p>
+<strong>Note:</strong> Currently Xcode 10 and higher have a
+<a href="https://github.com/openMSX/openMSX/issues/1126">known issue</a> and are
+not supported. You can get the older Xcode 9.4.1 distribution from the
+<a href="https://developer.apple.com/download/more/">Apple Developer Portal</a>.
+</p>
+
 <h4>Visual C++</h4>
 
 <p>To build with Visual C++ you need to have the latest version of it installed. Currently, this is 2017.</p>


### PR DESCRIPTION
Instead recommending people to download Xcode 9.4.1.
See issue #1126.