### PR TITLE
Really enable build on riscv64

### DIFF
--- a/build/detectsys.py
+++ b/build/detectsys.py
@@ -53,6 +53,8 @@ def detectCPU():
 		return 'sheb' if cpu.endswith('eb') else 'sh'
 	elif cpu == 'avr32':
 		return 'avr32'
+	elif cpu == 'riscv64':
+		return 'riscv64'
 	elif cpu == '':
 		# Python couldn't figure it out.
 		os = system().lower()


### PR DESCRIPTION
https://github.com/openMSX/openMSX/commit/b06f755fa5654b3b17643feeaf74497a64755cf0 adds support for riscv64 in build/cpu.py, but misses a change needed in build/detectsys.py.