### PR TITLE
Fixes 'Initializer not allowed' error in shader.

### DIFF
--- a/share/shaders/scale2x.vert
+++ b/share/shaders/scale2x.vert
@@ -9,8 +9,8 @@ varying vec2 coord2pi;
 varying vec2 texCoord;
 varying vec2 videoCoord;
 
-const float pi = 4.0 * atan(1.0);
-const float pi2 = 2.0 * pi;
+float pi = 4.0 * atan(1.0);
+float pi2 = 2.0 * pi;
 
 void main()
 {


### PR DESCRIPTION
The video setting scaler: ScaleNx gives a shader error on macOS:

```
Error(s) compiling shader "scale2x.vert":
ERROR: 0:14: Initializer not allowed
ERROR: 0:15: Use of undeclared identifier 'pi'
ERROR: 0:21: Use of undeclared identifier 'pi2'
```

Most likely reason for the error is that the compiler cannot evaluate the (constant) value at compile time. Removing the `const` type qualifier fixes the problem and the shader works as intended. 

Before the fix, **scale2x** shader is ignored:
<img width="1072" alt="before fix" src="https://user-images.githubusercontent.com/15607023/137997370-7778093e-bfaf-453a-911e-736f62f50b34.png">

After the fix, **scale2x** shader works as intended:
<img width="1072" alt="after fix" src="https://user-images.githubusercontent.com/15607023/137997451-acceb5be-e381-4b9e-91a8-1c3deb2b5711.png">

