### PR TITLE
Properly fix drawing of OSD progress info

### DIFF
--- a/src/video/Display.hh
+++ b/src/video/Display.hh
@@ -46,11 +46,12 @@ public:
 	[[nodiscard]] CommandConsole& getCommandConsole() { return commandConsole; }
 
 	/** Redraw the display.
-	  * repaint() should only be called from the VideoSystem.
+	  * The repaintImpl() methods are for internal and VideoSystem/VisibleSurface use only.
 	  */
 	void repaint();
-	void repaint(OutputSurface& surface);
 	void repaintDelayed(uint64_t delta);
+	void repaintImpl();
+	void repaintImpl(OutputSurface& surface);
 
 	void addLayer(Layer& layer);
 	void removeLayer(Layer& layer);

--- a/src/video/SDLVideoSystem.cc
+++ b/src/video/SDLVideoSystem.cc
@@ -229,7 +229,7 @@ void SDLVideoSystem::takeScreenShot(const std::string& filename, bool withOsd)
 		ScopedLayerHider hideConsole(*consoleLayer);
 		ScopedLayerHider hideOsd(*osdGuiLayer);
 		std::unique_ptr<OutputSurface> surf = screen->createOffScreenSurface();
-		display.repaint(*surf);
+		display.repaintImpl(*surf);
 		surf->saveScreenshot(filename);
 	}
 }
@@ -251,7 +251,8 @@ void SDLVideoSystem::showCursor(bool show)
 
 void SDLVideoSystem::repaint()
 {
-	display.repaint();
+	// With SDL we can simply repaint the display directly.
+	display.repaintImpl();
 }
 
 void SDLVideoSystem::resize()

--- a/src/video/VideoSystem.hh
+++ b/src/video/VideoSystem.hh
@@ -75,6 +75,9 @@ public:
 	/** TODO */
 	[[nodiscard]] virtual OutputSurface* getOutputSurface() = 0;
 	virtual void showCursor(bool show) = 0;
+	
+	/** Requests a repaint of the output surface. An implementation might
+	 *  start a repaint directly, or trigger a queued rendering. */
 	virtual void repaint() = 0;
 
 protected:


### PR DESCRIPTION
The original solution in b6fd832980 was to call repaintDelayed with time zero, but that had unintended side-effects. The partial 'fix' of ca95ac84 broke the actual intention of b6fd832980. This patch properly fixes both commits.