### PR TITLE
Fixed python3 error when building from shallow checkout

### DIFF
--- a/build/executils.py
+++ b/build/executils.py
@@ -44,8 +44,8 @@ def captureStdout(log, commandLine):
 		log.write('%s executing "%s"\n' % (severity.capitalize(), commandLine))
 		# pylint 0.18.0 somehow thinks stderrdata is a list, not a string.
 		# pylint: disable-msg=E1103
-		stderrdata = stderrdata.replace('\r', '')
-		log.write(stderrdata.decode('utf-8'))
+		stderrdata = stderrdata.decode('utf-8').replace('\r', '')
+		log.write(stderrdata)
 		if not stderrdata.endswith('\n'):
 			log.write('\n')
 	if proc.returncode == 0:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "build/version2code.py", line 18, in <module>
    rewriteIfChanged(sys.argv[1], iterVersionInclude())
  File "/home/jools/Repos/RetroPie/RetroPie-Setup/tmp/build/openmsx/build/outpututils.py", line 20, in rewriteIfChanged
    newLines = [line + '\n' for line in lines]
  File "/home/jools/Repos/RetroPie/RetroPie-Setup/tmp/build/openmsx/build/outpututils.py", line 20, in <listcomp>
    newLines = [line + '\n' for line in lines]
  File "build/version2code.py", line 9, in iterVersionInclude
    revision = extractRevisionString()
  File "/home/jools/Repos/RetroPie/RetroPie-Setup/tmp/build/openmsx/build/version.py", line 81, in extractRevisionString
    return extractRevision() or 'unknown'
  File "/home/jools/Repos/RetroPie/RetroPie-Setup/tmp/build/openmsx/build/version.py", line 70, in extractRevision
    revision = extractGitRevision(log)
  File "/home/jools/Repos/RetroPie/RetroPie-Setup/tmp/build/openmsx/build/version.py", line 47, in extractGitRevision
    log, 'git describe --dirty', r'\S+?-(\S+)$'
  File "/home/jools/Repos/RetroPie/RetroPie-Setup/tmp/build/openmsx/build/version.py", line 31, in _extractRevisionFromStdout
    text = captureStdout(log, command)
  File "/home/jools/Repos/RetroPie/RetroPie-Setup/tmp/build/openmsx/build/executils.py", line 47, in captureStdout
    stderrdata = stderrdata.replace('\r', '')
TypeError: a bytes-like object is required, not 'str'
make: *** [build/main.mk:423: derived/x86_64-linux-opt/config/Version.ii] Error 1
```

This only occurs when doing a shallow checkout on my system - I assume the git code is causing an error only in this case so captureStdout is called which has the issue on python3

System is x86_64 linux runing Ubuntu 19.04