### PR TITLE
Make it possible to use non-SDL video backends

### DIFF
--- a/src/Reactor.cc
+++ b/src/Reactor.cc
@@ -555,21 +555,24 @@ void Reactor::run(CommandLineParser& parser)
 		}
 	}
 
-	while (running) {
-		eventDistributor->deliverEvents();
-		assert(garbageBoards.empty());
-		bool blocked = (blockedCounter > 0) || !activeBoard;
-		if (!blocked) blocked = !activeBoard->execute();
-		if (blocked) {
-			// At first sight a better alternative is to use the
-			// SDL_WaitEvent() function. Though when inspecting
-			// the implementation of that function, it turns out
-			// to also use a sleep/poll loop, with even shorter
-			// sleep periods as we use here. Maybe in future
-			// SDL implementations this will be improved.
-			eventDistributor->sleep(20 * 1000);
-		}
+	while(iterate());
+}
+
+bool Reactor::iterate() {
+	eventDistributor->deliverEvents();
+	assert(garbageBoards.empty());
+	bool blocked = (blockedCounter > 0) || !activeBoard;
+	if (!blocked) blocked = !activeBoard->execute();
+	if (blocked) {
+		// At first sight a better alternative is to use the
+		// SDL_WaitEvent() function. Though when inspecting
+		// the implementation of that function, it turns out
+		// to also use a sleep/poll loop, with even shorter
+		// sleep periods as we use here. Maybe in future
+		// SDL implementations this will be improved.
+		eventDistributor->sleep(20 * 1000);
 	}
+	return running;
 }
 
 void Reactor::unpause()

--- a/src/Reactor.hh
+++ b/src/Reactor.hh
@@ -124,6 +124,8 @@ private:
 	// EventListener
 	int signalEvent(const std::shared_ptr<const Event>& event) override;
 
+	bool iterate();
+
 	void unpause();
 	void pause();
 

--- a/src/ReverseManager.cc
+++ b/src/ReverseManager.cc
@@ -320,7 +320,7 @@ static void reportProgress(Reactor& reactor, const EmuTime& targetTime, int perc
 		std::fmod(targetTimeDisp, 60.0) <<
 		"... " << percentage << '%';
 	reactor.getCliComm().printProgress(sstr.str());
-	reactor.getDisplay().repaint();
+	reactor.getDisplay().repaintDelayed(0);
 }
 
 void ReverseManager::goTo(

--- a/src/console/OSDWidget.cc
+++ b/src/console/OSDWidget.cc
@@ -1,5 +1,5 @@
 #include "OSDWidget.hh"
-#include "OutputSurface.hh"
+#include "SDLOutputSurface.hh"
 #include "Display.hh"
 #include "CommandException.hh"
 #include "TclObject.hh"
@@ -56,7 +56,7 @@ private:
 
 
 SDLScopedClip::SDLScopedClip(OutputSurface& output, vec2 xy, vec2 wh)
-	: renderer(output.getSDLRenderer())
+	: renderer(dynamic_cast<SDLOutputSurface&>(output).getSDLRenderer())
 {
 	ivec2 i_xy = round(xy); auto [x, y] = i_xy;
 	ivec2 i_wh = round(wh); auto [w, h] = i_wh;

--- a/src/file/FilePool.cc
+++ b/src/file/FilePool.cc
@@ -332,7 +332,7 @@ static void reportProgress(const string& filename, size_t percentage,
 {
 	reactor.getCliComm().printProgress(
 		"Calculating SHA1 sum for ", filename, "... ", percentage, '%');
-	reactor.getDisplay().repaint();
+	reactor.getDisplay().repaintDelayed(0);
 }
 
 static Sha1Sum calcSha1sum(File& file, Reactor& reactor)
@@ -467,7 +467,7 @@ File FilePool::scanFile(const Sha1Sum& sha1sum, const string& filename,
 			sha1sum.toString(), "...\nIndexing filepool ", poolPath,
 			": [", progress.amountScanned, "]: ",
 			std::string_view(filename).substr(poolPath.size()));
-		reactor.getDisplay().repaint();
+		reactor.getDisplay().repaintDelayed(0);
 	}
 
 	// Note: do NOT call 'reactor.getEventDistributor().deliverEvents()'.

--- a/src/ide/HD.cc
+++ b/src/ide/HD.cc
@@ -139,7 +139,7 @@ void HD::showProgress(size_t position, size_t maxPosition)
 		motherBoard.getMSXCliComm().printProgress(
 			"Calculating hash for ", filename.getResolved(),
 			"... ", percentage, '%');
-		motherBoard.getReactor().getDisplay().repaint();
+		motherBoard.getReactor().getDisplay().repaintDelayed(0);
 		everDidProgress = true;
 	}
 }

--- a/src/video/Deflicker.cc
+++ b/src/video/Deflicker.cc
@@ -14,7 +14,7 @@ namespace openmsx {
 template<typename Pixel> class DeflickerImpl final : public Deflicker
 {
 public:
-	DeflickerImpl(const SDL_PixelFormat& format,
+	DeflickerImpl(const PixelFormat& format,
 	              std::unique_ptr<RawFrame>* lastFrames);
 
 private:
@@ -27,16 +27,16 @@ private:
 
 
 std::unique_ptr<Deflicker> Deflicker::create(
-	const SDL_PixelFormat& format,
+	const PixelFormat& format,
 	std::unique_ptr<RawFrame>* lastFrames)
 {
 #if HAVE_16BPP
-	if (format.BitsPerPixel == 15 || format.BitsPerPixel == 16) {
+	if (format.getBytesPerPixel() == 2) {
 		return std::make_unique<DeflickerImpl<uint16_t>>(format, lastFrames);
 	}
 #endif
 #if HAVE_32BPP
-	if (format.BitsPerPixel == 32) {
+	if (format.getBytesPerPixel() == 4) {
 		return std::make_unique<DeflickerImpl<uint32_t>>(format, lastFrames);
 	}
 #endif
@@ -44,7 +44,7 @@ std::unique_ptr<Deflicker> Deflicker::create(
 }
 
 
-Deflicker::Deflicker(const SDL_PixelFormat& format,
+Deflicker::Deflicker(const PixelFormat& format,
                      std::unique_ptr<RawFrame>* lastFrames_)
 	: FrameSource(format)
 	, lastFrames(lastFrames_)
@@ -64,7 +64,7 @@ unsigned Deflicker::getLineWidth(unsigned line) const
 
 
 template<typename Pixel>
-DeflickerImpl<Pixel>::DeflickerImpl(const SDL_PixelFormat& format,
+DeflickerImpl<Pixel>::DeflickerImpl(const PixelFormat& format,
                                     std::unique_ptr<RawFrame>* lastFrames_)
 	: Deflicker(format, lastFrames_)
 	, pixelOps(format)

--- a/src/video/Deflicker.hh
+++ b/src/video/Deflicker.hh
@@ -13,13 +13,13 @@ class Deflicker : public FrameSource
 public:
 	// Factory method, actually returns a Deflicker subclass.
 	static std::unique_ptr<Deflicker> create(
-		const SDL_PixelFormat& format,
+		const PixelFormat& format,
 		std::unique_ptr<RawFrame>* lastFrames);
 	void init();
 	virtual ~Deflicker() = default;
 
 protected:
-	Deflicker(const SDL_PixelFormat& format,
+	Deflicker(const PixelFormat& format,
 	          std::unique_ptr<RawFrame>* lastFrames);
 
 	unsigned getLineWidth(unsigned line) const override;

--- a/src/video/DeinterlacedFrame.cc
+++ b/src/video/DeinterlacedFrame.cc
@@ -3,7 +3,7 @@
 
 namespace openmsx {
 
-DeinterlacedFrame::DeinterlacedFrame(const SDL_PixelFormat& format)
+DeinterlacedFrame::DeinterlacedFrame(const PixelFormat& format)
 	: FrameSource(format)
 {
 }

--- a/src/video/DeinterlacedFrame.hh
+++ b/src/video/DeinterlacedFrame.hh
@@ -12,7 +12,7 @@ namespace openmsx {
 class DeinterlacedFrame final : public FrameSource
 {
 public:
-	explicit DeinterlacedFrame(const SDL_PixelFormat& format);
+	explicit DeinterlacedFrame(const PixelFormat& format);
 	void init(FrameSource* evenField, FrameSource* oddField);
 
 private:

--- a/src/video/Display.cc
+++ b/src/video/Display.cc
@@ -175,7 +175,7 @@ Display::Layers::iterator Display::baseLayer()
 
 void Display::executeRT()
 {
-	repaint();
+	videoSystem->repaint();
 }
 
 int Display::signalEvent(const std::shared_ptr<const Event>& event)
@@ -183,7 +183,7 @@ int Display::signalEvent(const std::shared_ptr<const Event>& event)
 	if (event->getType() == OPENMSX_FINISH_FRAME_EVENT) {
 		auto& ffe = checked_cast<const FinishFrameEvent&>(*event);
 		if (ffe.needRender()) {
-			repaint();
+			videoSystem->repaint();
 			reactor.getEventDistributor().distributeEvent(
 				std::make_shared<SimpleEvent>(
 					OPENMSX_FRAME_DRAWN_EVENT));
@@ -211,7 +211,7 @@ int Display::signalEvent(const std::shared_ptr<const Event>& event)
 		//  port discovers that the graphics context is gone.
 		// -When gaining the focus, this repaint does nothing as
 		//  the renderFrozen flag is still false
-		repaint();
+		videoSystem->repaint();
 		auto& focusEvent = checked_cast<const FocusEvent&>(*event);
 		ad_printf("Setting renderFrozen to %d", !focusEvent.getGain());
 		renderFrozen = !focusEvent.getGain();

--- a/src/video/Display.hh
+++ b/src/video/Display.hh
@@ -46,6 +46,7 @@ public:
 	CommandConsole& getCommandConsole() { return commandConsole; }
 
 	/** Redraw the display.
+	  * repaint() should only be called from the VideoSystem.
 	  */
 	void repaint();
 	void repaint(OutputSurface& surface);

--- a/src/video/DoubledFrame.cc
+++ b/src/video/DoubledFrame.cc
@@ -3,7 +3,7 @@
 
 namespace openmsx {
 
-DoubledFrame::DoubledFrame(const SDL_PixelFormat& format)
+DoubledFrame::DoubledFrame(const PixelFormat& format)
 	: FrameSource(format)
 {
 }

--- a/src/video/DoubledFrame.hh
+++ b/src/video/DoubledFrame.hh
@@ -12,7 +12,7 @@ namespace openmsx {
 class DoubledFrame final : public FrameSource
 {
 public:
-	explicit DoubledFrame(const SDL_PixelFormat& format);
+	explicit DoubledFrame(const PixelFormat& format);
 	void init(FrameSource* field, unsigned skip);
 
 private:

--- a/src/video/DummyVideoSystem.cc
+++ b/src/video/DummyVideoSystem.cc
@@ -38,4 +38,8 @@ OutputSurface* DummyVideoSystem::getOutputSurface()
 	return nullptr;
 }
 
+void DummyVideoSystem::showCursor(bool /*show*/)
+{
+}
+
 } // namespace openmsx

--- a/src/video/DummyVideoSystem.cc
+++ b/src/video/DummyVideoSystem.cc
@@ -42,4 +42,8 @@ void DummyVideoSystem::showCursor(bool /*show*/)
 {
 }
 
+void DummyVideoSystem::repaint()
+{
+}
+
 } // namespace openmsx

--- a/src/video/DummyVideoSystem.hh
+++ b/src/video/DummyVideoSystem.hh
@@ -20,6 +20,7 @@ public:
 	void flush() override;
 	OutputSurface* getOutputSurface() override;
 	void showCursor(bool show) override;
+	void repaint() override;
 };
 
 } // namespace openmsx

--- a/src/video/DummyVideoSystem.hh
+++ b/src/video/DummyVideoSystem.hh
@@ -19,6 +19,7 @@ public:
 #endif
 	void flush() override;
 	OutputSurface* getOutputSurface() override;
+	void showCursor(bool show) override;
 };
 
 } // namespace openmsx

--- a/src/video/FBPostProcessor.cc
+++ b/src/video/FBPostProcessor.cc
@@ -5,7 +5,7 @@
 #include "RenderSettings.hh"
 #include "Scaler.hh"
 #include "ScalerFactory.hh"
-#include "OutputSurface.hh"
+#include "SDLOutputSurface.hh"
 #include "Math.hh"
 #include "aligned.hh"
 #include "random.hh"
@@ -204,10 +204,11 @@ void FBPostProcessor<Pixel>::drawNoiseLine(
 }
 
 template <class Pixel>
-void FBPostProcessor<Pixel>::drawNoise(OutputSurface& output)
+void FBPostProcessor<Pixel>::drawNoise(OutputSurface& output_)
 {
 	if (renderSettings.getNoise() == 0.0f) return;
 
+	auto& output = dynamic_cast<SDLOutputSurface&>(output_);
 	unsigned h = output.getHeight();
 	unsigned w = output.getWidth();
 	output.lock();
@@ -254,8 +255,9 @@ FBPostProcessor<Pixel>::~FBPostProcessor()
 }
 
 template <class Pixel>
-void FBPostProcessor<Pixel>::paint(OutputSurface& output)
+void FBPostProcessor<Pixel>::paint(OutputSurface& output_)
 {
+	auto& output = dynamic_cast<SDLOutputSurface&>(output_);
 	if (renderSettings.getInterleaveBlackFrame()) {
 		interleaveCount ^= 1;
 		if (interleaveCount) {

--- a/src/video/FBPostProcessor.cc
+++ b/src/video/FBPostProcessor.cc
@@ -237,7 +237,7 @@ FBPostProcessor<Pixel>::FBPostProcessor(MSXMotherBoard& motherBoard_,
 		motherBoard_, display_, screen_, videoSource, maxWidth_, height_,
 		canDoInterlace_)
 	, noiseShift(screen.getHeight())
-	, pixelOps(screen.getSDLFormat())
+	, pixelOps(screen.getPixelFormat())
 {
 	scaleAlgorithm = RenderSettings::NO_SCALER;
 	scaleFactor = unsigned(-1);
@@ -275,7 +275,7 @@ void FBPostProcessor<Pixel>::paint(OutputSurface& output_)
 		scaleAlgorithm = algo;
 		scaleFactor = factor;
 		currScaler = ScalerFactory<Pixel>::createScaler(
-			PixelOperations<Pixel>(output.getSDLFormat()),
+			PixelOperations<Pixel>(output.getPixelFormat()),
 			renderSettings);
 	}
 

--- a/src/video/FrameSource.cc
+++ b/src/video/FrameSource.cc
@@ -12,7 +12,7 @@
 
 namespace openmsx {
 
-FrameSource::FrameSource(const SDL_PixelFormat& format)
+FrameSource::FrameSource(const PixelFormat& format)
 	: pixelFormat(format)
 {
 }

--- a/src/video/FrameSource.hh
+++ b/src/video/FrameSource.hh
@@ -1,11 +1,10 @@
 #ifndef FRAMESOURCE_HH
 #define FRAMESOURCE_HH
 
+#include "PixelFormat.hh"
 #include "aligned.hh"
 #include <algorithm>
 #include <cassert>
-
-struct SDL_PixelFormat;
 
 namespace openmsx {
 
@@ -187,12 +186,12 @@ public:
 		return 0;
 	}
 
-	const SDL_PixelFormat& getSDLPixelFormat() const {
+	const PixelFormat& getPixelFormat() const {
 		return pixelFormat;
 	}
 
 protected:
-	explicit FrameSource(const SDL_PixelFormat& format);
+	explicit FrameSource(const PixelFormat& format);
 	~FrameSource() = default;
 
 	void setHeight(unsigned height_) { height = height_; }
@@ -211,7 +210,7 @@ protected:
 private:
 	/** Pixel format. Needed for getLinePtr scaling
 	  */
-	const SDL_PixelFormat& pixelFormat;
+	const PixelFormat& pixelFormat;
 
 	/** Number of lines in this frame.
 	  */

--- a/src/video/OutputSurface.cc
+++ b/src/video/OutputSurface.cc
@@ -4,25 +4,6 @@
 
 namespace openmsx {
 
-void OutputSurface::lock()
-{
-	if (isLocked()) return;
-	locked = true;
-	if (surface && SDL_MUSTLOCK(surface)) {
-		// Note: we ignore the return value from SDL_LockSurface()
-		SDL_LockSurface(surface);
-	}
-}
-
-void OutputSurface::unlock()
-{
-	if (!isLocked()) return;
-	locked = false;
-	if (surface && SDL_MUSTLOCK(surface)) {
-		SDL_UnlockSurface(surface);
-	}
-}
-
 void OutputSurface::calculateViewPort(gl::ivec2 physSize_)
 {
 	m_physSize = physSize_;
@@ -62,18 +43,14 @@ void OutputSurface::setSDLFormat(const SDL_PixelFormat& format_)
 #endif
 }
 
-void OutputSurface::setBufferPtr(char* data_, unsigned pitch_)
-{
-	data = data_;
-	pitch = pitch_;
-}
-
 void OutputSurface::flushFrameBuffer()
 {
+	UNREACHABLE;
 }
 
 void  OutputSurface::clearScreen()
 {
+	UNREACHABLE;
 }
 
 } // namespace openmsx

--- a/src/video/OutputSurface.cc
+++ b/src/video/OutputSurface.cc
@@ -1,6 +1,5 @@
 #include "OutputSurface.hh"
 #include "unreachable.hh"
-#include "build-info.hh"
 
 namespace openmsx {
 
@@ -18,29 +17,6 @@ void OutputSurface::calculateViewPort(gl::ivec2 physSize_)
 
 	gl::vec2 viewOffset = (physSize - viewSize) / 2.0f;
 	m_viewOffset = round(viewOffset);
-}
-
-void OutputSurface::setSDLFormat(const SDL_PixelFormat& format_)
-{
-	format = format_;
-#if HAVE_32BPP
-	// SDL sets an alpha channel only for GL modes. We want an alpha channel
-	// for all 32bpp output surfaces, so we add one ourselves if necessary.
-	if (format.BytesPerPixel == 4 && format.Amask == 0) {
-		unsigned rgbMask = format.Rmask | format.Gmask | format.Bmask;
-		if ((rgbMask & 0x000000FF) == 0) {
-			format.Amask  = 0x000000FF;
-			format.Ashift = 0;
-			format.Aloss  = 0;
-		} else if ((rgbMask & 0xFF000000) == 0) {
-			format.Amask  = 0xFF000000;
-			format.Ashift = 24;
-			format.Aloss  = 0;
-		} else {
-			UNREACHABLE;
-		}
-	}
-#endif
 }
 
 void OutputSurface::flushFrameBuffer()

--- a/src/video/OutputSurface.hh
+++ b/src/video/OutputSurface.hh
@@ -1,10 +1,10 @@
 #ifndef OUTPUTSURFACE_HH
 #define OUTPUTSURFACE_HH
 
+#include "PixelFormat.hh"
 #include "gl_vec.hh"
 #include <string>
 #include <cassert>
-#include <SDL.h>
 
 namespace openmsx {
 
@@ -30,7 +30,7 @@ public:
 	gl::vec2  getViewScale()  const { return m_viewScale; }
 	bool      isViewScaled()  const { return m_viewScale != gl::vec2(1.0f); }
 
-	const SDL_PixelFormat& getSDLFormat() const { return format; }
+	virtual const PixelFormat& getPixelFormat() const = 0;
 
 	/** Returns the pixel value for the given RGB color.
 	  * No effort is made to ensure that the returned pixel value is not the
@@ -43,11 +43,7 @@ public:
 
 	/** Same as mapRGB, but RGB components are in range [0..255].
 	 */
-	unsigned mapRGB255(gl::ivec3 rgb)
-	{
-		auto [r, g, b] = rgb;
-		return SDL_MapRGB(&format, r, g, b); // alpha is fully opaque
-	}
+	virtual unsigned mapRGB255(gl::ivec3 rgb) = 0;
 
 	/** Returns the color key for this output surface.
 	  */
@@ -114,10 +110,8 @@ protected:
 	OutputSurface() = default;
 
 	void calculateViewPort(gl::ivec2 physSize);
-	void setSDLFormat(const SDL_PixelFormat& format);
 
 private:
-	SDL_PixelFormat format;
 	gl::ivec2 m_physSize;
 	gl::ivec2 m_viewOffset;
 	gl::ivec2 m_viewSize;

--- a/src/video/OutputSurface.hh
+++ b/src/video/OutputSurface.hh
@@ -20,8 +20,8 @@ public:
 
 	virtual ~OutputSurface() = default;
 
-	int getWidth()  const { return surface->w; }
-	int getHeight() const { return surface->h; }
+	virtual int getWidth()  const = 0;
+	virtual int getHeight() const = 0;
 	gl::ivec2 getLogicalSize()  const { return {getWidth(), getHeight()}; }
 	gl::ivec2 getPhysicalSize() const { return m_physSize; }
 
@@ -31,8 +31,6 @@ public:
 	bool      isViewScaled()  const { return m_viewScale != gl::vec2(1.0f); }
 
 	const SDL_PixelFormat& getSDLFormat() const { return format; }
-	SDL_Surface* getSDLSurface()          const { return surface; }
-	SDL_Renderer* getSDLRenderer()        const { return renderer; }
 
 	/** Returns the pixel value for the given RGB color.
 	  * No effort is made to ensure that the returned pixel value is not the
@@ -97,31 +95,6 @@ public:
 		return mapKeyedRGB255<Pixel>(gl::ivec3(rgb * 255.0f));
 	}
 
-	/** Lock this OutputSurface.
-	  * Direct pixel access is only allowed on a locked surface.
-	  * Locking an already locked surface has no effect.
-	  */
-	void lock();
-
-	/** Unlock this OutputSurface.
-	  * @see lock().
-	  */
-	void unlock();
-
-	/** Is this OutputSurface currently locked?
-	  */
-	bool isLocked() const { return locked; }
-
-	/** Returns a pointer to the requested line in the pixel buffer.
-	  * Not all implementations support this operation, e.g. in SDLGL
-	  * you don't have direct access to a pixel buffer.
-	  */
-	template <typename Pixel>
-	Pixel* getLinePtrDirect(unsigned y) {
-		assert(isLocked());
-		return reinterpret_cast<Pixel*>(data + y * pitch);
-	}
-
 	/** Copy frame buffer to display buffer.
 	  * The default implementation does nothing.
 	  */
@@ -141,23 +114,14 @@ protected:
 	OutputSurface() = default;
 
 	void calculateViewPort(gl::ivec2 physSize);
-	void setSDLSurface(SDL_Surface* surface_) { surface = surface_; }
-	void setSDLRenderer(SDL_Renderer* r) { renderer = r; }
 	void setSDLFormat(const SDL_PixelFormat& format);
-	void setBufferPtr(char* data, unsigned pitch);
 
 private:
-	SDL_Surface* surface = nullptr;
-	SDL_Renderer* renderer = nullptr;
 	SDL_PixelFormat format;
-	char* data;
-	unsigned pitch;
 	gl::ivec2 m_physSize;
 	gl::ivec2 m_viewOffset;
 	gl::ivec2 m_viewSize;
 	gl::vec2 m_viewScale{1.0f};
-
-	bool locked = false;
 };
 
 } // namespace openmsx

--- a/src/video/OutputSurface.hh
+++ b/src/video/OutputSurface.hh
@@ -10,7 +10,7 @@ namespace openmsx {
 
 /** A frame buffer where pixels can be written to.
   * It could be an in-memory buffer or a video buffer visible to the user
-  * (see VisibleSurface subclass).
+  * (see *OffScreenSurface and *VisibleSurface classes).
   */
 class OutputSurface
 {

--- a/src/video/PNG.cc
+++ b/src/video/PNG.cc
@@ -1,5 +1,4 @@
 #include "PNG.hh"
-#include "SDLSurfacePtr.hh"
 #include "MSXException.hh"
 #include "File.hh"
 #include "build-info.hh"
@@ -379,15 +378,15 @@ static void save(SDL_Surface* image, const std::string& filename)
 }
 
 void save(unsigned width, unsigned height, const void** rowPointers,
-          const SDL_PixelFormat& format, const std::string& filename)
+          const PixelFormat& format, const std::string& filename)
 {
 	// this implementation creates 1 extra copy, can be optimized if required
 	SDLSurfacePtr surface(
-		width, height, format.BitsPerPixel,
-		format.Rmask, format.Gmask, format.Bmask, format.Amask);
+		width, height, format.getBpp(),
+		format.getRmask(), format.getGmask(), format.getBmask(), format.getAmask());
 	for (unsigned y = 0; y < height; ++y) {
 		memcpy(surface.getLinePtr(y),
-		       rowPointers[y], width * format.BytesPerPixel);
+		       rowPointers[y], width * format.getBytesPerPixel());
 	}
 	save(surface.get(), filename);
 }

--- a/src/video/PNG.hh
+++ b/src/video/PNG.hh
@@ -1,10 +1,9 @@
 #ifndef PNG_HH
 #define PNG_HH
 
+#include "PixelFormat.hh"
 #include "SDLSurfacePtr.hh"
 #include <string>
-
-struct SDL_PixelFormat;
 
 /** Utility functions to hide the complexity of saving to a PNG file.
   */
@@ -18,7 +17,7 @@ namespace openmsx::PNG {
 	SDLSurfacePtr load(const std::string& filename, bool want32bpp);
 
 	void save(unsigned width, unsigned height, const void** rowPointers,
-	          const SDL_PixelFormat& format, const std::string& filename);
+	          const PixelFormat& format, const std::string& filename);
 	void save(unsigned width, unsigned height, const void** rowPointers,
 	          const std::string& filename);
 	void saveGrayscale(unsigned width, unsigned height,

--- a/src/video/PixelFormat.hh
+++ b/src/video/PixelFormat.hh
@@ -1,0 +1,31 @@
+#ifndef PIXELFORMAT_HH
+#define PIXELFORMAT_HH
+
+namespace openmsx {
+
+class PixelFormat
+{
+public:
+	PixelFormat() = default;
+	virtual ~PixelFormat() = default;
+
+	virtual unsigned map(unsigned r, unsigned g, unsigned b) const = 0;
+	virtual unsigned getBpp() const = 0;
+	virtual unsigned getBytesPerPixel() const = 0;
+	virtual unsigned getRmask() const = 0;
+	virtual unsigned getGmask() const = 0;
+	virtual unsigned getBmask() const = 0;
+	virtual unsigned getAmask() const = 0;
+	virtual unsigned getRshift() const = 0;
+	virtual unsigned getGshift() const = 0;
+	virtual unsigned getBshift() const = 0;
+	virtual unsigned getAshift() const = 0;
+	virtual unsigned getRloss() const = 0;
+	virtual unsigned getGloss() const = 0;
+	virtual unsigned getBloss() const = 0;
+	virtual unsigned getAloss() const = 0;
+};
+
+} // namespace openmsx
+
+#endif

--- a/src/video/PixelOperations.hh
+++ b/src/video/PixelOperations.hh
@@ -1,36 +1,39 @@
 #ifndef PIXELOPERATIONS_HH
 #define PIXELOPERATIONS_HH
 
+#include "PixelFormat.hh"
 #include "unreachable.hh"
 #include "build-info.hh"
 #include "Math.hh"
-#include <SDL.h>
+#if PLATFORM_DINGUX
+#include "SDLPixelFormat.hh"
+#endif
 
 namespace openmsx {
 
 template<typename Pixel> class PixelOpBase
 {
 public:
-	explicit PixelOpBase(const SDL_PixelFormat& format_)
+	explicit PixelOpBase(const PixelFormat& format_)
 		: format(format_)
 		, blendMask(calcBlendMask())
 	{
 	}
 
-	const SDL_PixelFormat& getSDLPixelFormat() const { return format; }
+	const PixelFormat& getPixelFormat() const { return format; }
 
-	inline int getRmask()  const { return format.Rmask;  }
-	inline int getGmask()  const { return format.Gmask;  }
-	inline int getBmask()  const { return format.Bmask;  }
-	inline int getAmask()  const { return format.Amask;  }
-	inline int getRshift() const { return format.Rshift; }
-	inline int getGshift() const { return format.Gshift; }
-	inline int getBshift() const { return format.Bshift; }
-	inline int getAshift() const { return format.Ashift; }
-	inline int getRloss()  const { return format.Rloss;  }
-	inline int getGloss()  const { return format.Gloss;  }
-	inline int getBloss()  const { return format.Bloss;  }
-	inline int getAloss()  const { return format.Aloss;  }
+	inline int getRmask()  const { return format.getRmask();  }
+	inline int getGmask()  const { return format.getGmask();  }
+	inline int getBmask()  const { return format.getBmask();  }
+	inline int getAmask()  const { return format.getAmask();  }
+	inline int getRshift() const { return format.getRshift(); }
+	inline int getGshift() const { return format.getGshift(); }
+	inline int getBshift() const { return format.getBshift(); }
+	inline int getAshift() const { return format.getAshift(); }
+	inline int getRloss()  const { return format.getRloss();  }
+	inline int getGloss()  const { return format.getGloss();  }
+	inline int getBloss()  const { return format.getBloss();  }
+	inline int getAloss()  const { return format.getAloss();  }
 
 	/** Returns a constant that is useful to calculate the average of
 	  * two pixel values. See the implementation of blend(p1, p2) for
@@ -56,7 +59,7 @@ private:
 		return ~(rBit | gBit | bBit);
 	}
 
-	const SDL_PixelFormat& format;
+	const PixelFormat& format;
 
 	/** Mask used for blending.
 	  * The least significant bit of R,G,B must be 0,
@@ -72,19 +75,19 @@ private:
 template<> class PixelOpBase<unsigned>
 {
 public:
-	explicit PixelOpBase(const SDL_PixelFormat& format_)
+	explicit PixelOpBase(const PixelFormat& format_)
 		: format(format_) {}
 
-	const SDL_PixelFormat& getSDLPixelFormat() const { return format; }
+	const PixelFormat& getPixelFormat() const { return format; }
 
-	inline int getRmask()  const { return format.Rmask;  }
-	inline int getGmask()  const { return format.Gmask;  }
-	inline int getBmask()  const { return format.Bmask;  }
-	inline int getAmask()  const { return format.Amask;  }
-	inline int getRshift() const { return format.Rshift; }
-	inline int getGshift() const { return format.Gshift; }
-	inline int getBshift() const { return format.Bshift; }
-	inline int getAshift() const { return format.Ashift; }
+	inline int getRmask()  const { return format.getRmask();  }
+	inline int getGmask()  const { return format.getGmask();  }
+	inline int getBmask()  const { return format.getBmask();  }
+	inline int getAmask()  const { return format.getAmask();  }
+	inline int getRshift() const { return format.getRshift(); }
+	inline int getGshift() const { return format.getGshift(); }
+	inline int getBshift() const { return format.getBshift(); }
+	inline int getAshift() const { return format.getAshift(); }
 	inline int getRloss()  const { return 0;             }
 	inline int getGloss()  const { return 0;             }
 	inline int getBloss()  const { return 0;             }
@@ -95,7 +98,7 @@ public:
 	static constexpr bool IS_RGB565 = false;
 
 private:
-	const SDL_PixelFormat& format;
+	const PixelFormat& format;
 };
 
 
@@ -106,26 +109,15 @@ private:
 template<> class PixelOpBase<uint16_t>
 {
 public:
-	explicit PixelOpBase(const SDL_PixelFormat& /*format*/) {}
+	explicit PixelOpBase(const PixelFormat& /*format*/) {}
 
-	const SDL_PixelFormat& getSDLPixelFormat() const
+	const PixelFormat& getPixelFormat() const
 	{
-		static SDL_PixelFormat format;
-		format.palette = nullptr;
-		format.BitsPerPixel = 16;
-		format.BytesPerPixel = 2;
-		format.Rloss = 3;
-		format.Gloss = 2;
-		format.Bloss = 3;
-		format.Aloss = 8;
-		format.Rshift =  0;
-		format.Gshift =  5;
-		format.Bshift = 11;
-		format.Ashift =  0;
-		format.Rmask = 0x001F;
-		format.Gmask = 0x07E0;
-		format.Bmask = 0xF800;
-		format.Amask = 0x0000;
+		static SDLPixelFormat format(16,
+			0x001F,  0, 3,
+			0x07E0,  5, 2,
+			0xF800, 11, 3,
+			0x0000,  0, 8);
 		return format;
 	}
 
@@ -153,7 +145,7 @@ public:
 template<typename Pixel> class PixelOperations : public PixelOpBase<Pixel>
 {
 public:
-	using PixelOpBase<Pixel>::getSDLPixelFormat;
+	using PixelOpBase<Pixel>::getPixelFormat;
 	using PixelOpBase<Pixel>::getRmask;
 	using PixelOpBase<Pixel>::getGmask;
 	using PixelOpBase<Pixel>::getBmask;
@@ -169,7 +161,7 @@ public:
 	using PixelOpBase<Pixel>::getBlendMask;
 	using PixelOpBase<Pixel>::IS_RGB565;
 
-	explicit PixelOperations(const SDL_PixelFormat& format);
+	explicit PixelOperations(const PixelFormat& format);
 
 	/** Extract RGB componts
 	  */
@@ -258,7 +250,7 @@ private:
 
 
 template <typename Pixel>
-PixelOperations<Pixel>::PixelOperations(const SDL_PixelFormat& format_)
+PixelOperations<Pixel>::PixelOperations(const PixelFormat& format_)
 	: PixelOpBase<Pixel>(format_)
 {
 }

--- a/src/video/PostProcessor.cc
+++ b/src/video/PostProcessor.cc
@@ -48,13 +48,13 @@ PostProcessor::PostProcessor(MSXMotherBoard& motherBoard_,
 {
 	if (canDoInterlace) {
 		deinterlacedFrame = std::make_unique<DeinterlacedFrame>(
-			screen.getSDLFormat());
+			screen.getPixelFormat());
 		interlacedFrame   = std::make_unique<DoubledFrame>(
-			screen.getSDLFormat());
+			screen.getPixelFormat());
 		deflicker = Deflicker::create(
-			screen.getSDLFormat(), lastFrames);
+			screen.getPixelFormat(), lastFrames);
 		superImposedFrame = SuperImposedFrame::create(
-			screen.getSDLFormat());
+			screen.getPixelFormat());
 	} else {
 		// Laserdisc always produces non-interlaced frames, so we don't
 		// need lastFrames[1..3], deinterlacedFrame and
@@ -195,7 +195,7 @@ std::unique_ptr<RawFrame> PostProcessor::rotateFrames(
 	if (canDoInterlace) {
 		if (unlikely(!recycleFrame)) {
 			recycleFrame = std::make_unique<RawFrame>(
-				screen.getSDLFormat(), maxWidth, height);
+				screen.getPixelFormat(), maxWidth, height);
 		}
 		return recycleFrame;
 	} else {
@@ -264,12 +264,12 @@ void PostProcessor::takeRawScreenShot(unsigned height2, const std::string& filen
 	WorkBuffer workBuffer;
 	getScaledFrame(*paintFrame, getBpp(), height2, lines, workBuffer);
 	unsigned width = (height2 == 240) ? 320 : 640;
-	PNG::save(width, height2, lines, paintFrame->getSDLPixelFormat(), filename);
+	PNG::save(width, height2, lines, paintFrame->getPixelFormat(), filename);
 }
 
 unsigned PostProcessor::getBpp() const
 {
-	return screen.getSDLFormat().BitsPerPixel;
+	return screen.getPixelFormat().getBpp();
 }
 
 } // namespace openmsx

--- a/src/video/RawFrame.cc
+++ b/src/video/RawFrame.cc
@@ -1,17 +1,16 @@
 #include "RawFrame.hh"
 #include <cstdint>
-#include <SDL.h>
 
 namespace openmsx {
 
 RawFrame::RawFrame(
-		const SDL_PixelFormat& format, unsigned maxWidth_, unsigned height_)
+		const PixelFormat& format, unsigned maxWidth_, unsigned height_)
 	: FrameSource(format)
 	, lineWidths(height_)
 	, maxWidth(maxWidth_)
 {
 	setHeight(height_);
-	unsigned bytesPerPixel = format.BytesPerPixel;
+	unsigned bytesPerPixel = format.getBytesPerPixel();
 
 	// Allocate memory, make sure each line starts at a 64 byte boundary:
 	// - SSE instructions need 16 byte aligned data

--- a/src/video/RawFrame.hh
+++ b/src/video/RawFrame.hh
@@ -25,7 +25,7 @@ struct V9958RasterizerBorderInfo
 class RawFrame final : public FrameSource
 {
 public:
-	RawFrame(const SDL_PixelFormat& format, unsigned maxWidth, unsigned height);
+	RawFrame(const PixelFormat& format, unsigned maxWidth, unsigned height);
 
 	template<typename Pixel>
 	Pixel* getLinePtrDirect(unsigned y) {

--- a/src/video/SDLCommonVisibleSurface.cc
+++ b/src/video/SDLCommonVisibleSurface.cc
@@ -1,0 +1,127 @@
+#include "SDLCommonVisibleSurface.hh"
+#include "InitException.hh"
+#include "Icon.hh"
+#include "Display.hh"
+#include "RenderSettings.hh"
+#include "SDLSurfacePtr.hh"
+#include "PNG.hh"
+#include "FileContext.hh"
+#include "CliComm.hh"
+#include "build-info.hh"
+#include <cassert>
+
+namespace openmsx {
+
+// TODO: The video subsystem is not de-inited on errors.
+//       While it would be consistent to do so, doing it in this class is
+//       not ideal since the init doesn't happen here.
+void SDLCommonVisibleSurface::createSurface(int width, int height, unsigned flags)
+{
+	if (getDisplay().getRenderSettings().getFullScreen()) {
+		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+	}
+	flags |= SDL_WINDOW_ALLOW_HIGHDPI;
+
+	assert(!window);
+	window.reset(SDL_CreateWindow(
+			getDisplay().getWindowTitle().c_str(),
+			SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+			width, height,
+			flags));
+	if (!window) {
+		std::string err = SDL_GetError();
+		throw InitException("Could not create window: ", err);
+	}
+
+	updateWindowTitle();
+
+	renderer.reset(SDL_CreateRenderer(window.get(), -1, 0));
+	if (!renderer) {
+		std::string err = SDL_GetError();
+		throw InitException("Could not create renderer: " + err);
+	}
+	SDL_RenderSetLogicalSize(renderer.get(), width, height);
+	setSDLRenderer(renderer.get());
+
+	surface.reset(SDL_CreateRGBSurface(
+			0, width, height, 32,
+			0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000));
+	if (!surface) {
+		std::string err = SDL_GetError();
+		throw InitException("Could not create surface: " + err);
+	}
+	setSDLSurface(surface.get());
+
+	texture.reset(SDL_CreateTexture(
+			renderer.get(), SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING,
+			width, height));
+	if (!texture) {
+		std::string err = SDL_GetError();
+		throw InitException("Could not create texture: " + err);
+	}
+
+	// prefer linear filtering (instead of nearest neighbour)
+	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1");
+
+	// set icon
+	if (OPENMSX_SET_WINDOW_ICON) {
+		SDLSurfacePtr iconSurf;
+		// always use 32x32 icon on Windows, for some reason you get badly scaled icons there
+#ifndef _WIN32
+		try {
+			iconSurf = PNG::load(preferSystemFileContext().resolve("icons/openMSX-logo-256.png"), true);
+		} catch (MSXException& e) {
+			getCliComm().printWarning(
+				"Falling back to built in 32x32 icon, because failed to load icon: ",
+				e.getMessage());
+#endif
+			iconSurf.reset(SDL_CreateRGBSurfaceFrom(
+				const_cast<char*>(openMSX_icon.pixel_data),
+				openMSX_icon.width, openMSX_icon.height,
+				openMSX_icon.bytes_per_pixel * 8,
+				openMSX_icon.bytes_per_pixel * openMSX_icon.width,
+				OPENMSX_BIGENDIAN ? 0xFF000000 : 0x000000FF,
+				OPENMSX_BIGENDIAN ? 0x00FF0000 : 0x0000FF00,
+				OPENMSX_BIGENDIAN ? 0x0000FF00 : 0x00FF0000,
+				OPENMSX_BIGENDIAN ? 0x000000FF : 0xFF000000));
+#ifndef _WIN32
+		}
+#endif
+		SDL_SetColorKey(iconSurf.get(), SDL_TRUE, 0);
+		SDL_SetWindowIcon(window.get(), iconSurf.get());
+	}
+}
+
+void SDLCommonVisibleSurface::updateWindowTitle()
+{
+	assert(window);
+	SDL_SetWindowTitle(window.get(), getDisplay().getWindowTitle().c_str());
+}
+
+bool SDLCommonVisibleSurface::setFullScreen(bool fullscreen)
+{
+	auto flags = SDL_GetWindowFlags(window.get());
+	// Note: SDL_WINDOW_FULLSCREEN_DESKTOP also has the SDL_WINDOW_FULLSCREEN
+	//       bit set.
+	bool currentState = (flags & SDL_WINDOW_FULLSCREEN) != 0;
+	if (currentState == fullscreen) {
+		// already wanted stated
+		return true;
+	}
+
+	// in win32, toggling full screen requires opening a new SDL screen
+	// in Linux calling the SDL_WM_ToggleFullScreen usually works fine
+	// We now always create a new screen to make the code on both OSes
+	// more similar (we had a windows-only bug because of this difference)
+	return false;
+
+	/*
+	// try to toggle full screen
+	SDL_Surface* surf = getSDLSurface();
+	SDL_WM_ToggleFullScreen(surf);
+	bool newState = (surf->flags & SDL_FULLSCREEN) != 0;
+	return newState == fullscreen;
+	*/
+}
+
+} // namespace openmsx

--- a/src/video/SDLCommonVisibleSurface.hh
+++ b/src/video/SDLCommonVisibleSurface.hh
@@ -1,0 +1,30 @@
+#ifndef SDLCOMMONVISIBLESURFACE_HH
+#define SDLCOMMONVISIBLESURFACE_HH
+
+#include "VisibleSurface.hh"
+#include "SDLSurfacePtr.hh"
+
+namespace openmsx {
+
+/** Common functionality for the plain SDL and SDLGL VisibleSurface classes.
+  */
+class SDLCommonVisibleSurface : public VisibleSurface
+{
+public:
+	void updateWindowTitle() override;
+	bool setFullScreen(bool fullscreen) override;
+
+protected:
+	using VisibleSurface::VisibleSurface;
+	void createSurface(int width, int height, unsigned flags);
+
+	SDLSubSystemInitializer<SDL_INIT_VIDEO> videoSubSystem;
+	SDLWindowPtr window;
+	SDLRendererPtr renderer;
+	SDLSurfacePtr surface;
+	SDLTexturePtr texture;
+};
+
+} // namespace openmsx
+
+#endif

--- a/src/video/SDLCommonVisibleSurface.hh
+++ b/src/video/SDLCommonVisibleSurface.hh
@@ -1,7 +1,7 @@
 #ifndef SDLCOMMONVISIBLESURFACE_HH
 #define SDLCOMMONVISIBLESURFACE_HH
 
-#include "OutputSurface.hh"
+#include "SDLOutputSurface.hh"
 #include "VisibleSurface.hh"
 #include "SDLSurfacePtr.hh"
 
@@ -9,7 +9,7 @@ namespace openmsx {
 
 /** Common functionality for the plain SDL and SDLGL VisibleSurface classes.
   */
-class SDLCommonVisibleSurface : public OutputSurface, public VisibleSurface
+class SDLCommonVisibleSurface : public SDLOutputSurface, public VisibleSurface
 {
 public:
 	void updateWindowTitle() override;

--- a/src/video/SDLCommonVisibleSurface.hh
+++ b/src/video/SDLCommonVisibleSurface.hh
@@ -1,6 +1,7 @@
 #ifndef SDLCOMMONVISIBLESURFACE_HH
 #define SDLCOMMONVISIBLESURFACE_HH
 
+#include "OutputSurface.hh"
 #include "VisibleSurface.hh"
 #include "SDLSurfacePtr.hh"
 
@@ -8,7 +9,7 @@ namespace openmsx {
 
 /** Common functionality for the plain SDL and SDLGL VisibleSurface classes.
   */
-class SDLCommonVisibleSurface : public VisibleSurface
+class SDLCommonVisibleSurface : public OutputSurface, public VisibleSurface
 {
 public:
 	void updateWindowTitle() override;

--- a/src/video/SDLGLOffScreenSurface.cc
+++ b/src/video/SDLGLOffScreenSurface.cc
@@ -5,7 +5,12 @@
 namespace openmsx {
 
 SDLGLOffScreenSurface::SDLGLOffScreenSurface(const SDLGLVisibleSurface& output)
-	: fboTex(true) // enable interpolation   TODO why?
+	: SDLOutputSurface(32,
+		OPENMSX_BIGENDIAN ? 0xFF000000 : 0x00FF0000, OPENMSX_BIGENDIAN ? 24 : 16, 0,
+		OPENMSX_BIGENDIAN ? 0x00FF0000 : 0x0000FF00, OPENMSX_BIGENDIAN ? 16 :  8, 0,
+		OPENMSX_BIGENDIAN ? 0x0000FF00 : 0x000000FF, OPENMSX_BIGENDIAN ?  8 :  0, 0,
+		OPENMSX_BIGENDIAN ? 0x000000FF : 0xFF000000, OPENMSX_BIGENDIAN ?  0 : 24, 0)
+	, fboTex(true) // enable interpolation   TODO why?
 {
 	// only used for width and height
 	setSDLSurface(const_cast<SDL_Surface*>(output.getSDLSurface()));
@@ -25,10 +30,6 @@ SDLGLOffScreenSurface::SDLGLOffScreenSurface(const SDLGLVisibleSurface& output)
 	fbo = gl::FrameBufferObject(fboTex);
 	fbo.push();
 
-	SDLAllocFormatPtr frmt(SDL_AllocFormat(
-		        OPENMSX_BIGENDIAN ? SDL_PIXELFORMAT_RGBA8888 :
-		                            SDL_PIXELFORMAT_ARGB8888));
-	setSDLFormat(*frmt);
 	setBufferPtr(nullptr, 0); // direct access not allowed
 }
 

--- a/src/video/SDLGLOffScreenSurface.cc
+++ b/src/video/SDLGLOffScreenSurface.cc
@@ -9,7 +9,6 @@ SDLGLOffScreenSurface::SDLGLOffScreenSurface(const SDLGLVisibleSurface& output)
 {
 	// only used for width and height
 	setSDLSurface(const_cast<SDL_Surface*>(output.getSDLSurface()));
-	setSDLRenderer(output.getSDLRenderer());
 	calculateViewPort(output.getPhysicalSize());
 
 	auto [w, h] = getPhysicalSize();

--- a/src/video/SDLGLOffScreenSurface.hh
+++ b/src/video/SDLGLOffScreenSurface.hh
@@ -1,7 +1,7 @@
 #ifndef SDLGLOFFSCREENSURFACE_HH
 #define SDLGLOFFSCREENSURFACE_HH
 
-#include "OutputSurface.hh"
+#include "SDLOutputSurface.hh"
 #include "GLUtil.hh"
 
 namespace openmsx {
@@ -11,7 +11,7 @@ class SDLGLVisibleSurface;
 /** This class installs a FrameBufferObject (FBO). So as long as this object
   * is live, all openGL draw commands will be redirected to this FBO.
   */
-class SDLGLOffScreenSurface final : public OutputSurface
+class SDLGLOffScreenSurface final : public SDLOutputSurface
 {
 public:
 	explicit SDLGLOffScreenSurface(const SDLGLVisibleSurface& output);

--- a/src/video/SDLGLVisibleSurface.cc
+++ b/src/video/SDLGLVisibleSurface.cc
@@ -73,10 +73,11 @@ SDLGLVisibleSurface::SDLGLVisibleSurface(
 	glOrtho(0, width, height, 0, -1, 1);
 	glMatrixMode(GL_MODELVIEW);
 
-	SDLAllocFormatPtr frmt(SDL_AllocFormat(
-		        OPENMSX_BIGENDIAN ? SDL_PIXELFORMAT_RGBA8888 :
-		                            SDL_PIXELFORMAT_ARGB8888));
-	setSDLFormat(*frmt);
+	pixelFormat = SDLPixelFormat(32,
+		OPENMSX_BIGENDIAN ? 0xFF000000 : 0x00FF0000, OPENMSX_BIGENDIAN ? 24 : 16, 0,
+		OPENMSX_BIGENDIAN ? 0x00FF0000 : 0x0000FF00, OPENMSX_BIGENDIAN ? 16 :  8, 0,
+		OPENMSX_BIGENDIAN ? 0x0000FF00 : 0x000000FF, OPENMSX_BIGENDIAN ?  8 :  0, 0,
+		OPENMSX_BIGENDIAN ? 0x000000FF : 0xFF000000, OPENMSX_BIGENDIAN ?  0 : 24, 0);
 	setBufferPtr(nullptr, 0); // direct access not allowed
 
 	gl::context = std::make_unique<gl::Context>(width, height);

--- a/src/video/SDLGLVisibleSurface.cc
+++ b/src/video/SDLGLVisibleSurface.cc
@@ -19,9 +19,10 @@ SDLGLVisibleSurface::SDLGLVisibleSurface(
 		RTScheduler& rtScheduler_,
 		EventDistributor& eventDistributor_,
 		InputEventGenerator& inputEventGenerator_,
-		CliComm& cliComm_)
-	: VisibleSurface(display_, rtScheduler_, eventDistributor_, inputEventGenerator_,
-			cliComm_)
+		CliComm& cliComm_,
+		VideoSystem& videoSystem_)
+	: SDLCommonVisibleSurface(display_, rtScheduler_, eventDistributor_,
+		inputEventGenerator_, cliComm_, videoSystem_)
 {
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 0);
@@ -83,7 +84,6 @@ SDLGLVisibleSurface::SDLGLVisibleSurface(
 
 SDLGLVisibleSurface::~SDLGLVisibleSurface()
 {
-	// TODO: Move context creation/deletion into Context class?
 	gl::context.reset();
 	SDL_GL_DeleteContext(glContext);
 }

--- a/src/video/SDLGLVisibleSurface.hh
+++ b/src/video/SDLGLVisibleSurface.hh
@@ -1,13 +1,13 @@
 #ifndef SDLGLVISIBLESURFACE_HH
 #define SDLGLVISIBLESURFACE_HH
 
-#include "VisibleSurface.hh"
+#include "SDLCommonVisibleSurface.hh"
 
 namespace openmsx {
 
 /** Visible surface for SDL openGL renderers
  */
-class SDLGLVisibleSurface final : public VisibleSurface
+class SDLGLVisibleSurface final : public SDLCommonVisibleSurface
 {
 public:
 	SDLGLVisibleSurface(unsigned width, unsigned height,
@@ -15,13 +15,13 @@ public:
 	                    RTScheduler& rtScheduler,
 	                    EventDistributor& eventDistributor,
 	                    InputEventGenerator& inputEventGenerator,
-	                    CliComm& cliComm);
+	                    CliComm& cliComm,
+	                    VideoSystem& videoSystem);
 	~SDLGLVisibleSurface() override;
 
 	static void saveScreenshotGL(const OutputSurface& output,
 	                             const std::string& filename);
 
-private:
 	// OutputSurface
 	void saveScreenshot(const std::string& filename) override;
 

--- a/src/video/SDLImage.cc
+++ b/src/video/SDLImage.cc
@@ -1,6 +1,6 @@
 #include "SDLImage.hh"
 #include "PNG.hh"
-#include "OutputSurface.hh"
+#include "SDLOutputSurface.hh"
 #include <cassert>
 #include <cstdlib>
 #include <cmath>
@@ -247,7 +247,7 @@ SDLImage::SDLImage(OutputSurface& output, SDLSurfacePtr image)
 SDLTexturePtr SDLImage::toTexture(OutputSurface& output, SDL_Surface& surface)
 {
 	SDLTexturePtr result(SDL_CreateTextureFromSurface(
-		output.getSDLRenderer(), &surface));
+		dynamic_cast<SDLOutputSurface&>(output).getSDLRenderer(), &surface));
 	SDL_SetTextureBlendMode(result.get(), SDL_BLENDMODE_BLEND);
 	SDL_QueryTexture(result.get(), nullptr, nullptr, &size[0], &size[1]);
 	return result;
@@ -373,9 +373,10 @@ void SDLImage::draw(OutputSurface& output, gl::ivec2 pos, uint8_t r, uint8_t g, 
 	if (flipX) x -= w;
 	if (flipY) y -= h;
 
+	auto renderer = dynamic_cast<SDLOutputSurface&>(output).getSDLRenderer();
 	SDL_SetTextureAlphaMod(texture.get(), alpha);
 	SDL_Rect dst = {x, y, w, h};
-	SDL_RenderCopy(output.getSDLRenderer(), texture.get(), nullptr, &dst);
+	SDL_RenderCopy(renderer, texture.get(), nullptr, &dst);
 }
 
 } // namespace openmsx

--- a/src/video/SDLOffScreenSurface.cc
+++ b/src/video/SDLOffScreenSurface.cc
@@ -5,6 +5,7 @@
 namespace openmsx {
 
 SDLOffScreenSurface::SDLOffScreenSurface(const SDL_Surface& proto)
+	: SDLOutputSurface(*proto.format)
 {
 	// SDL_CreateRGBSurface() allocates an internal buffer, on 32-bit
 	// systems this buffer is only 8-bytes aligned. For some scalers (with
@@ -14,17 +15,15 @@ SDLOffScreenSurface::SDLOffScreenSurface(const SDL_Surface& proto)
 	// Of course it would be better to get rid of SDL_Surface in the
 	// OutputSurface interface.
 
-	setSDLFormat(*proto.format);
-	const SDL_PixelFormat& frmt = getSDLFormat();
-
-	unsigned pitch2 = proto.w * frmt.BitsPerPixel / 8;
+	const PixelFormat& frmt = getPixelFormat();
+	unsigned pitch2 = proto.w * frmt.getBpp() / 8;
 	assert((pitch2 % 16) == 0);
 	unsigned size = pitch2 * proto.h;
 	buffer.resize(size);
 	memset(buffer.data(), 0, size);
 	surface.reset(SDL_CreateRGBSurfaceFrom(
-		buffer.data(), proto.w, proto.h, frmt.BitsPerPixel, pitch2,
-		frmt.Rmask, frmt.Gmask, frmt.Bmask, frmt.Amask));
+		buffer.data(), proto.w, proto.h, frmt.getBpp(), pitch2,
+		frmt.getRmask(), frmt.getGmask(), frmt.getBmask(), frmt.getAmask()));
 
 	setSDLSurface(surface.get());
 	setBufferPtr(static_cast<char*>(surface->pixels), surface->pitch);

--- a/src/video/SDLOffScreenSurface.hh
+++ b/src/video/SDLOffScreenSurface.hh
@@ -1,13 +1,13 @@
 #ifndef SDLOFFSCREENSURFACE_HH
 #define SDLOFFSCREENSURFACE_HH
 
-#include "OutputSurface.hh"
+#include "SDLOutputSurface.hh"
 #include "SDLSurfacePtr.hh"
 #include "MemBuffer.hh"
 
 namespace openmsx {
 
-class SDLOffScreenSurface final : public OutputSurface
+class SDLOffScreenSurface final : public SDLOutputSurface
 {
 public:
 	explicit SDLOffScreenSurface(const SDL_Surface& prototype);

--- a/src/video/SDLOutputSurface.cc
+++ b/src/video/SDLOutputSurface.cc
@@ -1,0 +1,30 @@
+#include "SDLOutputSurface.hh"
+
+namespace openmsx {
+
+void SDLOutputSurface::lock()
+{
+	if (isLocked()) return;
+	locked = true;
+	if (surface && SDL_MUSTLOCK(surface)) {
+		// Note: we ignore the return value from SDL_LockSurface()
+		SDL_LockSurface(surface);
+	}
+}
+
+void SDLOutputSurface::unlock()
+{
+	if (!isLocked()) return;
+	locked = false;
+	if (surface && SDL_MUSTLOCK(surface)) {
+		SDL_UnlockSurface(surface);
+	}
+}
+
+void SDLOutputSurface::setBufferPtr(char* data_, unsigned pitch_)
+{
+	data = data_;
+	pitch = pitch_;
+}
+
+} // namespace openmsx

--- a/src/video/SDLOutputSurface.hh
+++ b/src/video/SDLOutputSurface.hh
@@ -1,0 +1,67 @@
+#ifndef SDLOUTPUTSURFACE_HH
+#define SDLOUTPUTSURFACE_HH
+
+#include "OutputSurface.hh"
+#include "gl_vec.hh"
+#include <cassert>
+#include <SDL.h>
+
+namespace openmsx {
+
+/** A frame buffer where pixels can be written to.
+  * It could be an in-memory buffer or a video buffer visible to the user
+  * (see VisibleSurface subclass).
+  */
+class SDLOutputSurface : public OutputSurface
+{
+public:
+	SDLOutputSurface(const SDLOutputSurface&) = delete;
+	SDLOutputSurface& operator=(const SDLOutputSurface&) = delete;
+
+	int getWidth()  const override { return surface->w; }
+	int getHeight() const override { return surface->h; }
+
+	SDL_Surface*  getSDLSurface()  const { return surface; }
+	SDL_Renderer* getSDLRenderer() const { return renderer; }
+
+	/** Lock this OutputSurface.
+	  * Direct pixel access is only allowed on a locked surface.
+	  * Locking an already locked surface has no effect.
+	  */
+	void lock();
+
+	/** Unlock this OutputSurface.
+	  * @see lock().
+	  */
+	void unlock();
+
+	/** Is this OutputSurface currently locked?
+	  */
+	bool isLocked() const { return locked; }
+
+	/** Returns a pointer to the requested line in the pixel buffer.
+	  */
+	template <typename Pixel>
+	Pixel* getLinePtrDirect(unsigned y) {
+		assert(isLocked());
+		return reinterpret_cast<Pixel*>(data + y * pitch);
+	}
+
+protected:
+	SDLOutputSurface() = default;
+
+	void setSDLSurface(SDL_Surface* surface_) { surface = surface_; }
+	void setSDLRenderer(SDL_Renderer* r) { renderer = r; }
+	void setBufferPtr(char* data, unsigned pitch);
+
+private:
+	SDL_Surface* surface = nullptr;
+	SDL_Renderer* renderer = nullptr;
+	char* data;
+	unsigned pitch;
+	bool locked = false;
+};
+
+} // namespace openmsx
+
+#endif

--- a/src/video/SDLPixelFormat.hh
+++ b/src/video/SDLPixelFormat.hh
@@ -1,0 +1,82 @@
+#ifndef SDLPIXELFORMAT_HH
+#define SDLPIXELFORMAT_HH
+
+#include "PixelFormat.hh"
+#include "build-info.hh"
+#include <SDL.h>
+
+namespace openmsx {
+
+class SDLPixelFormat final : public PixelFormat
+{
+public:
+	SDLPixelFormat() = default;
+	SDLPixelFormat(unsigned bpp,
+	               unsigned Rmask, unsigned Rshift, unsigned Rloss,
+	               unsigned Gmask, unsigned Gshift, unsigned Gloss,
+	               unsigned Bmask, unsigned Bshift, unsigned Bloss,
+	               unsigned Amask, unsigned Ashift, unsigned Aloss)
+	{
+		format.palette = nullptr;
+		format.BitsPerPixel = bpp;
+		format.BytesPerPixel = (bpp + 7) / 8;
+		format.Rmask = Rmask;
+		format.Gmask = Gmask;
+		format.Bmask = Bmask;
+		format.Amask = Amask;
+		format.Rshift = Rshift;
+		format.Gshift = Gshift;
+		format.Bshift = Bshift;
+		format.Ashift = Ashift;
+		format.Rloss = Rloss;
+		format.Gloss = Gloss;
+		format.Bloss = Bloss;
+		format.Aloss = Aloss;
+	}
+	SDLPixelFormat(const SDL_PixelFormat& format_)
+	{
+		format = format_;
+#if HAVE_32BPP
+		// SDL sets an alpha channel only for GL modes. We want an alpha channel
+		// for all 32bpp output surfaces, so we add one ourselves if necessary.
+		if (format.BitsPerPixel == 32 && format.Amask == 0) {
+			unsigned rgbMask = format.Rmask | format.Gmask | format.Bmask;
+			format.Amask = ~rgbMask;
+			format.Ashift = rgbMask & 24;
+			format.Aloss = 0;
+		}
+#endif
+	}
+
+	unsigned map(unsigned r, unsigned g, unsigned b) const override {
+		return SDL_MapRGB(&format, r, g, b);
+	}
+
+	unsigned getBpp() const override {
+		return format.BitsPerPixel;
+	}
+
+	unsigned getBytesPerPixel() const override {
+		return format.BytesPerPixel;
+	}
+
+	unsigned getRmask()  const override { return format.Rmask; }
+	unsigned getGmask()  const override { return format.Gmask; }
+	unsigned getBmask()  const override { return format.Bmask; }
+	unsigned getAmask()  const override { return format.Amask; }
+	unsigned getRshift() const override { return format.Rshift; }
+	unsigned getGshift() const override { return format.Gshift; }
+	unsigned getBshift() const override { return format.Bshift; }
+	unsigned getAshift() const override { return format.Ashift; }
+	unsigned getRloss()  const override { return format.Rloss; }
+	unsigned getGloss()  const override { return format.Gloss; }
+	unsigned getBloss()  const override { return format.Bloss; }
+	unsigned getAloss()  const override { return format.Aloss; }
+
+private:
+	SDL_PixelFormat format;
+};
+
+} // namespace openmsx
+
+#endif

--- a/src/video/SDLRasterizer.cc
+++ b/src/video/SDLRasterizer.cc
@@ -7,7 +7,7 @@
 #include "RenderSettings.hh"
 #include "PostProcessor.hh"
 #include "MemoryOps.hh"
-#include "VisibleSurface.hh"
+#include "OutputSurface.hh"
 #include "build-info.hh"
 #include "components.hh"
 #include <algorithm>
@@ -69,7 +69,7 @@ inline void SDLRasterizer<Pixel>::renderBitmapLine(Pixel* buf, unsigned vramLine
 
 template <class Pixel>
 SDLRasterizer<Pixel>::SDLRasterizer(
-		VDP& vdp_, Display& display, VisibleSurface& screen_,
+		VDP& vdp_, Display& display, OutputSurface& screen_,
 		std::unique_ptr<PostProcessor> postProcessor_)
 	: vdp(vdp_), vram(vdp.getVRAM())
 	, screen(screen_)

--- a/src/video/SDLRasterizer.cc
+++ b/src/video/SDLRasterizer.cc
@@ -74,7 +74,7 @@ SDLRasterizer<Pixel>::SDLRasterizer(
 	: vdp(vdp_), vram(vdp.getVRAM())
 	, screen(screen_)
 	, postProcessor(std::move(postProcessor_))
-	, workFrame(std::make_unique<RawFrame>(screen.getSDLFormat(), 640, 240))
+	, workFrame(std::make_unique<RawFrame>(screen.getPixelFormat(), 640, 240))
 	, renderSettings(display.getRenderSettings())
 	, characterConverter(vdp, palFg, palBg)
 	, bitmapConverter(palFg, PALETTE256, V9958_COLORS)

--- a/src/video/SDLRasterizer.hh
+++ b/src/video/SDLRasterizer.hh
@@ -15,7 +15,6 @@ class Display;
 class VDP;
 class VDPVRAM;
 class OutputSurface;
-class VisibleSurface;
 class RawFrame;
 class RenderSettings;
 class Setting;
@@ -33,7 +32,7 @@ public:
 	SDLRasterizer& operator=(const SDLRasterizer&) = delete;
 
 	SDLRasterizer(
-		VDP& vdp, Display& display, VisibleSurface& screen,
+		VDP& vdp, Display& display, OutputSurface& screen,
 		std::unique_ptr<PostProcessor> postProcessor);
 	~SDLRasterizer() override;
 

--- a/src/video/SDLSnow.cc
+++ b/src/video/SDLSnow.cc
@@ -1,5 +1,5 @@
 #include "SDLSnow.hh"
-#include "OutputSurface.hh"
+#include "SDLOutputSurface.hh"
 #include "Display.hh"
 #include "build-info.hh"
 #include "random.hh"
@@ -20,11 +20,12 @@ SDLSnow<Pixel>::SDLSnow(OutputSurface& output, Display& display_)
 }
 
 template <class Pixel>
-void SDLSnow<Pixel>::paint(OutputSurface& output)
+void SDLSnow<Pixel>::paint(OutputSurface& output_)
 {
 	auto& generator = global_urng(); // fast (non-cryptographic) random numbers
 	std::uniform_int_distribution<int> distribution(0, 255);
 
+	auto& output = dynamic_cast<SDLOutputSurface&>(output_);
 	output.lock();
 	const unsigned width = output.getWidth();
 	const unsigned height = output.getHeight();

--- a/src/video/SDLVideoSystem.cc
+++ b/src/video/SDLVideoSystem.cc
@@ -244,6 +244,15 @@ OutputSurface* SDLVideoSystem::getOutputSurface()
 	return screen.get();
 }
 
+void SDLVideoSystem::showCursor(bool show)
+{
+	if (show) {
+		SDL_ShowCursor(SDL_ENABLE);
+	} else {
+		SDL_ShowCursor(SDL_DISABLE);
+	}
+}
+
 void SDLVideoSystem::resize()
 {
 	auto& rtScheduler         = reactor.getRTScheduler();
@@ -259,14 +268,14 @@ void SDLVideoSystem::resize()
 		screen = std::make_unique<SDLVisibleSurface>(
 			width, height, display, rtScheduler,
 			eventDistributor, inputEventGenerator,
-			reactor.getCliComm());
+			reactor.getCliComm(), *this);
 		break;
 #if COMPONENT_GL
 	case RenderSettings::SDLGL_PP:
 		screen = std::make_unique<SDLGLVisibleSurface>(
 			width, height, display, rtScheduler,
 			eventDistributor, inputEventGenerator,
-			reactor.getCliComm());
+			reactor.getCliComm(), *this);
 		break;
 #endif
 	default:

--- a/src/video/SDLVideoSystem.cc
+++ b/src/video/SDLVideoSystem.cc
@@ -253,6 +253,11 @@ void SDLVideoSystem::showCursor(bool show)
 	}
 }
 
+void SDLVideoSystem::repaint()
+{
+	display.repaint();
+}
+
 void SDLVideoSystem::resize()
 {
 	auto& rtScheduler         = reactor.getRTScheduler();

--- a/src/video/SDLVideoSystem.cc
+++ b/src/video/SDLVideoSystem.cc
@@ -66,7 +66,7 @@ std::unique_ptr<Rasterizer> SDLVideoSystem::createRasterizer(VDP& vdp)
 	auto& motherBoard = vdp.getMotherBoard();
 	switch (renderSettings.getRenderer()) {
 	case RenderSettings::SDL:
-		switch (screen->getSDLFormat().BytesPerPixel) {
+		switch (screen->getPixelFormat().getBytesPerPixel()) {
 #if HAVE_16BPP
 		case 2:
 			return std::make_unique<SDLRasterizer<uint16_t>>(
@@ -108,7 +108,7 @@ std::unique_ptr<V9990Rasterizer> SDLVideoSystem::createV9990Rasterizer(
 	MSXMotherBoard& motherBoard = vdp.getMotherBoard();
 	switch (renderSettings.getRenderer()) {
 	case RenderSettings::SDL:
-		switch (screen->getSDLFormat().BytesPerPixel) {
+		switch (screen->getPixelFormat().getBytesPerPixel()) {
 #if HAVE_16BPP
 		case 2:
 			return std::make_unique<V9990SDLRasterizer<uint16_t>>(
@@ -149,7 +149,7 @@ std::unique_ptr<LDRasterizer> SDLVideoSystem::createLDRasterizer(
 	MSXMotherBoard& motherBoard = ld.getMotherBoard();
 	switch (renderSettings.getRenderer()) {
 	case RenderSettings::SDL:
-		switch (screen->getSDLFormat().BytesPerPixel) {
+		switch (screen->getPixelFormat().getBytesPerPixel()) {
 #if HAVE_16BPP
 		case 2:
 			return std::make_unique<LDSDLRasterizer<uint16_t>>(

--- a/src/video/SDLVideoSystem.hh
+++ b/src/video/SDLVideoSystem.hh
@@ -45,6 +45,7 @@ public:
 	void updateWindowTitle() override;
 	OutputSurface* getOutputSurface() override;
 	void showCursor(bool show) override;
+	void repaint() override;
 
 private:
 	// EventListener

--- a/src/video/SDLVideoSystem.hh
+++ b/src/video/SDLVideoSystem.hh
@@ -14,7 +14,7 @@ class Reactor;
 class CommandConsole;
 class Display;
 class RenderSettings;
-class VisibleSurface;
+class SDLCommonVisibleSurface;
 class Layer;
 class Setting;
 
@@ -58,7 +58,7 @@ private:
 	Reactor& reactor;
 	Display& display;
 	RenderSettings& renderSettings;
-	std::unique_ptr<VisibleSurface> screen;
+	std::unique_ptr<SDLCommonVisibleSurface> screen;
 	std::unique_ptr<Layer> consoleLayer;
 	std::unique_ptr<Layer> snowLayer;
 	std::unique_ptr<Layer> iconLayer;

--- a/src/video/SDLVideoSystem.hh
+++ b/src/video/SDLVideoSystem.hh
@@ -44,6 +44,7 @@ public:
 	void takeScreenShot(const std::string& filename, bool withOsd) override;
 	void updateWindowTitle() override;
 	OutputSurface* getOutputSurface() override;
+	void showCursor(bool show) override;
 
 private:
 	// EventListener

--- a/src/video/SDLVisibleSurface.cc
+++ b/src/video/SDLVisibleSurface.cc
@@ -19,9 +19,10 @@ SDLVisibleSurface::SDLVisibleSurface(
 		RTScheduler& rtScheduler_,
 		EventDistributor& eventDistributor_,
 		InputEventGenerator& inputEventGenerator_,
-		CliComm& cliComm_)
-	: VisibleSurface(display_, rtScheduler_, eventDistributor_,
-	                 inputEventGenerator_, cliComm_)
+		CliComm& cliComm_,
+		VideoSystem& videoSystem_)
+	: SDLCommonVisibleSurface(display_, rtScheduler_, eventDistributor_,
+	                 inputEventGenerator_, cliComm_, videoSystem_)
 {
 	int flags = 0;
 	createSurface(width, height, flags);

--- a/src/video/SDLVisibleSurface.cc
+++ b/src/video/SDLVisibleSurface.cc
@@ -27,7 +27,7 @@ SDLVisibleSurface::SDLVisibleSurface(
 	int flags = 0;
 	createSurface(width, height, flags);
 	const SDL_Surface* surf = getSDLSurface();
-	setSDLFormat(*surf->format);
+	pixelFormat = SDLPixelFormat(*surf->format);
 	setBufferPtr(static_cast<char*>(surf->pixels), surf->pitch);
 
 	// In the SDL renderer logical size is the same as physical size.
@@ -51,7 +51,7 @@ void SDLVisibleSurface::finish()
 
 std::unique_ptr<Layer> SDLVisibleSurface::createSnowLayer()
 {
-	switch (getSDLFormat().BytesPerPixel) {
+	switch (getPixelFormat().getBytesPerPixel()) {
 #if HAVE_16BPP
 	case 2:
 		return std::make_unique<SDLSnow<uint16_t>>(*this, getDisplay());

--- a/src/video/SDLVisibleSurface.cc
+++ b/src/video/SDLVisibleSurface.cc
@@ -89,7 +89,7 @@ void SDLVisibleSurface::saveScreenshot(const std::string& filename)
 }
 
 void SDLVisibleSurface::saveScreenshotSDL(
-	const OutputSurface& output, const std::string& filename)
+	const SDLOutputSurface& output, const std::string& filename)
 {
 	unsigned width = output.getWidth();
 	unsigned height = output.getHeight();

--- a/src/video/SDLVisibleSurface.hh
+++ b/src/video/SDLVisibleSurface.hh
@@ -16,7 +16,7 @@ public:
 	                  CliComm& cliComm,
 	                  VideoSystem& videoSystem);
 
-	static void saveScreenshotSDL(const OutputSurface& output,
+	static void saveScreenshotSDL(const SDLOutputSurface& output,
 	                              const std::string& filename);
 
 	// OutputSurface

--- a/src/video/SDLVisibleSurface.hh
+++ b/src/video/SDLVisibleSurface.hh
@@ -1,11 +1,11 @@
 #ifndef SDLVISIBLESURFACE_HH
 #define SDLVISIBLESURFACE_HH
 
-#include "VisibleSurface.hh"
+#include "SDLCommonVisibleSurface.hh"
 
 namespace openmsx {
 
-class SDLVisibleSurface final : public VisibleSurface
+class SDLVisibleSurface final : public SDLCommonVisibleSurface
 {
 public:
 	SDLVisibleSurface(unsigned width, unsigned height,
@@ -13,18 +13,18 @@ public:
 	                  RTScheduler& rtScheduler,
 	                  EventDistributor& eventDistributor,
 	                  InputEventGenerator& inputEventGenerator,
-	                  CliComm& cliComm);
+	                  CliComm& cliComm,
+	                  VideoSystem& videoSystem);
 
 	static void saveScreenshotSDL(const OutputSurface& output,
 	                              const std::string& filename);
 
-private:
 	// OutputSurface
 	void saveScreenshot(const std::string& filename) override;
+	void flushFrameBuffer() override;
 	void clearScreen() override;
 
 	// VisibleSurface
-	void flushFrameBuffer() override;
 	void finish() override;
 	std::unique_ptr<Layer> createSnowLayer() override;
 	std::unique_ptr<Layer> createConsoleLayer(

--- a/src/video/SuperImposedFrame.cc
+++ b/src/video/SuperImposedFrame.cc
@@ -14,7 +14,7 @@ template <typename Pixel>
 class SuperImposedFrameImpl final : public SuperImposedFrame
 {
 public:
-	explicit SuperImposedFrameImpl(const SDL_PixelFormat& format);
+	explicit SuperImposedFrameImpl(const PixelFormat& format);
 
 private:
 	unsigned getLineWidth(unsigned line) const override;
@@ -29,22 +29,22 @@ private:
 // class SuperImposedFrame
 
 std::unique_ptr<SuperImposedFrame> SuperImposedFrame::create(
-	const SDL_PixelFormat& format)
+	const PixelFormat& format)
 {
 #if HAVE_16BPP
-	if (format.BitsPerPixel == 15 || format.BitsPerPixel == 16) {
+	if (format.getBytesPerPixel() == 2) {
 		return std::make_unique<SuperImposedFrameImpl<uint16_t>>(format);
 	}
 #endif
 #if HAVE_32BPP
-	if (format.BitsPerPixel == 32) {
+	if (format.getBytesPerPixel() == 4) {
 		return std::make_unique<SuperImposedFrameImpl<uint32_t>>(format);
 	}
 #endif
 	UNREACHABLE; return nullptr; // avoid warning
 }
 
-SuperImposedFrame::SuperImposedFrame(const SDL_PixelFormat& format)
+SuperImposedFrame::SuperImposedFrame(const PixelFormat& format)
 	: FrameSource(format)
 {
 }
@@ -62,7 +62,7 @@ void SuperImposedFrame::init(
 
 template <typename Pixel>
 SuperImposedFrameImpl<Pixel>::SuperImposedFrameImpl(
-		const SDL_PixelFormat& format)
+		const PixelFormat& format)
 	: SuperImposedFrame(format)
 	, pixelOps(format)
 {

--- a/src/video/SuperImposedFrame.hh
+++ b/src/video/SuperImposedFrame.hh
@@ -15,12 +15,12 @@ class SuperImposedFrame : public FrameSource
 {
 public:
 	static std::unique_ptr<SuperImposedFrame> create(
-		const SDL_PixelFormat& format);
+		const PixelFormat& format);
 	void init(const FrameSource* top, const FrameSource* bottom);
 	virtual ~SuperImposedFrame() = default;
 
 protected:
-	explicit SuperImposedFrame(const SDL_PixelFormat& format);
+	explicit SuperImposedFrame(const PixelFormat& format);
 
 	const FrameSource* top;
 	const FrameSource* bottom;

--- a/src/video/SuperImposedVideoFrame.cc
+++ b/src/video/SuperImposedVideoFrame.cc
@@ -11,7 +11,7 @@ template <typename Pixel>
 SuperImposedVideoFrame<Pixel>::SuperImposedVideoFrame(
 		const FrameSource& src_, const FrameSource& super_,
 		const PixelOperations<Pixel>& pixelOps_)
-	: FrameSource(pixelOps_.getSDLPixelFormat())
+	: FrameSource(pixelOps_.getPixelFormat())
 	, src(src_), super(super_), pixelOps(pixelOps_)
 {
 	setHeight(src.getHeight());

--- a/src/video/VideoSystem.hh
+++ b/src/video/VideoSystem.hh
@@ -75,6 +75,7 @@ public:
 	/** TODO */
 	virtual OutputSurface* getOutputSurface() = 0;
 	virtual void showCursor(bool show) = 0;
+	virtual void repaint() = 0;
 
 protected:
 	VideoSystem() = default;

--- a/src/video/VideoSystem.hh
+++ b/src/video/VideoSystem.hh
@@ -74,6 +74,7 @@ public:
 
 	/** TODO */
 	virtual OutputSurface* getOutputSurface() = 0;
+	virtual void showCursor(bool show) = 0;
 
 protected:
 	VideoSystem() = default;

--- a/src/video/VisibleSurface.cc
+++ b/src/video/VisibleSurface.cc
@@ -1,18 +1,14 @@
 #include "VisibleSurface.hh"
 #include "InitException.hh"
-#include "Icon.hh"
 #include "Display.hh"
 #include "RenderSettings.hh"
-#include "SDLSurfacePtr.hh"
+#include "VideoSystem.hh"
 #include "FloatSetting.hh"
 #include "BooleanSetting.hh"
 #include "Event.hh"
 #include "EventDistributor.hh"
 #include "InputEventGenerator.hh"
-#include "PNG.hh"
-#include "FileContext.hh"
 #include "CliComm.hh"
-#include "build-info.hh"
 #include <cassert>
 
 namespace openmsx {
@@ -22,12 +18,14 @@ VisibleSurface::VisibleSurface(
 		RTScheduler& rtScheduler,
 		EventDistributor& eventDistributor_,
 		InputEventGenerator& inputEventGenerator_,
-		CliComm& cliComm_)
+		CliComm& cliComm_,
+		VideoSystem& videoSystem_)
 	: RTSchedulable(rtScheduler)
 	, display(display_)
 	, eventDistributor(eventDistributor_)
 	, inputEventGenerator(inputEventGenerator_)
 	, cliComm(cliComm_)
+	, videoSystem(videoSystem_)
 {
 	auto& renderSettings = display.getRenderSettings();
 
@@ -44,86 +42,6 @@ VisibleSurface::VisibleSurface(
 	updateCursor();
 }
 
-// TODO: The video subsystem is not de-inited on errors.
-//       While it would be consistent to do so, doing it in this class is
-//       not ideal since the init doesn't happen here.
-void VisibleSurface::createSurface(int width, int height, unsigned flags)
-{
-	if (getDisplay().getRenderSettings().getFullScreen()) {
-		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
-	}
-	flags |= SDL_WINDOW_ALLOW_HIGHDPI;
-
-	assert(!window);
-	window.reset(SDL_CreateWindow(
-			display.getWindowTitle().c_str(),
-			SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
-			width, height,
-			flags));
-	if (!window) {
-		std::string err = SDL_GetError();
-		throw InitException("Could not create window: ", err);
-	}
-
-	updateWindowTitle();
-
-	renderer.reset(SDL_CreateRenderer(window.get(), -1, 0));
-	if (!renderer) {
-		std::string err = SDL_GetError();
-		throw InitException("Could not create renderer: " + err);
-	}
-	SDL_RenderSetLogicalSize(renderer.get(), width, height);
-	setSDLRenderer(renderer.get());
-
-	surface.reset(SDL_CreateRGBSurface(
-			0, width, height, 32,
-			0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000));
-	if (!surface) {
-		std::string err = SDL_GetError();
-		throw InitException("Could not create surface: " + err);
-	}
-	setSDLSurface(surface.get());
-
-	texture.reset(SDL_CreateTexture(
-			renderer.get(), SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING,
-			width, height));
-	if (!texture) {
-		std::string err = SDL_GetError();
-		throw InitException("Could not create texture: " + err);
-	}
-
-	// prefer linear filtering (instead of nearest neighbour)
-	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1");
-
-	// set icon
-	if (OPENMSX_SET_WINDOW_ICON) {
-		SDLSurfacePtr iconSurf;
-		// always use 32x32 icon on Windows, for some reason you get badly scaled icons there
-#ifndef _WIN32
-		try {
-			iconSurf = PNG::load(preferSystemFileContext().resolve("icons/openMSX-logo-256.png"), true);
-		} catch (MSXException& e) {
-			cliComm.printWarning(
-				"Falling back to built in 32x32 icon, because failed to load icon: ",
-				e.getMessage());
-#endif
-			iconSurf.reset(SDL_CreateRGBSurfaceFrom(
-				const_cast<char*>(openMSX_icon.pixel_data),
-				openMSX_icon.width, openMSX_icon.height,
-				openMSX_icon.bytes_per_pixel * 8,
-				openMSX_icon.bytes_per_pixel * openMSX_icon.width,
-				OPENMSX_BIGENDIAN ? 0xFF000000 : 0x000000FF,
-				OPENMSX_BIGENDIAN ? 0x00FF0000 : 0x0000FF00,
-				OPENMSX_BIGENDIAN ? 0x0000FF00 : 0x00FF0000,
-				OPENMSX_BIGENDIAN ? 0x000000FF : 0xFF000000));
-#ifndef _WIN32
-		}
-#endif
-		SDL_SetColorKey(iconSurf.get(), SDL_TRUE, 0);
-		SDL_SetWindowIcon(window.get(), iconSurf.get());
-	}
-}
-
 VisibleSurface::~VisibleSurface()
 {
 	eventDistributor.unregisterEventListener(
@@ -138,38 +56,6 @@ VisibleSurface::~VisibleSurface()
 	renderSettings.getFullScreenSetting().detach(*this);
 }
 
-void VisibleSurface::updateWindowTitle()
-{
-	assert(window);
-	SDL_SetWindowTitle(window.get(), display.getWindowTitle().c_str());
-}
-
-bool VisibleSurface::setFullScreen(bool fullscreen)
-{
-	auto flags = SDL_GetWindowFlags(window.get());
-	// Note: SDL_WINDOW_FULLSCREEN_DESKTOP also has the SDL_WINDOW_FULLSCREEN
-	//       bit set.
-	bool currentState = (flags & SDL_WINDOW_FULLSCREEN) != 0;
-	if (currentState == fullscreen) {
-		// already wanted stated
-		return true;
-	}
-
-	// in win32, toggling full screen requires opening a new SDL screen
-	// in Linux calling the SDL_WM_ToggleFullScreen usually works fine
-	// We now always create a new screen to make the code on both OSes
-	// more similar (we had a windows-only bug because of this difference)
-	return false;
-
-	/*
-	// try to toggle full screen
-	SDL_Surface* surf = getSDLSurface();
-	SDL_WM_ToggleFullScreen(surf);
-	bool newState = (surf->flags & SDL_FULLSCREEN) != 0;
-	return newState == fullscreen;
-	*/
-}
-
 void VisibleSurface::update(const Setting& /*setting*/)
 {
 	updateCursor();
@@ -178,7 +64,7 @@ void VisibleSurface::update(const Setting& /*setting*/)
 void VisibleSurface::executeRT()
 {
 	// timer expired, hide cursor
-	SDL_ShowCursor(SDL_DISABLE);
+	videoSystem.showCursor(false);
 }
 
 int VisibleSurface::signalEvent(const std::shared_ptr<const Event>& event)
@@ -198,15 +84,16 @@ void VisibleSurface::updateCursor()
 	auto& renderSettings = display.getRenderSettings();
 	if (renderSettings.getFullScreen() ||
 	    inputEventGenerator.getGrabInput().getBoolean()) {
-		// always hide cursor in fullscreen or grabinput mode
-		SDL_ShowCursor(SDL_DISABLE);
+		// always hide cursor in fullscreen or grabinput mode, but do it
+		// after the derived class is constructed to avoid an SDL bug.
+		scheduleRT(0);
 		return;
 	}
 	float delay = renderSettings.getPointerHideDelay();
 	if (delay == 0.0f) {
-		SDL_ShowCursor(SDL_DISABLE);
+		videoSystem.showCursor(false);
 	} else {
-		SDL_ShowCursor(SDL_ENABLE);
+		videoSystem.showCursor(true);
 		if (delay > 0.0f) {
 			scheduleRT(int(delay * 1e6f)); // delay in s, schedule in us
 		}

--- a/src/video/VisibleSurface.hh
+++ b/src/video/VisibleSurface.hh
@@ -5,7 +5,6 @@
 #include "Observer.hh"
 #include "EventListener.hh"
 #include "RTSchedulable.hh"
-#include "SDLSurfacePtr.hh"
 #include <memory>
 
 namespace openmsx {
@@ -19,19 +18,19 @@ class Setting;
 class Display;
 class OSDGUI;
 class CliComm;
+class VideoSystem;
 
 /** An OutputSurface which is visible to the user, such as a window or a
   * full screen display.
-  * This class provides a frame buffer based renderer a common interface,
-  * no matter whether the back-end is plain SDL or SDL+OpenGL.
+  * This class provides a common interface.
   */
 class VisibleSurface : public OutputSurface, public EventListener,
                        private Observer<Setting>, private RTSchedulable
 {
 public:
 	~VisibleSurface() override;
-	void updateWindowTitle();
-	bool setFullScreen(bool fullscreen);
+	virtual void updateWindowTitle() = 0;
+	virtual bool setFullScreen(bool fullscreen) = 0;
 
 	/** When a complete frame is finished, call this method.
 	  * It will 'actually' display it. E.g. when using double buffering
@@ -50,6 +49,7 @@ public:
 	  */
 	virtual std::unique_ptr<OutputSurface> createOffScreenSurface() = 0;
 
+	CliComm& getCliComm() const { return cliComm; }
 	Display& getDisplay() const { return display; }
 
 protected:
@@ -57,14 +57,8 @@ protected:
 	               RTScheduler& rtScheduler,
 	               EventDistributor& eventDistributor,
 	               InputEventGenerator& inputEventGenerator,
-	               CliComm& cliComm);
-	void createSurface(int width, int height, unsigned flags);
-
-	SDLSubSystemInitializer<SDL_INIT_VIDEO> videoSubSystem;
-	SDLWindowPtr window;
-	SDLRendererPtr renderer;
-	SDLSurfacePtr surface;
-	SDLTexturePtr texture;
+	               CliComm& cliComm,
+	               VideoSystem& videoSystem);
 
 private:
 	void updateCursor();
@@ -80,6 +74,7 @@ private:
 	EventDistributor& eventDistributor;
 	InputEventGenerator& inputEventGenerator;
 	CliComm& cliComm;
+	VideoSystem& videoSystem;
 };
 
 } // namespace openmsx

--- a/src/video/VisibleSurface.hh
+++ b/src/video/VisibleSurface.hh
@@ -1,7 +1,6 @@
 #ifndef VISIBLESURFACE_HH
 #define VISIBLESURFACE_HH
 
-#include "OutputSurface.hh"
 #include "Observer.hh"
 #include "EventListener.hh"
 #include "RTSchedulable.hh"
@@ -10,6 +9,7 @@
 namespace openmsx {
 
 class Layer;
+class OutputSurface;
 class Reactor;
 class CommandConsole;
 class EventDistributor;
@@ -24,11 +24,11 @@ class VideoSystem;
   * full screen display.
   * This class provides a common interface.
   */
-class VisibleSurface : public OutputSurface, public EventListener,
-                       private Observer<Setting>, private RTSchedulable
+class VisibleSurface : public EventListener, private Observer<Setting>
+                     , private RTSchedulable
 {
 public:
-	~VisibleSurface() override;
+	virtual ~VisibleSurface();
 	virtual void updateWindowTitle() = 0;
 	virtual bool setFullScreen(bool fullscreen) = 0;
 

--- a/src/video/ZMBVEncoder.cc
+++ b/src/video/ZMBVEncoder.cc
@@ -246,7 +246,7 @@ void ZMBVEncoder::addXorBlock(
 }
 
 template<class P>
-void ZMBVEncoder::addXorFrame(const SDL_PixelFormat& pixelFormat, unsigned& workUsed)
+void ZMBVEncoder::addXorFrame(const PixelFormat& pixelFormat, unsigned& workUsed)
 {
 	PixelOperations<P> pixelOps(pixelFormat);
 	auto* vectors = reinterpret_cast<int8_t*>(&work[workUsed]);
@@ -290,7 +290,7 @@ void ZMBVEncoder::addXorFrame(const SDL_PixelFormat& pixelFormat, unsigned& work
 }
 
 template<class P>
-void ZMBVEncoder::addFullFrame(const SDL_PixelFormat& pixelFormat, unsigned& workUsed)
+void ZMBVEncoder::addFullFrame(const PixelFormat& pixelFormat, unsigned& workUsed)
 {
 	using LE_P = typename Endian::Little<P>::type;
 
@@ -386,12 +386,12 @@ void ZMBVEncoder::compressFrame(bool keyFrame, FrameSource* frame,
 		switch (pixelSize) {
 #if HAVE_16BPP
 		case 2:
-			addFullFrame<uint16_t>(frame->getSDLPixelFormat(), workUsed);
+			addFullFrame<uint16_t>(frame->getPixelFormat(), workUsed);
 			break;
 #endif
 #if HAVE_32BPP
 		case 4:
-			addFullFrame<uint32_t>(frame->getSDLPixelFormat(), workUsed);
+			addFullFrame<uint32_t>(frame->getPixelFormat(), workUsed);
 			break;
 #endif
 		default:
@@ -402,12 +402,12 @@ void ZMBVEncoder::compressFrame(bool keyFrame, FrameSource* frame,
 		switch (pixelSize) {
 #if HAVE_16BPP
 		case 2:
-			addXorFrame<uint16_t>(frame->getSDLPixelFormat(), workUsed);
+			addXorFrame<uint16_t>(frame->getPixelFormat(), workUsed);
 			break;
 #endif
 #if HAVE_32BPP
 		case 4:
-			addXorFrame<uint32_t>(frame->getSDLPixelFormat(), workUsed);
+			addXorFrame<uint32_t>(frame->getPixelFormat(), workUsed);
 			break;
 #endif
 		default:

--- a/src/video/ZMBVEncoder.hh
+++ b/src/video/ZMBVEncoder.hh
@@ -3,11 +3,10 @@
 #ifndef ZMBVENCODER_HH
 #define ZMBVENCODER_HH
 
+#include "PixelFormat.hh"
 #include "MemBuffer.hh"
 #include <cstdint>
 #include <zlib.h>
-
-struct SDL_PixelFormat;
 
 namespace openmsx {
 
@@ -32,8 +31,8 @@ private:
 
 	void setupBuffers(unsigned bpp);
 	unsigned neededSize();
-	template<class P> void addFullFrame(const SDL_PixelFormat& pixelFormat, unsigned& workUsed);
-	template<class P> void addXorFrame (const SDL_PixelFormat& pixelFormat, unsigned& workUsed);
+	template<class P> void addFullFrame(const PixelFormat& pixelFormat, unsigned& workUsed);
+	template<class P> void addXorFrame (const PixelFormat& pixelFormat, unsigned& workUsed);
 	template<class P> unsigned possibleBlock(int vx, int vy, unsigned offset);
 	template<class P> unsigned compareBlock(int vx, int vy, unsigned offset);
 	template<class P> void addXorBlock(

--- a/src/video/ld/LDSDLRasterizer.cc
+++ b/src/video/ld/LDSDLRasterizer.cc
@@ -2,6 +2,7 @@
 #include "RawFrame.hh"
 #include "PostProcessor.hh"
 #include "OutputSurface.hh"
+#include "PixelFormat.hh"
 #include "build-info.hh"
 #include "components.hh"
 #include <cstdint>
@@ -14,8 +15,7 @@ LDSDLRasterizer<Pixel>::LDSDLRasterizer(
 		OutputSurface& screen,
 		std::unique_ptr<PostProcessor> postProcessor_)
 	: postProcessor(std::move(postProcessor_))
-	, workFrame(std::make_unique<RawFrame>(screen.getSDLFormat(), 640, 480))
-	, pixelFormat(screen.getSDLFormat())
+	, workFrame(std::make_unique<RawFrame>(screen.getPixelFormat(), 640, 480))
 {
 }
 
@@ -40,7 +40,7 @@ void LDSDLRasterizer<Pixel>::drawBlank(int r, int g, int b)
 	// We should really be presenting the "LASERVISION" text
 	// here, like the real laserdisc player does. Note that this
 	// changes when seeking or starting to play.
-	auto background = static_cast<Pixel>(SDL_MapRGB(&pixelFormat, r, g, b));
+	auto background = static_cast<Pixel>(workFrame->getPixelFormat().map(r, g, b));
 	for (int y = 0; y < 480; ++y) {
 		workFrame->setBlank(y, background);
 	}

--- a/src/video/ld/LDSDLRasterizer.cc
+++ b/src/video/ld/LDSDLRasterizer.cc
@@ -1,7 +1,7 @@
 #include "LDSDLRasterizer.hh"
 #include "RawFrame.hh"
 #include "PostProcessor.hh"
-#include "VisibleSurface.hh"
+#include "OutputSurface.hh"
 #include "build-info.hh"
 #include "components.hh"
 #include <cstdint>
@@ -11,7 +11,7 @@ namespace openmsx {
 
 template <class Pixel>
 LDSDLRasterizer<Pixel>::LDSDLRasterizer(
-		VisibleSurface& screen,
+		OutputSurface& screen,
 		std::unique_ptr<PostProcessor> postProcessor_)
 	: postProcessor(std::move(postProcessor_))
 	, workFrame(std::make_unique<RawFrame>(screen.getSDLFormat(), 640, 480))

--- a/src/video/ld/LDSDLRasterizer.hh
+++ b/src/video/ld/LDSDLRasterizer.hh
@@ -7,7 +7,7 @@
 
 namespace openmsx {
 
-class VisibleSurface;
+class OutputSurface;
 class RawFrame;
 class PostProcessor;
 
@@ -19,7 +19,7 @@ class LDSDLRasterizer final : public LDRasterizer
 {
 public:
 	LDSDLRasterizer(
-		VisibleSurface& screen,
+		OutputSurface& screen,
 		std::unique_ptr<PostProcessor> postProcessor);
 	~LDSDLRasterizer() override;
 

--- a/src/video/ld/LDSDLRasterizer.hh
+++ b/src/video/ld/LDSDLRasterizer.hh
@@ -2,7 +2,6 @@
 #define LDSDLRASTERIZER_HH
 
 #include "LDRasterizer.hh"
-#include <SDL.h>
 #include <memory>
 
 namespace openmsx {
@@ -38,8 +37,6 @@ private:
 	/** The next frame as it is delivered by the VDP, work in progress.
 	  */
 	std::unique_ptr<RawFrame> workFrame;
-
-	const SDL_PixelFormat pixelFormat;
 };
 
 } // namespace openmsx

--- a/src/video/scalers/DirectScalerOutput.cc
+++ b/src/video/scalers/DirectScalerOutput.cc
@@ -1,5 +1,5 @@
 #include "DirectScalerOutput.hh"
-#include "OutputSurface.hh"
+#include "SDLOutputSurface.hh"
 #include "MemoryOps.hh"
 #include "build-info.hh"
 #include <cstdint>
@@ -7,7 +7,7 @@
 namespace openmsx {
 
 template<typename Pixel>
-DirectScalerOutput<Pixel>::DirectScalerOutput(OutputSurface& output_)
+DirectScalerOutput<Pixel>::DirectScalerOutput(SDLOutputSurface& output_)
 	: output(output_)
 {
 }

--- a/src/video/scalers/DirectScalerOutput.hh
+++ b/src/video/scalers/DirectScalerOutput.hh
@@ -5,13 +5,13 @@
 
 namespace openmsx {
 
-class OutputSurface;
+class SDLOutputSurface;
 
 template<typename Pixel>
 class DirectScalerOutput final : public ScalerOutput<Pixel>
 {
 public:
-	explicit DirectScalerOutput(OutputSurface& output);
+	explicit DirectScalerOutput(SDLOutputSurface& output);
 
 	unsigned getWidth()  const override;
 	unsigned getHeight() const override;
@@ -20,7 +20,7 @@ public:
 	void   fillLine   (unsigned y, Pixel color) override;
 
 private:
-	OutputSurface& output;
+	SDLOutputSurface& output;
 };
 
 } // namespace openmsx

--- a/src/video/scalers/LineScalers.hh
+++ b/src/video/scalers/LineScalers.hh
@@ -4,6 +4,7 @@
 #include "PixelOperations.hh"
 #include "likely.hh"
 #include <type_traits>
+#include <cstddef>
 #include <cstring>
 #include <cassert>
 #ifdef __SSE2__

--- a/src/video/scalers/StretchScalerOutput.cc
+++ b/src/video/scalers/StretchScalerOutput.cc
@@ -266,7 +266,7 @@ StretchScalerOutput288<Pixel>::StretchScalerOutput288(
 
 template<typename Pixel>
 unique_ptr<ScalerOutput<Pixel>> StretchScalerOutputFactory<Pixel>::create(
-	OutputSurface& output,
+	SDLOutputSurface& output,
 	PixelOperations<Pixel> pixelOps,
 	unsigned inWidth)
 {

--- a/src/video/scalers/StretchScalerOutput.hh
+++ b/src/video/scalers/StretchScalerOutput.hh
@@ -5,7 +5,7 @@
 
 namespace openmsx {
 
-class OutputSurface;
+class SDLOutputSurface;
 template<typename Pixel> class PixelOperations;
 template<typename Pixel> class ScalerOutput;
 
@@ -13,7 +13,7 @@ template<typename Pixel>
 struct StretchScalerOutputFactory
 {
 	static std::unique_ptr<ScalerOutput<Pixel>> create(
-		OutputSurface& output,
+		SDLOutputSurface& output,
 		PixelOperations<Pixel> pixelOps,
 		unsigned inWidth);
 };

--- a/src/video/v9990/V9990SDLRasterizer.cc
+++ b/src/video/v9990/V9990SDLRasterizer.cc
@@ -23,7 +23,7 @@ V9990SDLRasterizer<Pixel>::V9990SDLRasterizer(
 		std::unique_ptr<PostProcessor> postProcessor_)
 	: vdp(vdp_), vram(vdp.getVRAM())
 	, screen(screen_)
-	, workFrame(std::make_unique<RawFrame>(screen.getSDLFormat(), 1280, 240))
+	, workFrame(std::make_unique<RawFrame>(screen.getPixelFormat(), 1280, 240))
 	, renderSettings(display.getRenderSettings())
 	, displayMode(P1) // dummy value
 	, colorMode(PP)   //   avoid UMR

--- a/src/video/v9990/V9990SDLRasterizer.cc
+++ b/src/video/v9990/V9990SDLRasterizer.cc
@@ -3,7 +3,7 @@
 #include "RawFrame.hh"
 #include "PostProcessor.hh"
 #include "Display.hh"
-#include "VisibleSurface.hh"
+#include "OutputSurface.hh"
 #include "RenderSettings.hh"
 #include "MemoryOps.hh"
 #include "build-info.hh"
@@ -19,7 +19,7 @@ namespace openmsx {
 
 template <class Pixel>
 V9990SDLRasterizer<Pixel>::V9990SDLRasterizer(
-		V9990& vdp_, Display& display, VisibleSurface& screen_,
+		V9990& vdp_, Display& display, OutputSurface& screen_,
 		std::unique_ptr<PostProcessor> postProcessor_)
 	: vdp(vdp_), vram(vdp.getVRAM())
 	, screen(screen_)

--- a/src/video/v9990/V9990SDLRasterizer.hh
+++ b/src/video/v9990/V9990SDLRasterizer.hh
@@ -14,7 +14,6 @@ class V9990;
 class V9990VRAM;
 class RawFrame;
 class OutputSurface;
-class VisibleSurface;
 class RenderSettings;
 class Setting;
 class PostProcessor;
@@ -27,7 +26,7 @@ class V9990SDLRasterizer final : public V9990Rasterizer
 {
 public:
 	V9990SDLRasterizer(
-		V9990& vdp, Display& display, VisibleSurface& screen,
+		V9990& vdp, Display& display, OutputSurface& screen,
 		std::unique_ptr<PostProcessor> postProcessor);
 	~V9990SDLRasterizer() override;
 


### PR DESCRIPTION
Historically openMSX has provided drivers and renderers that seem to allow different video backends. In practice however, SDL-specific functionality has seeped into the very core of the video classes.

This set of commits make it possible to use non-SDL video backends by turning the core video classes into (abstract) base classes and moving the SDL functionality into derivations of them.

The first and last commit of this set, though strictly not SDL-specific, are necessary to allow videosystems such as GUI toolkits to work.