### PR TITLE
Don’t remove once-breakpoints if condition fails.

### DIFF
--- a/src/cpu/BreakPointBase.cc
+++ b/src/cpu/BreakPointBase.cc
@@ -19,11 +19,11 @@ bool BreakPointBase::isTrue(GlobalCliComm& cliComm, Interpreter& interp) const
 	}
 }
 
-void BreakPointBase::checkAndExecute(GlobalCliComm& cliComm, Interpreter& interp)
+bool BreakPointBase::checkAndExecute(GlobalCliComm& cliComm, Interpreter& interp)
 {
 	if (executing) {
 		// no recursive execution
-		return;
+		return false;
 	}
 	ScopedAssign sa(executing, true);
 	if (isTrue(cliComm, interp)) {
@@ -32,7 +32,9 @@ void BreakPointBase::checkAndExecute(GlobalCliComm& cliComm, Interpreter& interp
 		} catch (CommandException& e) {
 			cliComm.printWarning(e.getMessage());
 		}
+		return onlyOnce();
 	}
+	return false;
 }
 
 } // namespace openmsx

--- a/src/cpu/BreakPointBase.hh
+++ b/src/cpu/BreakPointBase.hh
@@ -20,7 +20,7 @@ public:
 	[[nodiscard]] TclObject getCommandObj()   const { return command; }
 	[[nodiscard]] bool onlyOnce() const { return once; }
 
-	void checkAndExecute(GlobalCliComm& cliComm, Interpreter& interp);
+	bool checkAndExecute(GlobalCliComm& cliComm, Interpreter& interp);
 
 protected:
 	// Note: we require GlobalCliComm here because breakpoint objects can

--- a/src/cpu/MSXCPUInterface.cc
+++ b/src/cpu/MSXCPUInterface.cc
@@ -816,15 +816,15 @@ void MSXCPUInterface::checkBreakPoints(
 	auto& globalCliComm = motherBoard.getReactor().getGlobalCliComm();
 	auto& interp        = motherBoard.getReactor().getInterpreter();
 	for (auto& p : bpCopy) {
-		p.checkAndExecute(globalCliComm, interp);
-		if (p.onlyOnce()) {
+		bool remove = p.checkAndExecute(globalCliComm, interp);
+		if (remove) {
 			removeBreakPoint(p.getId());
 		}
 	}
 	auto condCopy = conditions;
 	for (auto& c : condCopy) {
-		c.checkAndExecute(globalCliComm, interp);
-		if (c.onlyOnce()) {
+		bool remove = c.checkAndExecute(globalCliComm, interp);
+		if (remove) {
 			removeCondition(c.getId());
 		}
 	}
@@ -985,8 +985,8 @@ void MSXCPUInterface::executeMemWatch(WatchPoint::Type type,
 		if ((w->getBeginAddress() <= address) &&
 		    (w->getEndAddress()   >= address) &&
 		    (w->getType()         == type)) {
-			w->checkAndExecute(globalCliComm, interp);
-			if (w->onlyOnce()) {
+			bool remove = w->checkAndExecute(globalCliComm, interp);
+			if (remove) {
 				removeWatchPoint(w);
 			}
 		}

--- a/src/cpu/MSXWatchIODevice.cc
+++ b/src/cpu/MSXWatchIODevice.cc
@@ -43,8 +43,8 @@ void WatchIO::doReadCallback(unsigned port)
 	// keep this object alive by holding a shared_ptr to it, for the case
 	// this watchpoint deletes itself in checkAndExecute()
 	auto keepAlive = shared_from_this();
-	checkAndExecute(cliComm, interp);
-	if (onlyOnce()) {
+	bool remove = checkAndExecute(cliComm, interp);
+	if (remove) {
 		cpuInterface.removeWatchPoint(keepAlive);
 	}
 
@@ -63,8 +63,8 @@ void WatchIO::doWriteCallback(unsigned port, unsigned value)
 
 	// see comment in doReadCallback() above
 	auto keepAlive = shared_from_this();
-	checkAndExecute(cliComm, interp);
-	if (onlyOnce()) {
+	bool remove = checkAndExecute(cliComm, interp);
+	if (remove) {
 		cpuInterface.removeWatchPoint(keepAlive);
 	}
 

--- a/src/debugger/ProbeBreakPoint.cc
+++ b/src/debugger/ProbeBreakPoint.cc
@@ -32,8 +32,8 @@ void ProbeBreakPoint::update(const ProbeBase& /*subject*/) noexcept
 	auto& reactor = debugger.getMotherBoard().getReactor();
 	auto& cliComm = reactor.getGlobalCliComm();
 	auto& interp  = reactor.getInterpreter();
-	checkAndExecute(cliComm, interp);
-	if (onlyOnce()) {
+	bool remove = checkAndExecute(cliComm, interp);
+	if (remove) {
 		debugger.removeProbeBreakPoint(*this);
 	}
 }


### PR DESCRIPTION
Previously, a once-breakpoint would be removed even if its condition failed and
the breakpoint never actually executes.