### PR TITLE
Fix asserts on string_view() on MSVC 2019

### DIFF
--- a/src/input/UnicodeKeymap.cc
+++ b/src/input/UnicodeKeymap.cc
@@ -76,11 +76,13 @@ static string_view nextToken(string_view& str)
 {
 	skipSep(str);
 	auto tokenBegin = str.begin();
+	size_t tokenLength = 0;
 	while (!str.empty() && str.front() != '\n' && !isSep(str.front())) {
 		// Pop non-separator character.
 		str.remove_prefix(1);
+		tokenLength++;
 	}
-	return string_view(&*tokenBegin, str.begin() - tokenBegin);
+	return tokenLength ? string_view(&*tokenBegin, tokenLength) : string_view();
 }
 
 


### PR DESCRIPTION
Currently string_view operations (like remove_prefix) manipulate string_view::_Mydata and _Mysize, yet the subtract operator (-) asserts that both operands share the same _Mydata and _Mysize, and it only subtracts on _Myoff, which is never manipulated actually. If we just ignore the assert we're sure to get no tokens. This fix avoids using the string_view subtract operator altogether and counts the tokenLength manually instead.