### PR TITLE
Launch openMSX with retina support on macOS.

### DIFF
--- a/build/package-darwin/Info.plist
+++ b/build/package-darwin/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 	<key>CFAppleHelpAnchor</key>
 	<string>index</string>
 	<key>CFBundleDocumentTypes</key>

--- a/build/package-darwin/Info.plist
+++ b/build/package-darwin/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFAppleHelpAnchor</key>


### PR DESCRIPTION
This makes the window chrome appear sharp rather than blurred on a retina display.

Before:

<img width="752" alt="schermafbeelding 2018-12-01 om 12 22 20" src="https://user-images.githubusercontent.com/772052/49327659-e9548d00-f563-11e8-89e4-ce3843e4f411.png">

After:

<img width="752" alt="schermafbeelding 2018-12-01 om 12 23 14" src="https://user-images.githubusercontent.com/772052/49327672-1f920c80-f564-11e8-9dde-7b221a632535.png">

Note that if you symlink to openMSX and run it from the command line it currently already ignores the app’s Info.plist settings and opens the window with retina support, and I’ve been running openMSX like this for years without issues.