### PR TITLE
Fix V9990 P2 background rendering

### DIFF
--- a/src/video/v9990/V9990PxConverter.hh
+++ b/src/video/v9990/V9990PxConverter.hh
@@ -42,4 +42,3 @@ private:
 } // namespace openmsx
 
 #endif
-


### PR DESCRIPTION
In P1, each layer has its own palette offset. However, the coupling between palette offset and layer really comes from the fact that layer A patterns are in VRAM0, and layer B patterns are in VRAM1. This coupling between palette offset en VRAM chips also exists in P2, in which pattern data is interleaved between VRAM0 and VRAM1. Thus, even and odd bytes each have their own palette offset.

This patch implements that by always alternating between two palette offsets for even and odd bytes. In the case of P1 both offsets are the same for each respective layer.