### PR TITLE
Replace WavData with WavReader

### DIFF
--- a/src/cassette/WavImage.hh
+++ b/src/cassette/WavImage.hh
@@ -22,8 +22,6 @@ public:
 	void fillBuffer(unsigned pos, int** bufs, unsigned num) const override;
 
 private:
-	int16_t getSample(unsigned pos) const;
-
 	WavData wav;
 	DynamicClock clock;
 };

--- a/src/sound/SamplePlayer.cc
+++ b/src/sound/SamplePlayer.cc
@@ -73,12 +73,7 @@ void SamplePlayer::setWavParams()
 	if ((currentSampleNum < samples.size()) &&
 	    samples[currentSampleNum].getSize()) {
 		auto& wav = samples[currentSampleNum];
-		sampBuf = wav.getData();
 		bufferSize = wav.getSize();
-
-		unsigned bits = wav.getBits();
-		assert((bits == 8) || (bits == 16));
-		bits8 = (bits == 8);
 
 		unsigned freq = wav.getFreq();
 		if (freq != getInputRate()) {
@@ -102,13 +97,6 @@ void SamplePlayer::repeat(unsigned sampleNum)
 	}
 }
 
-inline int SamplePlayer::getSample(unsigned idx)
-{
-	return bits8
-	     ? (static_cast<const uint8_t*>(sampBuf)[idx] - 0x80) * 256
-	     :  static_cast<const int16_t*>(sampBuf)[idx];
-}
-
 void SamplePlayer::generateChannels(int** bufs, unsigned num)
 {
 	// Single channel device: replace content of bufs[0] (not add to it).
@@ -116,6 +104,8 @@ void SamplePlayer::generateChannels(int** bufs, unsigned num)
 		bufs[0] = nullptr;
 		return;
 	}
+
+	auto& wav = samples[currentSampleNum];
 	for (unsigned i = 0; i < num; ++i) {
 		if (index >= bufferSize) {
 			if (nextSampleNum != unsigned(-1)) {
@@ -129,7 +119,7 @@ void SamplePlayer::generateChannels(int** bufs, unsigned num)
 				break;
 			}
 		}
-		bufs[0][i] = 3 * getSample(index++);
+		bufs[0][i] = 3 * wav.getSample(index++);
 	}
 }
 

--- a/src/sound/SamplePlayer.hh
+++ b/src/sound/SamplePlayer.hh
@@ -45,7 +45,6 @@ public:
 	void serialize(Archive& ar, unsigned version);
 
 private:
-	int getSample(unsigned idx);
 	void setWavParams();
 	void doRepeat();
 
@@ -54,12 +53,10 @@ private:
 
 	std::vector<WavData> samples;
 
-	const void* sampBuf;
 	unsigned index;
 	unsigned bufferSize;
 	unsigned currentSampleNum;
 	unsigned nextSampleNum;
-	bool bits8;
 };
 
 } // namespace openmsx

--- a/src/sound/WavAudioInput.cc
+++ b/src/sound/WavAudioInput.cc
@@ -25,7 +25,7 @@ WavAudioInput::~WavAudioInput()
 
 void WavAudioInput::loadWave()
 {
-	wav = WavData(audioInputFilenameSetting.getString().str(), 16, 0);
+	wav = WavData(audioInputFilenameSetting.getString().str());
 }
 
 const string& WavAudioInput::getName() const
@@ -75,10 +75,7 @@ int16_t WavAudioInput::readSample(EmuTime::param time)
 {
 	if (wav.getSize()) {
 		unsigned pos = (time - reference).getTicksAt(wav.getFreq());
-		if (pos < wav.getSize()) {
-			auto buf = static_cast<const int16_t*>(wav.getData());
-			return buf[pos];
-		}
+		return wav.getSample(pos);
 	}
 	return 0;
 }

--- a/src/sound/WavData.hh
+++ b/src/sound/WavData.hh
@@ -7,25 +7,23 @@
 
 namespace openmsx {
 
-class WavData
+class WavData final
 {
 public:
 	/** Construct empty wav. */
 	WavData() = default;
 
-	/** Construct from .wav file, optionally convert to a specific
-	 * bit-depth and sample rate. */
-	explicit WavData(const std::string& filename, unsigned bits = 0, unsigned freq = 0);
+	/** Construct from .wav file. */
+	explicit WavData(const std::string& filename);
 
 	unsigned getFreq() const { return freq; }
-	unsigned getBits() const { return bits; }
 	unsigned getSize() const { return length; }
-	const void* getData() const { return buffer.data(); }
-	      void* getData()       { return buffer.data(); }
+	const int16_t* getData() const { return buffer.data(); }
+	      int16_t* getData()       { return buffer.data(); }
+	int16_t getSample(unsigned pos) const;
 
 private:
-	MemBuffer<uint8_t> buffer;
-	unsigned bits;
+	MemBuffer<int16_t> buffer;
 	unsigned freq;
 	unsigned length = 0;
 };

--- a/src/sound/YM2413Test.cc
+++ b/src/sound/YM2413Test.cc
@@ -52,10 +52,8 @@ static void loadWav(const string& filename, Samples& data)
 {
 	WavData wav(filename);
 	assert(wav.getFreq() == 3579545 / 72);
-	assert(wav.getBits() == 16);
-	assert(wav.getChannels() == 1);
 
-	auto rawData = reinterpret_cast<const int16_t*>(wav.getData());
+	auto rawData = wav.getData();
 	data.assign(rawData, rawData + wav.getSize());
 }
 


### PR DESCRIPTION
This patch replaces the usage of SDL_LoadWAV() with a custom implementation. Instead of loading the entire WAV file into RAM, WavReader uses a precached file. Furthermore the difference between 8bit unsigned and 16bit signed PCM is abstracted away and the need for several different getSample() implementations is removed.