### PR TITLE
add explicit ctime include

### DIFF
--- a/src/file/FileBase.hh
+++ b/src/file/FileBase.hh
@@ -3,6 +3,7 @@
 
 #include "MemBuffer.hh"
 #include <cstdint>
+#include <ctime>
 #include <span>
 #include <string>
 


### PR DESCRIPTION
Without it, we hit build failures related to missing time_t in some cases:

https://bugs.gentoo.org/868726

Signed-off-by: John Helmert III <ajak@gentoo.org>