### PR TITLE
Removed 32-bit check in platform-darwin.mk and updated Linux and Windows workflows

### DIFF
--- a/.github/workflows/linuxbuild.yml
+++ b/.github/workflows/linuxbuild.yml
@@ -24,12 +24,12 @@ jobs:
       run: |
         OPENMSX_VERSION=`python3 build/version.py`
         echo ::set-output name=OPENMSX_VERSION::$OPENMSX_VERSION
-    - name: Create redistributable zip
+    - name: Prepare redistributable directory
       run: |
-        cd derived/x86_64-linux-opt-3rd/bindist/install
-        zip -r ../openmsx-${{ steps.get_version.outputs.OPENMSX_VERSION }}-x86_64-linux-opt-3rd.zip *
+        cd derived/x86_64-linux-opt-3rd/bindist
+        mv install openmsx-${{ steps.get_version.outputs.OPENMSX_VERSION }}-x86_64-linux-opt-3rd
     - name: Upload redistributable zip
       uses: actions/upload-artifact@v1
       with:
         name: openmsx-${{ steps.get_version.outputs.OPENMSX_VERSION }}-x86_64-linux-opt-3rd.zip
-        path: derived/x86_64-linux-opt-3rd/bindist/openmsx-${{ steps.get_version.outputs.OPENMSX_VERSION }}-x86_64-linux-opt-3rd.zip
+        path: derived/x86_64-linux-opt-3rd/bindist/openmsx-${{ steps.get_version.outputs.OPENMSX_VERSION }}-x86_64-linux-opt-3rd

--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -30,10 +30,12 @@ jobs:
       run: |
         OPENMSX_VERSION=`python3 build/version.py`
         echo ::set-output name=OPENMSX_VERSION::$OPENMSX_VERSION
-    - name: Create redistributable zip
-      run: cd derived/x86_64-mingw-w64-opt-3rd/bindist/install && zip -r ../openmsx-${{ steps.get_version.outputs.OPENMSX_VERSION }}-x86_64-mingw-w64-opt.zip *
+    - name: Prepare redistributable directory
+      run: |
+        cd derived/x86_64-linux-opt-3rd/bindist
+        mv install openmsx-${{ steps.get_version.outputs.OPENMSX_VERSION }}-x86_64-mingw-w64-opt
     - name: Upload redistributable zip
       uses: actions/upload-artifact@v1
       with:
         name: openmsx-${{ steps.get_version.outputs.OPENMSX_VERSION }}-x86_64-mingw-w64-opt.zip
-        path: derived/x86_64-mingw-w64-opt-3rd/bindist/openmsx-${{ steps.get_version.outputs.OPENMSX_VERSION }}-x86_64-mingw-w64-opt.zip
+        path: derived/x86_64-mingw-w64-opt-3rd/bindist/openmsx-${{ steps.get_version.outputs.OPENMSX_VERSION }}-x86_64-mingw-w64-opt

--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -32,7 +32,7 @@ jobs:
         echo ::set-output name=OPENMSX_VERSION::$OPENMSX_VERSION
     - name: Prepare redistributable directory
       run: |
-        cd derived/x86_64-linux-opt-3rd/bindist
+        cd derived/x86_64-mingw-w64-opt-3rd/bindist
         mv install openmsx-${{ steps.get_version.outputs.OPENMSX_VERSION }}-x86_64-mingw-w64-opt
     - name: Upload redistributable zip
       uses: actions/upload-artifact@v1

--- a/build/platform-darwin.mk
+++ b/build/platform-darwin.mk
@@ -9,12 +9,7 @@ USE_SYMLINK:=true
 # replace this with its own low-res icon.
 SET_WINDOW_ICON:=false
 
-# Compile for the selected CPU.
-ifeq ($(OPENMSX_TARGET_CPU),x86)
-TARGET_FLAGS+=-arch i386
-else
 TARGET_FLAGS+=-arch $(OPENMSX_TARGET_CPU)
-endif
 
 # File name extension of executables.
 EXEEXT:=
@@ -26,7 +21,7 @@ LIBRARYEXT:=.so
 # since libraries such as libxml2 can change soname between OS X versions.
 # Clang as shipped with Xcode requires OS X 10.7 or higher for compiling with
 # libc++, when compiling Clang and libc++ from source 10.6 works as well.
-OSX_VER:=10.7
+OSX_VER:=10.13
 TARGET_FLAGS+=-mmacosx-version-min=$(OSX_VER)
 
 # Select Clang as the compiler and libc++ as the standard library.


### PR DESCRIPTION
Since 10.13 and up all support 64-bit apps there is no more need to build 32-bit.

The linux and windows workflows would zip the install dir, then the upload action would zip again (so we ended up with a zip in a zip). I removed the manual zip action and just renamed the install dir to the right name and have GitHub upload take care of zipping.