### PR TITLE
Fix MIDI In not working under Windows

### DIFF
--- a/src/serial/MidiInWindows.cc
+++ b/src/serial/MidiInWindows.cc
@@ -63,10 +63,10 @@ void MidiInWindows::plugHelper(Connector& connector_, EmuTime::param /*time*/)
 
 	setConnector(&connector_); // base class will do this in a moment,
 	                           // but thread already needs it
-	thread = std::thread([this]() { run(); });
 
 	{
 		std::unique_lock<std::mutex> threadIdLock(threadIdMutex);
+		thread = std::thread([this]() { run(); });
 		threadIdCond.wait(threadIdLock);
 	}
 	{
@@ -139,10 +139,10 @@ void MidiInWindows::run()
 		std::lock_guard<std::mutex> threadIdLock(threadIdMutex);
 		threadId = GetCurrentThreadId();
 	}
-	threadIdCond.notify_all();
 
 	{
 		std::unique_lock<std::mutex> devIdxLock(devIdxMutex);
+		threadIdCond.notify_all();
 		devIdxCond.wait(devIdxLock);
 	}
 

--- a/src/serial/Midi_w32.cc
+++ b/src/serial/Midi_w32.cc
@@ -376,6 +376,9 @@ unsigned w32_midiInOpen(const char *vfn, DWORD thrdid)
 	if (midiInAddBuffer(reinterpret_cast<HMIDIIN>(vfnt_midiin[idx].handle), static_cast<LPMIDIHDR>(&inhdr), sizeof(inhdr)) != MMSYSERR_NOERROR) {
 		return unsigned(-1);
 	}
+	if (midiInStart(reinterpret_cast<HMIDIIN>(vfnt_midiin[idx].handle)) != MMSYSERR_NOERROR) {
+		return unsigned(-1);
+	}
 	return idx;
 }
 


### PR DESCRIPTION
Formerly: Fix deadlock when plugging Windows MIDI-In device

When plugging a MIDI Input device into the MSX via
`plug msx-midi-in midi-in-0`
then the emulator will freeze under Windows.

What happens is:
- The main thread creates a worker thread in `MidiInWindows::plugHelper()`.
- The worker thread `MidiInWindows::run()` runs and calls `threadIdCond.notify_all();` before the main thread continues.
- The main thread eventually calls `threadIdCond.wait(threadIdLock);`, but the worker thread already issued the signal before the main thread started waiting for it, creating a deadlock.

Creating the thread while `threadIdMutex` is locked resolves the issue. (first commit)
The bug was introduced with ad85714b24a9c27fb23a5f60cc990e2ba847bec5.

Also, `midiInStart` was never called, thus it never started receiving events. (fixed by second commit)

fixes #999