### PR TITLE
fix Windows MIDI output

### DIFF
--- a/src/serial/MidiOutWindows.cc
+++ b/src/serial/MidiOutWindows.cc
@@ -59,10 +59,10 @@ std::string_view MidiOutWindows::getDescription() const
 	return desc;
 }
 
-void MidiOutWindows::recvByte(byte value, EmuTime::param /*time*/)
+void MidiOutWindows::recvMessage(const std::vector<uint8_t>& message, EmuTime::param /*time*/)
 {
 	if (devidx != unsigned(-1)) {
-		w32_midiOutPut(value, devidx);
+		w32_midiOutMsg(message.size(), message.data(), devidx);
 	}
 }
 

--- a/src/serial/MidiOutWindows.hh
+++ b/src/serial/MidiOutWindows.hh
@@ -24,7 +24,7 @@ public:
 	std::string_view getDescription() const override;
 
 	// SerialDataInterface (part)
-	void recvByte(byte value, EmuTime::param time) override;
+	void recvMessage(const std::vector<uint8_t>& message, EmuTime::param time) override;
 
 	template<typename Archive>
 	void serialize(Archive& ar, unsigned version);

--- a/src/serial/Midi_w32.cc
+++ b/src/serial/Midi_w32.cc
@@ -59,9 +59,6 @@ struct vfn_midi {
 };
 
 struct outbuf {
-	DWORD    shortmes;
-	unsigned longmes_cnt;
-	char     longmes[OPENMSX_W32_MIDI_SYSMES_MAXLEN];
 	MIDIHDR  header;
 };
 
@@ -194,8 +191,8 @@ int w32_midiOutClose(unsigned idx)
 static int w32_midiOutFlushExclusiveMsg(unsigned idx)
 {
 	int i;
-	buf_out[idx].header.lpData = buf_out[idx].longmes;
-	buf_out[idx].header.dwBufferLength = buf_out[idx].longmes_cnt;
+	//buf_out[idx].header.lpData = buf_out[idx].longmes;
+	//buf_out[idx].header.dwBufferLength = buf_out[idx].longmes_cnt;
 	buf_out[idx].header.dwFlags = 0;
 	if ((i = midiOutPrepareHeader(reinterpret_cast<HMIDIOUT>(vfnt_midiout[idx].handle), &buf_out[idx].header, sizeof(buf_out[idx].header))) != MMSYSERR_NOERROR) {
 		throw FatalError("midiOutPrepareHeader() returned ", i);
@@ -212,89 +209,32 @@ static int w32_midiOutFlushExclusiveMsg(unsigned idx)
 	if ((i = midiOutUnprepareHeader(reinterpret_cast<HMIDIOUT>(vfnt_midiout[idx].handle), &buf_out[idx].header, sizeof(buf_out[idx].header))) != MMSYSERR_NOERROR) {
 		throw FatalError("midiOutUnPrepareHeader() returned ", i);
 	}
-	buf_out[idx].longmes_cnt = 0;
 	return 0;
 }
 
-int w32_midiOutPut(unsigned char value, unsigned idx)
+int w32_midiOutMsg(unsigned size, const uint8_t* data, unsigned idx)
 {
-	if ((state_out[idx] & 0x1000) || ((value & 0x0ff) == 0x0f0)) {
-		if (!(state_out[idx] & 0x1000)) {
-			// SYSTEM MESSAGE Exclusive start
-			state_out[idx] |= 0x1000;
-		}
-		if (buf_out[idx].longmes_cnt >= OPENMSX_W32_MIDI_SYSMES_MAXLEN) {
+	if (size <= 0)
+		return 0;
+	HMIDIOUT hMidiOut = reinterpret_cast<HMIDIOUT>(vfnt_midiout[idx].handle);
+	if (data[0] == 0xF0 || data[0] == 0xF7)	// SysEx
+	{
+		if (size > OPENMSX_W32_MIDI_SYSMES_MAXLEN)
 			return -1;
-		}
-		buf_out[idx].longmes[buf_out[idx].longmes_cnt++] = value;
-
-		if (value == 0x0f7) {
-			// SYSTEM MESSAGES Exclusive end
-			w32_midiOutFlushExclusiveMsg(idx);
-			state_out[idx] &= ~0x1000;
-		}
-	} else {
-		switch (state_out[idx]) {
-		case 0x0000:
-			switch (value & 0x0f0) {
-			case 0x080: // Note Off
-			case 0x090: // Note On
-			case 0x0a0: // Key Pressure
-			case 0x0b0: // Control Change
-			case 0x0e0: // Pitch Wheel
-				state_out[idx] = 0x0082;
-				buf_out[idx].shortmes = DWORD(value) & 0x0ff;
-				break;
-			case 0x0c0: // Program Change
-			case 0x0d0: // After Touch
-				state_out[idx] = 0x0041;
-				buf_out[idx].shortmes = DWORD(value) & 0x0ff;
-				break;
-			case 0x0f0: // SYSTEM MESSAGE (other than "EXCLUSIVE")
-				switch (value &0x0f) {
-					case 0x02: // Song Position Pointer
-						state_out[idx] = 0x0082;
-						buf_out[idx].shortmes = DWORD(value) & 0x0ff;
-						break;
-					case 0x01: // Time Code
-					case 0x03: // Song Select
-						state_out[idx] = 0x0041;
-						buf_out[idx].shortmes = DWORD(value) & 0x0ff;
-						break;
-					default: // Timing Clock, Sequencer Start, Sequencer Continue,
-					         // Sequencer Stop, Cable Check, System Reset, and Unknown...
-						state_out[idx] = 0;
-						buf_out[idx].shortmes = DWORD(value) & 0x0ff;
-						midiOutShortMsg(reinterpret_cast<HMIDIOUT>(vfnt_midiout[idx].handle), buf_out[idx].shortmes);
-						break;
-				}
-				break;
-			default:
-				state_out[idx] = 0;
-				buf_out[idx].shortmes = DWORD(value) & 0x0ff;
-				midiOutShortMsg(reinterpret_cast<HMIDIOUT>(vfnt_midiout[idx].handle), buf_out[idx].shortmes);
-				break;
-			}
-			break;
-		case 0x0041:
-			buf_out[idx].shortmes |= (DWORD(value) & 0x0ff) << 8;
-			midiOutShortMsg(reinterpret_cast<HMIDIOUT>(vfnt_midiout[idx].handle), buf_out[idx].shortmes);
-			state_out[idx] = 0;
-			break;
-		case 0x0082:
-			buf_out[idx].shortmes |= (DWORD(value) & 0x0ff) << 8;
-			state_out[idx] = 0x0081;
-			break;
-		case 0x0081:
-			buf_out[idx].shortmes |= (DWORD(value) & 0x0ff) << 16;
-			midiOutShortMsg(reinterpret_cast<HMIDIOUT>(vfnt_midiout[idx].handle), buf_out[idx].shortmes);
-			state_out[idx] = 0;
-			break;
-		default:
-			// not reach...
-			midiOutShortMsg(reinterpret_cast<HMIDIOUT>(vfnt_midiout[idx].handle), DWORD(value) & 0x0ff);
-			break;
-		}
+		auto& buf = buf_out[idx];
+		// Note: We have to be careful with the const_cast here.
+		// Even though Windows doesn't write to the buffer, it fails if you don't have
+		// write access to the respective memory page.
+		buf.header.lpData = const_cast<LPSTR>(reinterpret_cast<LPCSTR>(data));
+		buf.header.dwBufferLength = size;
+		w32_midiOutFlushExclusiveMsg(idx);
+	}
+	else
+	{
+		DWORD midiMsg = 0x000000;
+		for (unsigned i = 0; i < size && i < 4; i++)
+			midiMsg |= data[i] << (8 * i);
+		midiOutShortMsg(hMidiOut, midiMsg);
 	}
 	return 0;
 }

--- a/src/serial/Midi_w32.hh
+++ b/src/serial/Midi_w32.hh
@@ -43,7 +43,7 @@ std::string w32_midiOutGetVFN(unsigned nmb);
 std::string w32_midiOutGetRDN(unsigned nmb);
 unsigned w32_midiOutOpen(const char* vfn);
 int w32_midiOutClose(unsigned idx);
-int w32_midiOutPut(unsigned char value, unsigned idx);
+int w32_midiOutMsg(unsigned size, const uint8_t* data, unsigned idx);
 
 int w32_midiInInit();
 void w32_midiInClean();


### PR DESCRIPTION
Windows MIDI used a custom MIDI byte stream parser, which failed to
handle the "running status" correctly.
This bug is fixed by using the parser from MidiOutDevice. It also
greatly simplifies the Windows MIDI logic.