### PR TITLE
Automatically msx_update widgets msx_init created

### DIFF
--- a/share/scripts/_osd_widgets.tcl
+++ b/share/scripts/_osd_widgets.tcl
@@ -18,9 +18,42 @@ This will display a white 16x16 box at MSX location x,y == 10,10.}
 set_help_text osd_widgets::msx_init   $help_text
 set_help_text osd_widgets::msx_update $help_text
 
+variable registered_msx_widgets []
+variable msx_widgets_adjust_watchpoint ""
+
 proc msx_init {name} {
+	variable registered_msx_widgets
+	variable msx_widgets_adjust_watchpoint
+
 	osd create rectangle $name -scaled true -alpha 0
 	msx_update $name
+
+	if {[lsearch -exact $registered_msx_widgets $name] == -1} {
+		lappend registered_msx_widgets $name
+	}
+	if {[lindex [lindex [trace info variable ::horizontal_stretch] 0] 1] == ""} {
+		trace add variable ::horizontal_stretch {write unset array} ::osd_widgets::update_registered_msx_widgets
+	}
+	if {$msx_widgets_adjust_watchpoint == ""} {
+		# Triggers when REG18SAV is written to. Frame delay is necessary for msx_update to get the updated data.
+		# Though it is perhaps not enough to just watch the memory address rather than the actual register?
+		set msx_widgets_adjust_watchpoint [debug set_watchpoint write_mem 0xFFF1 {} {
+			after frame ::osd_widgets::update_registered_msx_widgets
+		}]
+	}
+}
+
+# Update all known MSX widgets to adjust to new compensation factors. This is currently only used when the horizontal stretch is changed.
+proc update_registered_msx_widgets { args } {
+	variable registered_msx_widgets
+ 	foreach name $registered_msx_widgets {
+		if {[osd exists $name]} {
+			msx_update $name
+		} else {
+			set idx [lsearch $registered_msx_widgets $name]
+			set registered_msx_widgets [lreplace $registered_msx_widgets $idx $idx]
+		}
+	}
 }
 
 proc msx_update {name} {


### PR DESCRIPTION
Trace changes to ::horizontal_update, as well as watch writes to REG18SAV memory address 0xFFF1.
Once detected, call ::osd_widgets::msx_update on each OSD widget MSX layer initialised by ::osd_widget::msx_init.

This should make sure that OSD widgets that should be relative to the MSX screen, stay properly positioned even when `set horizontal_stretch` is called from openMSX, or `set adjust(x,y)` is called from the MSX.

Theoretically changes to the amount of MSX lines (vdpreg 9) could also be traced I guess, but I couldn't think of a good way to test this, or implement. It's probably also best to be left to future script writers who actually run into the issue.