### PR TITLE
remove 'dead' code

### DIFF
--- a/src/memory/RomFactory.cc
+++ b/src/memory/RomFactory.cc
@@ -146,14 +146,6 @@ static RomType guessRomType(const Rom& rom)
 				type = static_cast<RomType>(i);
 			}
 		}
-		// in case of doubt we go for type ROM_GENERIC_8KB
-		// in case of even type ROM_ASCII16 and ROM_ASCII8 we would
-		// prefer ROM_ASCII16 but we would still prefer ROM_GENERIC_8KB
-		// above ROM_ASCII8 or ROM_ASCII16
-		if ((type == ROM_ASCII16) &&
-		    (typeGuess[ROM_GENERIC_8KB] == typeGuess[ROM_ASCII16])) {
-			type = ROM_GENERIC_8KB;
-		}
 		return type;
 	}
 }


### PR DESCRIPTION
    the condition:
    ```
            ((type == ROM_ASCII16) &&
                (typeGuess[ROM_GENERIC_8KB] == typeGuess[ROM_ASCII16]))
    ```
    is always `false` due to the fact that `typeGuess[ROM_GENERIC_8KB]`
    is always zero and `type` is initialized as `ROM_GENERIC_8KB` -
    would change to `ROM_ASCII16` only if `typeGuess[ROM_ASCII16]` > 0
    which makes second part of condition `false`

    PS i wanted to track down to commit which has changed some logic and created
    this leftover but it wasn't possible - some part of commit history was lost
    during move from svn to git and this code was already there back in 2004