### PR TITLE
build: Fix unmountable DMG images on macOS < 10.13

### DIFF
--- a/build/package-darwin/app.mk
+++ b/build/package-darwin/app.mk
@@ -26,6 +26,7 @@ app: install $(DESTDIR)/$(APP_PLIST) $(DESTDIR)/$(APP_ICON)
 bindist: app $(DESTDIR)/$(BINDIST_README) $(DESTDIR)/$(BINDIST_LICENSE)
 	@echo "Creating disk image:"
 	@hdiutil create -srcfolder $(BINDIST_DIR) \
+		-fs HFS+J \
 		-volname openMSX \
 		-imagekey zlib-level=9 \
 		-ov $(BINDIST_PACKAGE)


### PR DESCRIPTION
The default either changed to APFS or depends on the local file system.
Since APFS is not supported on macOS versions before 10.13, we tell
hdiutil explicitly to use the HFS+J file system.

Pending confirmation by one of the affected users here:
https://www.msx.org/news/en/openmsx-160-released#comment-387833

You can use the freshly built DMG here for distribution on the openmsx.org:
http://www.grauw.nl/etc/msx/openmsx-16.0-mac-x86_64-bin.dmg