### PR TITLE
YMF278: Restart sample position when wave changes during release.

### DIFF
--- a/src/sound/YMF278.cc
+++ b/src/sound/YMF278.cc
@@ -604,6 +604,9 @@ void YMF278::writeRegDirect(byte reg, byte data, EmuTime::param time)
 			}
 			if (slot.keyon) {
 				keyOnHelper(slot);
+			} else {
+				slot.stepptr = 0;
+				slot.pos = 0;
 			}
 			break;
 		}


### PR DESCRIPTION
I verified on real OPL4 that changing wave during key on indeed retriggers the EG, however doing so during key off does not. The EG state is unaffected other than the new wave table parameters being applied to it. The sample position does get reset though, so it plays from the beginning.

Test VGM and recording: [opl4test.zip](https://github.com/openMSX/openMSX/files/8780808/opl4test.zip)
 