### PR TITLE
T9769 applies VDP I/O waitcycles only on Z80

### DIFF
--- a/src/cpu/MSXCPU.cc
+++ b/src/cpu/MSXCPU.cc
@@ -188,10 +188,10 @@ void MSXCPU::wait(EmuTime::param time)
 	          : r800->wait(time);
 }
 
-EmuTime MSXCPU::waitCycles(EmuTime::param time, unsigned cycles)
+EmuTime MSXCPU::waitCyclesZ80(EmuTime::param time, unsigned cycles)
 {
 	return z80Active ? z80 ->waitCycles(time, cycles)
-	                 : r800->waitCycles(time, cycles);
+	                 : time;
 }
 
 EmuTime MSXCPU::waitCyclesR800(EmuTime::param time, unsigned cycles)

--- a/src/cpu/MSXCPU.hh
+++ b/src/cpu/MSXCPU.hh
@@ -110,7 +110,7 @@ public:
 	void setNextSyncPoint(EmuTime::param time);
 
 	void wait(EmuTime::param time);
-	EmuTime waitCycles(EmuTime::param time, unsigned cycles);
+	EmuTime waitCyclesZ80(EmuTime::param time, unsigned cycles);
 	EmuTime waitCyclesR800(EmuTime::param time, unsigned cycles);
 
 	CPURegs& getRegisters();

--- a/src/video/VDP.cc
+++ b/src/video/VDP.cc
@@ -643,7 +643,7 @@ void VDP::writeIO(word port, byte value, EmuTime::param time_)
 	// It seems to originate from the T9769x and for x=C the delay is 1
 	// cycle and for other x it seems the delay is 2 cycles
 	if (fixedVDPIOdelayCycles > 0) {
-		time = cpu.waitCycles(time, fixedVDPIOdelayCycles);
+		time = cpu.waitCyclesZ80(time, fixedVDPIOdelayCycles);
 	}
 
 	assert(isInsideFrame(time));


### PR DESCRIPTION
The reason for this is that both the Z80 and the waitcycle circuit are internal to the T9769 MSX-ENGINE and do not manifest externally. The situation before this patch caused a 1 or 2 cycle wait on R800 which does not exist in real hardware.