### PR TITLE
Set macOS target to 10.13, and reimplement FileOperations in Objective-C without deprecated APIs

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -256,6 +256,9 @@ endif # goal requires dependencies
 SOURCE_DIRS:=$(sort $(shell find src -type d))
 
 SOURCES_FULL:=$(foreach dir,$(SOURCE_DIRS),$(sort $(wildcard $(dir)/*.cc)))
+ifeq ($(OPENMSX_TARGET_OS),darwin)
+SOURCES_FULL+=$(foreach dir,$(SOURCE_DIRS),$(sort $(wildcard $(dir)/*.mm)))
+endif
 SOURCES_FULL:=$(filter-out %Test.cc,$(SOURCES_FULL))
 
 # TODO: This doesn't work since MAX_SCALE_FACTOR is not a Make variable,
@@ -303,7 +306,7 @@ $(error Sources list empty $(if \
    $(OPENMSX_SUBSET),after applying subset "$(OPENMSX_SUBSET)*"))
 endif
 
-SOURCES:=$(SOURCES_FULL:$(SOURCES_PATH)/%.cc=%)
+SOURCES:=$(SOURCES_FULL:$(SOURCES_PATH)/%=%)
 
 DEPEND_PATH:=$(BUILD_PATH)/dep
 DEPEND_FULL:=$(addsuffix .d,$(addprefix $(DEPEND_PATH)/,$(SOURCES)))
@@ -486,8 +489,8 @@ $(SUB_MAKEFILES):
 endif
 
 # Compile and generate dependency files in one go.
-DEPEND_SUBST=$(patsubst $(SOURCES_PATH)/%.cc,$(DEPEND_PATH)/%.d,$<)
-$(OBJECTS_FULL): $(OBJECTS_PATH)/%.o: $(SOURCES_PATH)/%.cc $(DEPEND_PATH)/%.d \
+DEPEND_SUBST=$(patsubst $(SOURCES_PATH)/%,$(DEPEND_PATH)/%.d,$<)
+$(OBJECTS_FULL): $(OBJECTS_PATH)/%.o: $(SOURCES_PATH)/% $(DEPEND_PATH)/%.d \
 		| config $(GENERATED_HEADERS)
 	$(SUM) "Compiling $(patsubst $(SOURCES_PATH)/%,%,$<)..."
 	$(CMD)mkdir -p $(@D)

--- a/build/package-darwin/Info.plist
+++ b/build/package-darwin/Info.plist
@@ -66,7 +66,7 @@
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
 		<key>x86_64</key>
-		<string>10.7.0</string>
+		<string>10.13.0</string>
 	</dict>
 	<key>LSRequiresCarbon</key>
 	<true/>

--- a/build/platform-darwin.mk
+++ b/build/platform-darwin.mk
@@ -26,7 +26,7 @@ LIBRARYEXT:=.so
 # since libraries such as libxml2 can change soname between OS X versions.
 # Clang as shipped with Xcode requires OS X 10.7 or higher for compiling with
 # libc++, when compiling Clang and libc++ from source 10.6 works as well.
-OSX_VER:=10.7
+OSX_VER:=10.13
 TARGET_FLAGS+=-mmacosx-version-min=$(OSX_VER)
 
 # Select Clang as the compiler and libc++ as the standard library.

--- a/build/platform-darwin.mk
+++ b/build/platform-darwin.mk
@@ -33,7 +33,13 @@ TARGET_FLAGS+=-mmacosx-version-min=$(OSX_VER)
 CXX:=clang++
 TARGET_FLAGS+=-stdlib=libc++
 
+# Enable automatic reference counting in Objective-C
+ifneq ($(3RDPARTY_FLAG),true)
+TARGET_FLAGS+=-fobjc-arc
+endif
+
 # Link against system frameworks.
 LINK_FLAGS+= \
 	-framework CoreFoundation -framework CoreServices \
-	-framework ApplicationServices -framework CoreMIDI
+	-framework ApplicationServices -framework CoreMIDI \
+	-framework Foundation

--- a/src/file/FileOperationsMac.hh
+++ b/src/file/FileOperationsMac.hh
@@ -1,0 +1,12 @@
+#ifndef FILEOPERATIONSMAC_HH
+#define FILEOPERATIONSMAC_HH
+
+#include <string>
+
+namespace openmsx::FileOperations {
+
+std::string findShareDir();
+
+}
+
+#endif

--- a/src/file/FileOperationsMac.mm
+++ b/src/file/FileOperationsMac.mm
@@ -1,0 +1,34 @@
+#include "FileOperationsMac.hh"
+
+#include <Foundation/Foundation.h>
+#include "FileException.hh"
+
+namespace openmsx::FileOperations {
+
+std::string findShareDir()
+{
+	@autoreleasepool
+	{
+		NSBundle* mainBundle = [NSBundle mainBundle];
+		if (mainBundle == nil) {
+			throw FatalError("Failed to get main bundle");
+		}
+
+		NSURL* url = [mainBundle executableURL].URLByResolvingSymlinksInPath.URLByDeletingLastPathComponent;
+		while (url != nil) {
+			NSURL* shareURL = [url URLByAppendingPathComponent:@"share" isDirectory:YES];
+			NSNumber* isDirectory;
+			BOOL success = [shareURL getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:nil];
+			if (success && [isDirectory boolValue]) {
+				return std::string(shareURL.fileSystemRepresentation);
+			}
+			if (![url getResourceValue:&url forKey:NSURLParentDirectoryURLKey error:nil]) {
+				url = nil;
+			}
+		}
+	}
+
+	throw FatalError("Could not find \"share\" directory anywhere");
+}
+
+}


### PR DESCRIPTION
Upgrade macOS target version to 10.13 High Sierra. This version supports macs from 2009/2010.

Add Objective-C compilation support. I’m not sure the makefile rules in main.mk work cross-platform; the .mm files should only be compiled on macOS. Maybe someone with stronger mk-fu can take a look at this.

Lastly, reimplement FileOperations::findShareDir() in Objective-C. The old implementation uses functions which were deprecated in macOS 10.8 and 10.9. This serves both to eliminate those deprecation warnings, as well as be a first user for the Objective-C support. It’s also significantly more compact.

In the future the Objective-C support is useful to add e.g. Metal and touch bar support.