### PR TITLE
Exotic arch fixes

### DIFF
--- a/build/cpu.py
+++ b/build/cpu.py
@@ -88,6 +88,12 @@ class PPC64(CPU):
 	name = 'ppc64'
 	bigEndian = True
 
+class PPC64LE(CPU):
+	'''64-bit Power PC LE.
+	'''
+	name = 'ppc64le'
+	bigEndian = False
+
 class S390(CPU):
 	'''IBM S/390.
 	'''

--- a/build/detectsys.py
+++ b/build/detectsys.py
@@ -22,6 +22,8 @@ def detectCPU():
 		return 'x86_64'
 	elif cpu in ('x86', 'i386', 'i486', 'i586', 'i686'):
 		return 'x86'
+	elif cpu == 'ppc64le':
+		return 'ppc64le'
 	elif cpu.startswith('ppc') or cpu.endswith('ppc') or cpu.startswith('power'):
 		return 'ppc64' if cpu.endswith('64') else 'ppc'
 	elif cpu.startswith('arm'):

--- a/src/utils/small_compare.hh
+++ b/src/utils/small_compare.hh
@@ -81,7 +81,7 @@ template<typename T, T v, T m> struct ScValBeImpl<T, v, m> {
 };
 template<typename T, T v, T m, char N0, char ...Ns> struct ScValBeImpl<T, v, m, N0, Ns...>
 	: ScValBeImpl<T, (v << 8) + T(N0 & 255), (m >> 8), Ns...> {};
-template<typename T, char ...Ns> struct ScValBe : ScValBeImpl<T, 0, -1, Ns...> {};
+template<typename T, char ...Ns> struct ScValBe : ScValBeImpl<T, 0, T(-1), Ns...> {};
 
 // ScVal: combines all given characters in one value of type T, also computes a
 // mask-value with 1-bits in the 'used' positions.


### PR DESCRIPTION
2 compile fixes for ppc64le and s390 architectures.