### PR TITLE
Fix MSX1's VDP window timing

### DIFF
--- a/src/video/VDP.cc
+++ b/src/video/VDP.cc
@@ -131,8 +131,8 @@ VDP::VDP(const DeviceConfig& config)
 		version = TMS91X8;
 		defaultSaturation = 100;
 	} else if (versionString == "TMS9128") version = TMS91X8;
-	else if (versionString == "TMS9929A") {version = TMS9929A; slotTimeShift = 2500.0;}
-	else if (versionString == "TMS9129") version = TMS9129;
+	else if (versionString == "TMS9929A") version = TMS9929A;
+	else if (versionString == "TMS9129") {version = TMS9129; slotTimeShift = 2420.0;}
 	else if (versionString == "V9938") version = V9938;
 	else if (versionString == "V9958") version = V9958;
 	else throw MSXException("Unknown VDP version \"", versionString, '"');

--- a/src/video/VDP.cc
+++ b/src/video/VDP.cc
@@ -114,13 +114,15 @@ VDP::VDP(const DeviceConfig& config)
 
 	int defaultSaturation = 54;
 
+    slotTimeShift = 0;
+
 	std::string versionString = config.getChildData("version");
 	if (versionString == "TMS99X8A") version = TMS99X8A;
 	else if (versionString == "TMS9918A") {
 		version = TMS99X8A;
 		defaultSaturation = 100;
 	} else if (versionString == "TMS9928A") version = TMS99X8A;
-	else if (versionString == "T6950PAL") version = T6950PAL;
+	else if (versionString == "T6950PAL") {version = T6950PAL; slotTimeShift = 4930.0;}
 	else if (versionString == "T6950NTSC") version = T6950NTSC;
 	else if (versionString == "T7937APAL") version = T7937APAL;
 	else if (versionString == "T7937ANTSC") version = T7937ANTSC;
@@ -129,7 +131,7 @@ VDP::VDP(const DeviceConfig& config)
 		version = TMS91X8;
 		defaultSaturation = 100;
 	} else if (versionString == "TMS9128") version = TMS91X8;
-	else if (versionString == "TMS9929A") version = TMS9929A;
+	else if (versionString == "TMS9929A") {version = TMS9929A; slotTimeShift = 2500.0;}
 	else if (versionString == "TMS9129") version = TMS9129;
 	else if (versionString == "V9938") version = V9938;
 	else if (versionString == "V9958") version = V9958;
@@ -812,7 +814,7 @@ void VDP::scheduleCpuVramAccess(bool isRead, byte write, EmuTime::param time)
             // https://youtu.be/7HXZHeZIuJY?t=1867
             // [ToDo] Check if the timing needs also to be corrected in MSX2.
             // Related bug: https://github.com/openMSX/openMSX/issues/949
-			EmuTime access_slot_time = time - (isMSX1VDP() ? EmuDuration(double(4930.0/MAIN_FREQ)) :
+			EmuTime access_slot_time = time - (isMSX1VDP() ? EmuDuration(double(slotTimeShift/MAIN_FREQ)) :
                                                              EmuDuration(double(0)));
 			auto delta = isMSX1VDP() ? VDPAccessSlots::DELTA_32
 						 : VDPAccessSlots::DELTA_16;

--- a/src/video/VDP.cc
+++ b/src/video/VDP.cc
@@ -114,7 +114,7 @@ VDP::VDP(const DeviceConfig& config)
 
 	int defaultSaturation = 54;
 
-    slotTimeShift = 0;
+    slotTimeShift = 0.0;
 
 	std::string versionString = config.getChildData("version");
 	if (versionString == "TMS99X8A") version = TMS99X8A;
@@ -130,7 +130,7 @@ VDP::VDP(const DeviceConfig& config)
 	else if (versionString == "TMS9118") {
 		version = TMS91X8;
 		defaultSaturation = 100;
-	} else if (versionString == "TMS9128") version = TMS91X8;
+	} else if (versionString == "TMS9128") {version = TMS91X8; slotTimeShift = 1440.0;}
 	else if (versionString == "TMS9929A") version = TMS9929A;
 	else if (versionString == "TMS9129") {version = TMS9129; slotTimeShift = 2420.0;}
 	else if (versionString == "V9938") version = V9938;
@@ -814,11 +814,10 @@ void VDP::scheduleCpuVramAccess(bool isRead, byte write, EmuTime::param time)
             // https://youtu.be/7HXZHeZIuJY?t=1867
             // [ToDo] Check if the timing needs also to be corrected in MSX2.
             // Related bug: https://github.com/openMSX/openMSX/issues/949
-			EmuTime access_slot_time = time - (isMSX1VDP() ? EmuDuration(double(slotTimeShift/MAIN_FREQ)) :
-                                                             EmuDuration(double(0)));
+			EmuTime accessSlotTime = time - EmuDuration(double(slotTimeShift/MAIN_FREQ));
 			auto delta = isMSX1VDP() ? VDPAccessSlots::DELTA_32
 						 : VDPAccessSlots::DELTA_16;
-			syncCpuVramAccess.setSyncPoint(getAccessSlot(access_slot_time, delta));
+			syncCpuVramAccess.setSyncPoint(getAccessSlot(accessSlotTime, delta));
 		}
 	}
 }

--- a/src/video/VDP.hh
+++ b/src/video/VDP.hh
@@ -1073,6 +1073,10 @@ private:
 	  */
 	VdpVersion version;
 
+    /** Model-dependent constant to compute the access slot time shift
+      */
+    double slotTimeShift;
+
 	/** Saturation of Pr component of TMS9XXXA output circuitry.
 	  * The output of the VDP and the circuitry between the output and the
 	  * output connector influences this value. Percentage in range [0:100]


### PR DESCRIPTION
It seems that the actual slot time access happens slightly sooner in a real MSX 1. Thus, correct the scheduled time for the next access window.
This fixes Karateka and gives the same color corruption that can be seen in https://youtu.be/7HXZHeZIuJY?t=1867
[ToDo] Check if the timing needs also to be corrected in MSX2.
Related bug: https://github.com/openMSX/openMSX/issues/949
