### PR TITLE
Make nr of columns for showdebuggable configurable

### DIFF
--- a/share/scripts/_showdebuggable.tcl
+++ b/share/scripts/_showdebuggable.tcl
@@ -7,7 +7,7 @@ set_help_text showdebuggable \
 {Print content of debuggable nicely formatted
 
 Usage:
-   showdebuggable <debuggable> <address> [<linecount>]
+   showdebuggable <debuggable> <address> [<linecount>] [<columns>]
 }
 
 set_tabcompletion_proc showdebuggable [namespace code tab_showdebuggable]
@@ -17,26 +17,26 @@ proc tab_showdebuggable {args} {
 	}
 }
 
-proc showdebuggable_line {debuggable address} {
+proc showdebuggable_line {debuggable address {columns 16}} {
 	set size [debug size $debuggable]
-	set num [expr {(($address + 16) <= $size) ? 16 : ($size - $address)}]
+	set num [expr {(($address + $columns) <= $size) ? $columns : ($size - $address)}]
 	set mem "[debug read_block $debuggable $address $num]"
 	binary scan $mem c* values
 	set hex ""
 	foreach val $values {
 		append hex [format "%02x " [expr {$val & 0xff}]]
 	}
-	set pad [string repeat "   " [expr {16 - $num}]]
+	set pad [string repeat "   " [expr {$columns - $num}]]
 	set asc [regsub -all {[^ !-~]} $mem {.}]
 	return [format "%04x: %s%s %s\n" $address $hex $pad $asc]
 }
 
-proc showdebuggable {debuggable {address 0} {lines 8}} {
+proc showdebuggable {debuggable {address 0} {lines 8} {columns 16}} {
 	set result ""
 	for {set i 0} {$i < $lines} {incr i} {
 		if {$address >= [debug size $debuggable]} break
-		append result [showdebuggable_line $debuggable $address]
-		incr address 16
+		append result [showdebuggable_line $debuggable $address $columns]
+		incr address $columns
 	}
 	return $result
 }
@@ -45,14 +45,14 @@ proc showdebuggable {debuggable {address 0} {lines 8}} {
 # I prefer to keep this as a convenience function.
 set_help_text showmem \
 {Print the content of the CPU visible memory nicely formatted
-This is a shortcut for 'showdebuggable memory <address>'.
+This is a shortcut for 'showdebuggable memory <address> <linecount> <columns>'.
 
 Usage:
-   showmem <address> [<linecount>]
+   showmem <address> [<linecount>] [<columns>]
 }
 
-proc showmem {{address 0} {lines 8}} {
-	showdebuggable memory $address $lines
+proc showmem {{address 0} {lines 8} {columns 16}} {
+	showdebuggable memory $address $lines $columns
 }
 
 namespace export showdebuggable


### PR DESCRIPTION
@bitsofbas recently was looking for a way to get more than 16 columns out of `showmem`, so I made the amount of columns configurable in `showdebuggable`, `showdebuggable_line` and `showmem`, and had it default to 16 so existing scripts should not be affected.