### PR TITLE
Changed a leftover 'const std::string&' to fix macOS build

### DIFF
--- a/src/serial/MidiOutCoreMIDI.hh
+++ b/src/serial/MidiOutCoreMIDI.hh
@@ -69,7 +69,7 @@ public:
 	// Pluggable
 	void plugHelper(Connector& connector, EmuTime::param time) override;
 	void unplugHelper(EmuTime::param time) override;
-	[[nodiscard]] const std::string& getName() const override;
+	[[nodiscard]] std::string_view getName() const override;
 	[[nodiscard]] std::string_view getDescription() const override;
 
 	// MidiOutMessageBuffer


### PR DESCRIPTION
Fixes #1322 