### PR TITLE
Upgrade OpenGL drawing code to version 3.3 Core

### DIFF
--- a/share/shaders/default.frag
+++ b/share/shaders/default.frag
@@ -1,16 +1,18 @@
 uniform sampler2D tex;
 uniform sampler2D videoTex;
 
-varying vec2 texCoord;
-varying vec2 videoCoord;
+in vec2 texCoord;
+in vec2 videoCoord;
+
+out vec4 fragColor;
 
 void main()
 {
 #if SUPERIMPOSE
-	vec4 col = texture2D(tex, texCoord);
-	vec4 vid = texture2D(videoTex, videoCoord);
-	gl_FragColor = mix(vid, col, col.a);
+	vec4 col = texture(tex, texCoord);
+	vec4 vid = texture(videoTex, videoCoord);
+	fragColor = mix(vid, col, col.a);
 #else
-	gl_FragColor = texture2D(tex, texCoord);
+	fragColor = texture(tex, texCoord);
 #endif
 }

--- a/share/shaders/default.vert
+++ b/share/shaders/default.vert
@@ -1,11 +1,11 @@
 uniform mat4 u_mvpMatrix;
 uniform vec3 texSize; // not used
 
-attribute vec4 a_position;
-attribute vec3 a_texCoord;
+in vec4 a_position;
+in vec3 a_texCoord;
 
-varying vec2 texCoord;
-varying vec2 videoCoord;
+out vec2 texCoord;
+out vec2 videoCoord;
 
 void main()
 {

--- a/share/shaders/fill.frag
+++ b/share/shaders/fill.frag
@@ -1,6 +1,8 @@
-varying vec4 v_color;
+in vec4 v_color;
+
+out vec4 fragColor;
 
 void main()
 {
-	gl_FragColor = v_color;
+	fragColor = v_color;
 }

--- a/share/shaders/fill.vert
+++ b/share/shaders/fill.vert
@@ -1,9 +1,9 @@
 uniform mat4 u_mvpMatrix;
 
-attribute vec4 a_position;
-attribute vec4 a_color;
+in vec4 a_position;
+in vec4 a_color;
 
-varying vec4 v_color;
+out vec4 v_color;
 
 void main()
 {

--- a/share/shaders/hq.frag
+++ b/share/shaders/hq.frag
@@ -4,35 +4,37 @@ uniform sampler2D offsetTex;
 uniform sampler2D weightTex;
 uniform sampler2D videoTex;
 
-varying vec2 mid;
-varying vec2 leftTop;
-varying vec2 edgePos;
-varying vec2 weightPos;
-varying vec2 texStep2; // could be uniform
-varying vec2 videoCoord;
+in vec2 mid;
+in vec2 leftTop;
+in vec2 edgePos;
+in vec2 weightPos;
+in vec2 texStep2; // could be uniform
+in vec2 videoCoord;
+
+out vec4 fragColor;
 
 void main()
 {
-	float edgeBits = texture2D(edgeTex, edgePos).z;
-	//gl_FragColor = vec4(edgeBits, fract(edgeBits * 16.0), fract(edgeBits * 256.0), 1.0);
+	float edgeBits = texture(edgeTex, edgePos).z;
+	//fragColor = vec4(edgeBits, fract(edgeBits * 16.0), fract(edgeBits * 256.0), 1.0);
 
 	// transform (N x N x 4096) to (64N x 64N) texture coords
 	float t = 64.0 * edgeBits;
 	vec2 xy = vec2(fract(t), floor(t)/64.0);
 	xy += fract(weightPos) / 64.0;
-	vec4 offsets = texture2D(offsetTex, xy);
-	vec3 weights = texture2D(weightTex, xy).xyz;
+	vec4 offsets = texture(offsetTex, xy);
+	vec3 weights = texture(weightTex, xy).xyz;
 
-	vec4 c5 = texture2D(colorTex, mid);
-	vec4 cx = texture2D(colorTex, leftTop + texStep2 * offsets.xy);
-	vec4 cy = texture2D(colorTex, leftTop + texStep2 * offsets.zw);
+	vec4 c5 = texture(colorTex, mid);
+	vec4 cx = texture(colorTex, leftTop + texStep2 * offsets.xy);
+	vec4 cy = texture(colorTex, leftTop + texStep2 * offsets.zw);
 
 	vec4 col = cx * weights.x + cy * weights.y + c5 * weights.z;
 
 #if SUPERIMPOSE
-	vec4 vid = texture2D(videoTex, videoCoord);
-	gl_FragColor = mix(vid, col, col.a);
+	vec4 vid = texture(videoTex, videoCoord);
+	fragColor = mix(vid, col, col.a);
 #else
-	gl_FragColor = col;
+	fragColor = col;
 #endif
 }

--- a/share/shaders/hq.vert
+++ b/share/shaders/hq.vert
@@ -1,15 +1,15 @@
 uniform mat4 u_mvpMatrix;
 uniform vec3 texSize;
 
-attribute vec4 a_position;
-attribute vec3 a_texCoord;
+in vec4 a_position;
+in vec3 a_texCoord;
 
-varying vec2 mid;
-varying vec2 leftTop;
-varying vec2 edgePos;
-varying vec2 weightPos;
-varying vec2 texStep2; // could be uniform
-varying vec2 videoCoord;
+out vec2 mid;
+out vec2 leftTop;
+out vec2 edgePos;
+out vec2 weightPos;
+out vec2 texStep2; // could be uniform
+out vec2 videoCoord;
 
 void main()
 {

--- a/share/shaders/hqlite.frag
+++ b/share/shaders/hqlite.frag
@@ -3,31 +3,33 @@ uniform sampler2D colorTex;
 uniform sampler2D offsetTex;
 uniform sampler2D videoTex;
 
-varying vec2 leftTop;
-varying vec2 edgePos;
-varying vec4 misc;
-varying vec2 videoCoord;
+in vec2 leftTop;
+in vec2 edgePos;
+in vec4 misc;
+in vec2 videoCoord;
+
+out vec4 fragColor;
 
 void main()
 {
-	float edgeBits = texture2D(edgeTex, edgePos).x;
-	//gl_FragColor = vec4(edgeBits, fract(edgeBits * 16.0), fract(edgeBits * 256.0), 1.0);
+	float edgeBits = texture(edgeTex, edgePos).x;
+	//fragColor = vec4(edgeBits, fract(edgeBits * 16.0), fract(edgeBits * 256.0), 1.0);
 
 	// transform (N x N x 4096) to (64N x 64N) texture coords
 	float t = 64.0 * edgeBits;
 	vec2 xy = vec2(fract(t), floor(t)/64.0);
 	vec2 subPixelPos = misc.xy;
 	xy += fract(subPixelPos) / 64.0;
-	vec2 offset = texture2D(offsetTex, xy).xw;
+	vec2 offset = texture(offsetTex, xy).xw;
 
 	// fract not really needed, but it eliminates one MOV instruction
 	vec2 texStep2 = fract(misc.zw);
-	vec4 col = texture2D(colorTex, leftTop + offset * texStep2);
+	vec4 col = texture(colorTex, leftTop + offset * texStep2);
 
 #if SUPERIMPOSE
-	vec4 vid = texture2D(videoTex, videoCoord);
-	gl_FragColor = mix(vid, col, col.a);
+	vec4 vid = texture(videoTex, videoCoord);
+	fragColor = mix(vid, col, col.a);
 #else
-	gl_FragColor = col;
+	fragColor = col;
 #endif
 }

--- a/share/shaders/hqlite.vert
+++ b/share/shaders/hqlite.vert
@@ -1,13 +1,13 @@
 uniform mat4 u_mvpMatrix;
 uniform vec3 texSize;
 
-attribute vec4 a_position;
-attribute vec3 a_texCoord;
+in vec4 a_position;
+in vec3 a_texCoord;
 
-varying vec2 leftTop;
-varying vec2 edgePos;
-varying vec4 misc;
-varying vec2 videoCoord;
+out vec2 leftTop;
+out vec2 edgePos;
+out vec4 misc;
+out vec2 videoCoord;
 
 void main()
 {

--- a/share/shaders/monitor3D.frag
+++ b/share/shaders/monitor3D.frag
@@ -1,9 +1,11 @@
 uniform sampler2D u_tex;
 
-varying float v_color;
-varying vec2 v_texCoord;
+in float v_color;
+in vec2 v_texCoord;
+
+out vec4 fragColor;
 
 void main()
 {
-	gl_FragColor = v_color * texture2D(u_tex, v_texCoord);
+	fragColor = v_color * texture(u_tex, v_texCoord);
 }

--- a/share/shaders/monitor3D.vert
+++ b/share/shaders/monitor3D.vert
@@ -1,12 +1,12 @@
 uniform mat4 u_mvpMatrix;
 uniform mat3 u_normalMatrix;
 
-attribute vec3 a_position;
-attribute vec3 a_normal;
-attribute vec2 a_texCoord;
+in vec3 a_position;
+in vec3 a_normal;
+in vec2 a_texCoord;
 
-varying float v_color;
-varying vec2 v_texCoord;
+out float v_color;
+out vec2 v_texCoord;
 
 void main()
 {

--- a/share/shaders/rgb.frag
+++ b/share/shaders/rgb.frag
@@ -2,9 +2,11 @@ uniform sampler2D tex;
 uniform sampler2D videoTex;
 uniform vec4 cnsts;
 
-varying vec4 scaled;
-varying vec2 pos;
-varying vec2 videoCoord;
+in vec4 scaled;
+in vec2 pos;
+in vec2 videoCoord;
+
+out vec4 fragColor;
 
 // saturate operations are free on nvidia hardware
 vec3 saturate(vec3 x)
@@ -24,15 +26,15 @@ void main()
 	const float BIG = 128.0; // big number, actual value is not important
 	vec3 m = saturate((-BIG * fract(scaled.zyx)) + vec3(2.0 * BIG / 3.0));
 
-	vec4 col = texture2D(tex, pos);
+	vec4 col = texture(tex, pos);
 #if SUPERIMPOSE
-	vec4 vid = texture2D(videoTex, videoCoord);
+	vec4 vid = texture(videoTex, videoCoord);
 	vec4 p = mix(vid, col, col.a);
 #else
 	vec4 p = col;
 #endif
 	vec3 n = p.rgb * scan_c2;
 	vec3 s_n = n * c1_2_2 + saturate((n - 1.0) / 2.0);
-	gl_FragColor.rgb = n + m * s_n;
-	gl_FragColor.a   = p.a;
+	fragColor.rgb = n + m * s_n;
+	fragColor.a   = p.a;
 }

--- a/share/shaders/rgb.vert
+++ b/share/shaders/rgb.vert
@@ -1,12 +1,12 @@
 uniform mat4 u_mvpMatrix;
 uniform vec3 texSize;
 
-attribute vec4 a_position;
-attribute vec3 a_texCoord;
+in vec4 a_position;
+in vec3 a_texCoord;
 
-varying vec4 scaled;
-varying vec2 pos;
-varying vec2 videoCoord;
+out vec4 scaled;
+out vec2 pos;
+out vec2 videoCoord;
 
 void main()
 {

--- a/share/shaders/sai.frag
+++ b/share/shaders/sai.frag
@@ -1,11 +1,13 @@
 uniform sampler2D tex;
 uniform sampler2D videoTex;
 
-varying vec4 posABCD;
-varying vec4 posEL;
-varying vec4 posGJ;
-varying vec3 scaled;
-varying vec2 videoCoord;
+in vec4 posABCD;
+in vec4 posEL;
+in vec4 posGJ;
+in vec3 scaled;
+in vec2 videoCoord;
+
+out vec4 fragColor;
 
 void swap(inout vec4 a, inout vec4 b)
 {
@@ -14,10 +16,10 @@ void swap(inout vec4 a, inout vec4 b)
 
 vec4 sai()
 {
-	vec4 A = texture2D(tex, posABCD.xy);
-	vec4 B = texture2D(tex, posABCD.zy);
-	vec4 C = texture2D(tex, posABCD.xw);
-	vec4 D = texture2D(tex, posABCD.zw);
+	vec4 A = texture(tex, posABCD.xy);
+	vec4 B = texture(tex, posABCD.zy);
+	vec4 C = texture(tex, posABCD.xw);
+	vec4 D = texture(tex, posABCD.zw);
 	vec3 pp = fract(scaled);
 
 	bvec2 b1 = bvec2(A.rgb == D.rgb, B.rgb == C.rgb);
@@ -33,10 +35,10 @@ vec4 sai()
 			pos2 = posGJ.zyxw;
 			p = pp.yz;
 		}
-		vec4 E = texture2D(tex, pos1.xy);
-		vec4 L = texture2D(tex, pos1.zw);
-		vec4 G = texture2D(tex, pos2.xy);
-		vec4 J = texture2D(tex, pos2.zw);
+		vec4 E = texture(tex, pos1.xy);
+		vec4 L = texture(tex, pos1.zw);
+		vec4 G = texture(tex, pos2.xy);
+		vec4 J = texture(tex, pos2.zw);
 
 		vec2 d = p / 2.0 - 0.25;
 		float d2 = p.y - p.x;
@@ -71,9 +73,9 @@ void main()
 {
 #if SUPERIMPOSE
 	vec4 col = sai();
-	vec4 vid = texture2D(videoTex, videoCoord);
-	gl_FragColor = mix(vid, col, col.a);
+	vec4 vid = texture(videoTex, videoCoord);
+	fragColor = mix(vid, col, col.a);
 #else
-	gl_FragColor = sai();
+	fragColor = sai();
 #endif
 }

--- a/share/shaders/sai.vert
+++ b/share/shaders/sai.vert
@@ -1,14 +1,14 @@
 uniform mat4 u_mvpMatrix;
 uniform vec3 texSize;
 
-attribute vec4 a_position;
-attribute vec3 a_texCoord;
+in vec4 a_position;
+in vec3 a_texCoord;
 
-varying vec4 posABCD;
-varying vec4 posEL;
-varying vec4 posGJ;
-varying vec3 scaled;
-varying vec2 videoCoord;
+out vec4 posABCD;
+out vec4 posEL;
+out vec4 posGJ;
+out vec3 scaled;
+out vec2 videoCoord;
 
 void main()
 {

--- a/share/shaders/scale2x.frag
+++ b/share/shaders/scale2x.frag
@@ -3,10 +3,12 @@
 uniform sampler2D tex;
 uniform sampler2D videoTex;
 
-varying vec2 texStep; // could be uniform
-varying vec2 coord2pi;
-varying vec2 texCoord;
-varying vec2 videoCoord;
+in vec2 texStep; // could be uniform
+in vec2 coord2pi;
+in vec2 texCoord;
+in vec2 videoCoord;
+
+out vec4 fragColor;
 
 vec4 scaleNx()
 {
@@ -17,13 +19,13 @@ vec4 scaleNx()
 	vec4 posLeftTop  = texCoord.stst - delta;
 	vec4 posRightBot = texCoord.stst + delta;
 
-	vec4 left  = texture2D(tex, posLeftTop.xy);
-	vec4 top   = texture2D(tex, posLeftTop.zw);
-	vec4 right = texture2D(tex, posRightBot.xy);
-	vec4 bot   = texture2D(tex, posRightBot.zw);
+	vec4 left  = texture(tex, posLeftTop.xy);
+	vec4 top   = texture(tex, posLeftTop.zw);
+	vec4 right = texture(tex, posRightBot.xy);
+	vec4 bot   = texture(tex, posRightBot.zw);
 
 	if (dot(left.rgb - right.rgb, top.rgb - bot.rgb) == 0.0 || left.rgb != top.rgb) {
-		return texture2D(tex, texCoord.st);
+		return texture(tex, texCoord.st);
 	} else {
 		return top;
 	}
@@ -33,9 +35,9 @@ void main()
 {
 #if SUPERIMPOSE
 	vec4 col = scaleNx();
-	vec4 vid = texture2D(videoTex, videoCoord);
-	gl_FragColor = mix(vid, col, col.a);
+	vec4 vid = texture(videoTex, videoCoord);
+	fragColor = mix(vid, col, col.a);
 #else
-	gl_FragColor = scaleNx();
+	fragColor = scaleNx();
 #endif
 }

--- a/share/shaders/scale2x.vert
+++ b/share/shaders/scale2x.vert
@@ -1,13 +1,13 @@
 uniform mat4 u_mvpMatrix;
 uniform vec3 texSize;
 
-attribute vec4 a_position;
-attribute vec3 a_texCoord;
+in vec4 a_position;
+in vec3 a_texCoord;
 
-varying vec2 texStep; // could be uniform
-varying vec2 coord2pi;
-varying vec2 texCoord;
-varying vec2 videoCoord;
+out vec2 texStep; // could be uniform
+out vec2 coord2pi;
+out vec2 texCoord;
+out vec2 videoCoord;
 
 float pi = 4.0 * atan(1.0);
 float pi2 = 2.0 * pi;

--- a/share/shaders/simple.frag
+++ b/share/shaders/simple.frag
@@ -3,9 +3,11 @@ uniform sampler2D videoTex;
 uniform vec4 cnst;
 uniform vec3 texStepX; // = vec3(vec2(1.0 / texSize.x), 0.0);
 
-varying vec2 scaled;
-varying vec3 misc;
-varying vec2 videoCoord;
+in vec2 scaled;
+in vec3 misc;
+in vec2 videoCoord;
+
+out vec4 fragColor;
 
 void main()
 {
@@ -15,17 +17,17 @@ void main()
 	float alpha  = cnst.w;
 
 	vec3 t = (vec3(floor(scaled.x)) + alpha * vec3(fract(scaled.x))) * texStepX + misc;
-	vec4 col1 = texture2D(tex, t.xz);
-	vec4 col2 = texture2D(tex, t.yz);
+	vec4 col1 = texture(tex, t.xz);
+	vec4 col2 = texture(tex, t.yz);
 
 	float scan = scan_c + scan_b * abs(fract(scaled.y) - scan_a);
 #if SUPERIMPOSE
 	vec4 col = (col1 + col2) / 2.0;
-	vec4 vid = texture2D(videoTex, videoCoord);
-	gl_FragColor = mix(vid, col, col.a) * scan;
+	vec4 vid = texture(videoTex, videoCoord);
+	fragColor = mix(vid, col, col.a) * scan;
 #else
 	// optimization: in case of not-superimpose, we moved the division by 2
 	// '(col1 + col2) / 2' to the 'scan_b' and 'scan_c' variables.
-	gl_FragColor = (col1 + col2) * scan;
+	fragColor = (col1 + col2) * scan;
 #endif
 }

--- a/share/shaders/simple.vert
+++ b/share/shaders/simple.vert
@@ -3,12 +3,12 @@ uniform vec3 texSize;
 uniform vec3 texStepX; // = vec3(vec2(1.0 / texSize.x), 0.0);
 uniform vec4 cnst;     // = vec4(scan_a, scan_b, scan_c, alpha);
 
-attribute vec4 a_position;
-attribute vec3 a_texCoord;
+in vec4 a_position;
+in vec3 a_texCoord;
 
-varying vec2 scaled;
-varying vec3 misc;
-varying vec2 videoCoord;
+out vec2 scaled;
+out vec3 misc;
+out vec2 videoCoord;
 
 void main()
 {

--- a/share/shaders/texture.frag
+++ b/share/shaders/texture.frag
@@ -1,9 +1,11 @@
 uniform sampler2D u_tex;
 uniform vec4 u_color;
 
-varying vec2 v_texCoord;
+in vec2 v_texCoord;
+
+out vec4 fragColor;
 
 void main()
 {
-	gl_FragColor = texture2D(u_tex, v_texCoord) * u_color;
+	fragColor = texture(u_tex, v_texCoord) * u_color;
 }

--- a/share/shaders/texture.vert
+++ b/share/shaders/texture.vert
@@ -1,9 +1,9 @@
 uniform mat4 u_mvpMatrix;
 
-attribute vec4 a_position;
-attribute vec2 a_texCoord;
+in vec4 a_position;
+in vec2 a_texCoord;
 
-varying vec2 v_texCoord;
+out vec2 v_texCoord;
 
 void main()
 {

--- a/share/shaders/tv.frag
+++ b/share/shaders/tv.frag
@@ -5,17 +5,19 @@ uniform sampler2D videoTex;
 uniform float minScanline;
 uniform float sizeVariance;
 
-varying vec4 intCoord;
-varying vec4 cornerCoord0;
-varying vec4 cornerCoord1;
+in vec4 intCoord;
+in vec4 cornerCoord0;
+in vec4 cornerCoord1;
+
+out vec4 fragColor;
 
 vec4 calcCorner(const vec2 texCoord0,
                 const vec2 texCoord1,
                 const float dist)
 {
-	vec4 col0 = texture2D(tex, texCoord0);
+	vec4 col0 = texture(tex, texCoord0);
 #if SUPERIMPOSE
-	vec4 vid = texture2D(videoTex, texCoord1);
+	vec4 vid = texture(videoTex, texCoord1);
 	vec4 col = mix(vid, col0, col0.a);
 #else
 	vec4 col = col0;
@@ -29,7 +31,7 @@ vec4 calcCorner(const vec2 texCoord0,
 void main()
 {
 	vec4 distComp = fract(intCoord);
-	gl_FragColor = mix(
+	fragColor = mix(
 		calcCorner(cornerCoord0.xy, cornerCoord1.xy, distComp.w) +
 		calcCorner(cornerCoord0.xw, cornerCoord1.xw, distComp.y),
 		calcCorner(cornerCoord0.zy, cornerCoord1.zy, distComp.w) +

--- a/share/shaders/tv.vert
+++ b/share/shaders/tv.vert
@@ -1,12 +1,12 @@
 uniform mat4 u_mvpMatrix;
 uniform vec3 texSize; // xy = texSize1,  xz = texSize2
 
-attribute vec4 a_position;
-attribute vec3 a_texCoord;
+in vec4 a_position;
+in vec3 a_texCoord;
 
-varying vec4 intCoord;
-varying vec4 cornerCoord0;
-varying vec4 cornerCoord1;
+out vec4 intCoord;
+out vec4 cornerCoord0;
+out vec4 cornerCoord1;
 
 void main()
 {

--- a/src/CommandLineParser.cc
+++ b/src/CommandLineParser.cc
@@ -69,9 +69,6 @@ CommandLineParser::CommandLineParser(Reactor& reactor_)
 	registerOption("-control",    controlOption, PHASE_BEFORE_SETTINGS, 1);
 	registerOption("-script",     scriptOption,  PHASE_BEFORE_SETTINGS, 1); // correct phase?
 	registerOption("-command",    commandOption, PHASE_BEFORE_SETTINGS, 1); // same phase as -script
-	#if COMPONENT_GL
-	registerOption("-nopbo",      noPBOOption,   PHASE_BEFORE_SETTINGS, 1);
-	#endif
 	registerOption("-testconfig", testConfigOption, PHASE_BEFORE_SETTINGS, 1);
 
 	registerOption("-machine",    machineOption, PHASE_LOAD_MACHINE);
@@ -548,23 +545,6 @@ void CommandLineParser::SettingOption::parseOption(
 string_view CommandLineParser::SettingOption::optionHelp() const
 {
 	return "Load an alternative settings file";
-}
-
-
-// class NoPBOOption
-
-void CommandLineParser::NoPBOOption::parseOption(
-	const string& /*option*/, span<string>& /*cmdLine*/)
-{
-	#if COMPONENT_GL
-	cout << "Disabling PBO\n";
-	gl::PixelBuffers::enabled = false;
-	#endif
-}
-
-string_view CommandLineParser::NoPBOOption::optionHelp() const
-{
-	return "Disables usage of openGL PBO (for debugging)";
 }
 
 

--- a/src/CommandLineParser.hh
+++ b/src/CommandLineParser.hh
@@ -129,11 +129,6 @@ private:
 		std::string_view optionHelp() const override;
 	} settingOption;
 
-	struct NoPBOOption final : CLIOption {
-		void parseOption(const std::string& option, span<std::string>& cmdLine) override;
-		std::string_view optionHelp() const override;
-	} noPBOOption;
-
 	struct TestConfigOption final : CLIOption {
 		void parseOption(const std::string& option, span<std::string>& cmdLine) override;
 		std::string_view optionHelp() const override;

--- a/src/video/GLImage.hh
+++ b/src/video/GLImage.hh
@@ -25,6 +25,11 @@ public:
 	          uint8_t r, uint8_t g, uint8_t b, uint8_t alpha) override;
 
 private:
+	void initBuffers();
+
+	gl::VertexArray vao;
+	gl::BufferObject vbo[3];
+	gl::BufferObject elementsBuffer;
 	gl::Texture texture; // must come after size
 	int borderSize;
 	int bgA[4], borderA;

--- a/src/video/GLPostProcessor.cc
+++ b/src/video/GLPostProcessor.cc
@@ -572,14 +572,25 @@ void GLPostProcessor::preCalcMonitor3D(float width)
 	}
 
 	// upload calculated values to buffers
+	monitor3DVAO.bind();
 	glBindBuffer(GL_ARRAY_BUFFER, arrayBuffer.get());
 	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices,
 	             GL_STATIC_DRAW);
+	char* base = nullptr;
+	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex),
+	                      base);
+	glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex),
+	                      base + sizeof(vec3));
+	glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex),
+	                      base + sizeof(vec3) + sizeof(vec3));
+	glEnableVertexAttribArray(0);
+	glEnableVertexAttribArray(1);
+	glEnableVertexAttribArray(2);
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, elementbuffer.get());
 	glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices,
 	             GL_STATIC_DRAW);
-	glBindBuffer(GL_ARRAY_BUFFER, 0);
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+	monitor3DVAO.unbind();
 
 	// calculate transformation matrices
 	mat4 proj = frustum(-1, 1, -1, 1, 1, 10);
@@ -602,27 +613,9 @@ void GLPostProcessor::preCalcMonitor3D(float width)
 void GLPostProcessor::drawMonitor3D()
 {
 	monitor3DProg.activate();
-
-	char* base = nullptr;
-	glBindBuffer(GL_ARRAY_BUFFER, arrayBuffer.get());
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, elementbuffer.get());
-	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex),
-	                      base);
-	glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex),
-	                      base + sizeof(vec3));
-	glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex),
-	                      base + sizeof(vec3) + sizeof(vec3));
-	glEnableVertexAttribArray(0);
-	glEnableVertexAttribArray(1);
-	glEnableVertexAttribArray(2);
-
+	monitor3DVAO.bind();
 	glDrawElements(GL_TRIANGLE_STRIP, NUM_INDICES, GL_UNSIGNED_SHORT, nullptr);
-	glDisableVertexAttribArray(2);
-	glDisableVertexAttribArray(1);
-	glDisableVertexAttribArray(0);
-
-	glBindBuffer(GL_ARRAY_BUFFER, 0);
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+	monitor3DVAO.unbind();
 }
 
 } // namespace openmsx

--- a/src/video/GLPostProcessor.hh
+++ b/src/video/GLPostProcessor.hh
@@ -101,6 +101,8 @@ private:
 	gl::VertexArray glowVAO;
 	gl::BufferObject vbo[2];
 	gl::BufferObject stretchVBO;
+	gl::VertexArray noiseVAO;
+	gl::BufferObject noiseVBO[2];
 
 	bool storedFrame;
 };

--- a/src/video/GLPostProcessor.hh
+++ b/src/video/GLPostProcessor.hh
@@ -93,6 +93,7 @@ private:
 	  */
 	RenderSettings::ScaleAlgorithm scaleAlgorithm;
 
+	gl::VertexArray monitor3DVAO;
 	gl::ShaderProgram monitor3DProg;
 	gl::BufferObject arrayBuffer;
 	gl::BufferObject elementbuffer;

--- a/src/video/GLPostProcessor.hh
+++ b/src/video/GLPostProcessor.hh
@@ -36,6 +36,7 @@ protected:
 	void update(const Setting& setting) override;
 
 private:
+	void initBuffers();
 	void createRegions();
 	void uploadFrame();
 	void uploadBlock(unsigned srcStartY, unsigned srcEndY,
@@ -95,6 +96,10 @@ private:
 	gl::ShaderProgram monitor3DProg;
 	gl::BufferObject arrayBuffer;
 	gl::BufferObject elementbuffer;
+	gl::VertexArray vao;
+	gl::VertexArray glowVAO;
+	gl::BufferObject vbo[2];
+	gl::BufferObject stretchVBO;
 
 	bool storedFrame;
 };

--- a/src/video/GLSnow.hh
+++ b/src/video/GLSnow.hh
@@ -20,6 +20,8 @@ public:
 
 private:
 	Display& display;
+	gl::VertexArray vao;
+	gl::BufferObject vbo[2];
 	gl::Texture noiseTexture;
 };
 

--- a/src/video/GLUtil.cc
+++ b/src/video/GLUtil.cc
@@ -340,4 +340,18 @@ BufferObject::~BufferObject()
 	glDeleteBuffers(1, &bufferId); // ok to delete 0-buffer
 }
 
+
+// class VertexArray
+
+VertexArray::VertexArray()
+{
+	glGenVertexArrays(1, &bufferId);
+}
+
+VertexArray::~VertexArray()
+{
+	unbind();
+	glDeleteVertexArrays(1, &bufferId); // ok to delete 0-buffer
+}
+
 } // namespace gl

--- a/src/video/GLUtil.cc
+++ b/src/video/GLUtil.cc
@@ -140,7 +140,7 @@ Shader::Shader(GLenum type, const string& header, const string& filename)
 void Shader::init(GLenum type, const string& header, const string& filename)
 {
 	// Load shader source.
-	string source = "#version 110\n" + header;
+	string source = "#version 330\n" + header;
 	try {
 		File file(systemFileContext().resolve("shaders/" + filename));
 		auto mmap = file.mmap();

--- a/src/video/GLUtil.cc
+++ b/src/video/GLUtil.cc
@@ -9,11 +9,6 @@
 #include <vector>
 #include <cstdio>
 
-#ifndef glGetShaderiv
-#error The version of GLEW you have installed is missing some OpenGL 2.0 entry points. \
-       Please upgrade to GLEW 1.3.2 or higher.
-#endif
-
 using std::string;
 using namespace openmsx;
 
@@ -100,14 +95,14 @@ static std::vector<GLuint> stack;
 
 FrameBufferObject::FrameBufferObject(Texture& texture)
 {
-	glGenFramebuffersEXT(1, &bufferId);
-	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, bufferId);
-	glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT,
-	                          GL_COLOR_ATTACHMENT0_EXT,
-	                          GL_TEXTURE_2D, texture.textureId, 0);
-	bool success = glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT) ==
-	               GL_FRAMEBUFFER_COMPLETE_EXT;
-	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, currentId);
+	glGenFramebuffers(1, &bufferId);
+	glBindFramebuffer(GL_FRAMEBUFFER, bufferId);
+	glFramebufferTexture2D(GL_FRAMEBUFFER,
+	                       GL_COLOR_ATTACHMENT0,
+	                       GL_TEXTURE_2D, texture.textureId, 0);
+	bool success = glCheckFramebufferStatus(GL_FRAMEBUFFER) ==
+	               GL_FRAMEBUFFER_COMPLETE;
+	glBindFramebuffer(GL_FRAMEBUFFER, currentId);
 	if (!success) {
 		throw InitException(
 			"Your OpenGL implementation support for "
@@ -124,14 +119,14 @@ FrameBufferObject::~FrameBufferObject()
 	if (currentId == bufferId) {
 		pop();
 	}
-	glDeleteFramebuffersEXT(1, &bufferId);
+	glDeleteFramebuffers(1, &bufferId);
 }
 
 void FrameBufferObject::push()
 {
 	stack.push_back(currentId);
 	currentId = bufferId;
-	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, currentId);
+	glBindFramebuffer(GL_FRAMEBUFFER, currentId);
 }
 
 void FrameBufferObject::pop()
@@ -140,7 +135,7 @@ void FrameBufferObject::pop()
 	assert(!stack.empty());
 	currentId = stack.back();
 	stack.pop_back();
-	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, currentId);
+	glBindFramebuffer(GL_FRAMEBUFFER, currentId);
 }
 
 

--- a/src/video/GLUtil.hh
+++ b/src/video/GLUtil.hh
@@ -132,6 +132,7 @@ public:
 
 private:
 	GLuint bufferId = 0; // 0 is not a valid openGL name
+	GLint previousId = 0;
 };
 
 /** Wrapper around a pixel buffer.

--- a/src/video/GLUtil.hh
+++ b/src/video/GLUtil.hh
@@ -473,6 +473,36 @@ private:
 	GLuint bufferId;
 };
 
+class VertexArray
+{
+public:
+	VertexArray();
+	~VertexArray();
+	VertexArray(VertexArray&& other) noexcept
+		: bufferId(other.bufferId)
+	{
+		other.bufferId = 0;
+	}
+	VertexArray& operator=(VertexArray&& other) noexcept {
+		std::swap(bufferId, other.bufferId);
+		return *this;
+	}
+
+	/** Bind this VertexArray. Must be called before glDraw*() and
+	  * glVertexAttribPointer() are used.
+	  */
+	void bind() const { glBindVertexArray(bufferId); }
+
+	/** Unbind this VertexArray.
+	  */
+	void unbind() const { glBindVertexArray(0); }
+
+	GLuint get() const { return bufferId; }
+
+private:
+	GLuint bufferId;
+};
+
 } // namespace gl
 
 #endif // COMPONENT_GL

--- a/src/video/SDLGLOffScreenSurface.cc
+++ b/src/video/SDLGLOffScreenSurface.cc
@@ -7,11 +7,7 @@ namespace openmsx {
 SDLGLOffScreenSurface::SDLGLOffScreenSurface(const SDLGLVisibleSurface& output)
 	: fboTex(true) // enable interpolation   TODO why?
 {
-	// only used for width and height, TODO still needed?
-	setSDLSurface(output.getSDLSurface());
-
 	calculateViewPort(output.getLogicalSize(), output.getPhysicalSize());
-
 	auto [w, h] = getPhysicalSize();
 	fboTex.bind();
 	glTexImage2D(GL_TEXTURE_2D,    // target
@@ -27,7 +23,6 @@ SDLGLOffScreenSurface::SDLGLOffScreenSurface(const SDLGLVisibleSurface& output)
 	fbo.push();
 
 	setOpenGlPixelFormat();
-	setBufferPtr(nullptr, 0); // direct access not allowed
 }
 
 void SDLGLOffScreenSurface::saveScreenshot(const std::string& filename)

--- a/src/video/SDLGLVisibleSurface.cc
+++ b/src/video/SDLGLVisibleSurface.cc
@@ -63,7 +63,7 @@ SDLGLVisibleSurface::SDLGLVisibleSurface(
 	// If that happens, center the area that we actually use.
 	int w, h;
 	SDL_GL_GetDrawableSize(window.get(), &w, &h);
-	calculateViewPort(gl::ivec2(surface->w, surface->h), gl::ivec2(w, h));
+	calculateViewPort(gl::ivec2(width, height), gl::ivec2(w, h));
 	auto [vx, vy] = getViewOffset();
 	auto [vw, vh] = getViewSize();
 	glViewport(vx, vy, vw, vh);
@@ -74,8 +74,6 @@ SDLGLVisibleSurface::SDLGLVisibleSurface(
 	glMatrixMode(GL_MODELVIEW);
 
 	setOpenGlPixelFormat();
-	setBufferPtr(nullptr, 0); // direct access not allowed
-
 	gl::context = std::make_unique<gl::Context>(width, height);
 }
 

--- a/src/video/SDLGLVisibleSurface.cc
+++ b/src/video/SDLGLVisibleSurface.cc
@@ -30,33 +30,21 @@ SDLGLVisibleSurface::SDLGLVisibleSurface(
 	int flags = SDL_WINDOW_OPENGL;
 	//flags |= SDL_RESIZABLE;
 	createSurface(width, height, flags);
+
+	// Create an OpenGL 3.3 Core profile
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
 	glContext = SDL_GL_CreateContext(window.get());
 
-	// From the glew documentation:
-	//   GLEW obtains information on the supported extensions from the
-	//   graphics driver. Experimental or pre-release drivers, however,
-	//   might not report every available extension through the standard
-	//   mechanism, in which case GLEW will report it unsupported. To
-	//   circumvent this situation, the glewExperimental global switch can
-	//   be turned on by setting it to GL_TRUE before calling glewInit(),
-	//   which ensures that all extensions with valid entry points will be
-	//   exposed.
-	// The 'glewinfo' utility also sets this flag before reporting results,
-	// so I believe it would cause less confusion to do the same here.
-	glewExperimental = GL_TRUE;
-
 	// Initialise GLEW library.
-	// This must happen after GL itself is initialised, which is done by
-	// the SDL_SetVideoMode() call in createSurface().
+	glewExperimental = GL_TRUE;
 	GLenum glew_error = glewInit();
 	if (glew_error != GLEW_OK) {
 		throw InitException(
 			"Failed to init GLEW: ",
 			reinterpret_cast<const char*>(
 				glewGetErrorString(glew_error)));
-	}
-	if (!GLEW_VERSION_2_0) {
-		throw InitException("Need at least openGL version 2.0.");
 	}
 
 	// The created surface may be larger than requested.

--- a/src/video/SDLOutputSurface.hh
+++ b/src/video/SDLOutputSurface.hh
@@ -65,8 +65,8 @@ protected:
 private:
 	SDL_Surface* surface = nullptr;
 	SDL_Renderer* renderer = nullptr;
-	char* data;
-	unsigned pitch;
+	char* data = nullptr;
+	unsigned pitch = 0;
 	bool locked = false;
 };
 

--- a/src/video/SDLVisibleSurface.hh
+++ b/src/video/SDLVisibleSurface.hh
@@ -31,6 +31,11 @@ public:
 		Reactor& reactor, CommandConsole& console) override;
 	std::unique_ptr<Layer> createOSDGUILayer(OSDGUI& gui) override;
 	std::unique_ptr<OutputSurface> createOffScreenSurface() override;
+
+private:
+	SDLRendererPtr renderer;
+	SDLSurfacePtr surface;
+	SDLTexturePtr texture;
 };
 
 } // namespace openmsx

--- a/src/video/SDLVisibleSurfaceBase.cc
+++ b/src/video/SDLVisibleSurfaceBase.cc
@@ -34,31 +34,6 @@ void SDLVisibleSurfaceBase::createSurface(int width, int height, unsigned flags)
 
 	updateWindowTitle();
 
-	renderer.reset(SDL_CreateRenderer(window.get(), -1, 0));
-	if (!renderer) {
-		std::string err = SDL_GetError();
-		throw InitException("Could not create renderer: " + err);
-	}
-	SDL_RenderSetLogicalSize(renderer.get(), width, height);
-	setSDLRenderer(renderer.get());
-
-	surface.reset(SDL_CreateRGBSurface(
-			0, width, height, 32,
-			0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000));
-	if (!surface) {
-		std::string err = SDL_GetError();
-		throw InitException("Could not create surface: " + err);
-	}
-	setSDLSurface(surface.get());
-
-	texture.reset(SDL_CreateTexture(
-			renderer.get(), SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING,
-			width, height));
-	if (!texture) {
-		std::string err = SDL_GetError();
-		throw InitException("Could not create texture: " + err);
-	}
-
 	// prefer linear filtering (instead of nearest neighbour)
 	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1");
 
@@ -113,14 +88,6 @@ bool SDLVisibleSurfaceBase::setFullScreen(bool fullscreen)
 	// We now always create a new screen to make the code on both OSes
 	// more similar (we had a windows-only bug because of this difference)
 	return false;
-
-	/*
-	// try to toggle full screen
-	SDL_Surface* surf = getSDLSurface();
-	SDL_WM_ToggleFullScreen(surf);
-	bool newState = (surf->flags & SDL_FULLSCREEN) != 0;
-	return newState == fullscreen;
-	*/
 }
 
 } // namespace openmsx

--- a/src/video/SDLVisibleSurfaceBase.hh
+++ b/src/video/SDLVisibleSurfaceBase.hh
@@ -21,9 +21,6 @@ protected:
 
 	SDLSubSystemInitializer<SDL_INIT_VIDEO> videoSubSystem;
 	SDLWindowPtr window;
-	SDLRendererPtr renderer;
-	SDLSurfacePtr surface;
-	SDLTexturePtr texture;
 };
 
 } // namespace openmsx

--- a/src/video/scalers/GLHQLiteScaler.cc
+++ b/src/video/scalers/GLHQLiteScaler.cc
@@ -25,13 +25,15 @@ GLHQLiteScaler::GLHQLiteScaler(GLScaler& fallback_)
 	edgeTexture.bind();
 	glTexImage2D(GL_TEXTURE_2D,    // target
 	             0,                // level
-	             GL_LUMINANCE16,   // internal format
+	             GL_R16,           // internal format
 	             320,              // width
 	             240,              // height
 	             0,                // border
-	             GL_LUMINANCE,     // format
+	             GL_RED,           // format
 	             GL_UNSIGNED_SHORT,// type
 	             nullptr);         // data
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, GL_RED);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
 	edgeBuffer.setImage(320, 240);
 
 	auto context = systemFileContext();
@@ -44,13 +46,16 @@ GLHQLiteScaler::GLHQLiteScaler(GLScaler& fallback_)
 		offsetTexture[i].bind();
 		glTexImage2D(GL_TEXTURE_2D,        // target
 		             0,                    // level
-		             GL_LUMINANCE8_ALPHA8, // internal format
+		             GL_RG8,               // internal format
 		             n * 64,               // width
 		             n * 64,               // height
 		             0,                    // border
-		             GL_LUMINANCE_ALPHA,   // format
+		             GL_RG,                // format
 		             GL_UNSIGNED_BYTE,     // type
 		             offsetFile.mmap().data());// data
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, GL_RED);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_GREEN);
 	}
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 4); // restore to default
 }
@@ -122,7 +127,7 @@ void GLHQLiteScaler::uploadBlock(
 		                srcStartY,           // offset y
 		                lineWidth,           // width
 		                srcEndY - srcStartY, // height
-		                GL_LUMINANCE,        // format
+		                GL_RED,              // format
 		                GL_UNSIGNED_SHORT,   // type
 		                edgeBuffer.getOffset(0, srcStartY)); // data
 	}

--- a/src/video/scalers/GLHQScaler.cc
+++ b/src/video/scalers/GLHQScaler.cc
@@ -26,13 +26,15 @@ GLHQScaler::GLHQScaler(GLScaler& fallback_)
 	edgeTexture.bind();
 	glTexImage2D(GL_TEXTURE_2D,    // target
 	             0,                // level
-	             GL_LUMINANCE16,   // internal format
+	             GL_R16,           // internal format
 	             320,              // width
 	             240,              // height
 	             0,                // border
-	             GL_LUMINANCE,     // format
+	             GL_RED,           // format
 	             GL_UNSIGNED_SHORT,// type
 	             nullptr);         // data
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, GL_RED);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
 	edgeBuffer.setImage(320, 240);
 
 	auto context = systemFileContext();
@@ -139,7 +141,7 @@ void GLHQScaler::uploadBlock(
 		                srcStartY,           // offset y
 		                lineWidth,           // width
 		                srcEndY - srcStartY, // height
-		                GL_LUMINANCE,        // format
+		                GL_RED,              // format
 		                GL_UNSIGNED_SHORT,   // type
 		                edgeBuffer.getOffset(0, srcStartY)); // data
 	}

--- a/src/video/scalers/GLScaler.cc
+++ b/src/video/scalers/GLScaler.cc
@@ -84,14 +84,17 @@ void GLScaler::execute(
 		vec3(1.0f + hShift, tex0EndY  , tex1EndY  ),
 		vec3(0.0f + hShift, tex0EndY  , tex1EndY  ),
 	};
-
-	glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, pos);
-	glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 0, tex);
+	vao.bind();
+	glBindBuffer(GL_ARRAY_BUFFER, vbo[0].get());
+	glBufferData(GL_ARRAY_BUFFER, sizeof(pos), pos, GL_STATIC_DRAW);
+	glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
 	glEnableVertexAttribArray(0);
+	glBindBuffer(GL_ARRAY_BUFFER, vbo[1].get());
+	glBufferData(GL_ARRAY_BUFFER, sizeof(tex), tex, GL_STATIC_DRAW);
+	glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
 	glEnableVertexAttribArray(1);
 	glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
-	glDisableVertexAttribArray(1);
-	glDisableVertexAttribArray(0);
+	vao.unbind();
 }
 
 } // namespace openmsx

--- a/src/video/scalers/GLScaler.hh
+++ b/src/video/scalers/GLScaler.hh
@@ -74,6 +74,8 @@ protected:
 	             bool textureFromZero = false);
 
 protected:
+	gl::VertexArray vao;
+	gl::BufferObject vbo[2];
 	gl::ShaderProgram program[2];
 	GLint unifTexSize[2];
 };


### PR DESCRIPTION
The main purpose of this series is to upgrade the OpenGL drawing code in openMSX to OpenGL 3.3 Core profile. This version should be supported on systems sold from 2008 onwards. I did a basic conversion, optimizing only obvious cases. I'm sure there is a lot more room for improvement.