### PR TITLE
Updates build process for macOS

### DIFF
--- a/build/package-darwin/app.mk
+++ b/build/package-darwin/app.mk
@@ -10,7 +10,7 @@ APP_ICON:=$(APP_RES)/openmsx-logo.icns
 # Override install locations.
 DESTDIR:=$(BINDIST_DIR)
 INSTALL_BINARY_DIR:=$(APP_EXE_DIR)
-INSTALL_SHARE_DIR:=$(APP_DIR)/share
+INSTALL_SHARE_DIR:=$(APP_RES)/share
 INSTALL_DOC_DIR:=Documentation
 
 PACKAGE_FULL:=$(shell PYTHONPATH=build $(PYTHON) -c \
@@ -23,7 +23,7 @@ BINDIST_LICENSE:=$(INSTALL_DOC_DIR)/GPL.txt
 # TODO: What is needed for an app folder?
 app: install $(DESTDIR)/$(APP_PLIST) $(DESTDIR)/$(APP_ICON)
 
-bindist: app $(DESTDIR)/$(BINDIST_README) $(DESTDIR)/$(BINDIST_LICENSE)
+bindist: app codesign $(DESTDIR)/$(BINDIST_README) $(DESTDIR)/$(BINDIST_LICENSE)
 	@echo "Creating disk image:"
 	@hdiutil create -srcfolder $(BINDIST_DIR) \
 		-fs HFS+J \
@@ -42,6 +42,14 @@ $(DESTDIR)/$(APP_ICON): $(DESTDIR)/$(APP_RES)/%: $(APP_SUPPORT_DIR)/% bindistcle
 	@echo "  Copying resources..."
 	@mkdir -p $(@D)
 	@cp $< $@
+
+codesign:
+	@if [ -z "$(CODE_SIGN_IDENTITY)" ]; then \
+		echo "  Skipping code sign, CODE_SIGN_IDENTITY not set."; \
+	else \
+		echo "  Signing the application bundle..."; \
+		codesign --deep --force --verify --verbose --options runtime --sign "$(CODE_SIGN_IDENTITY)" $(DESTDIR)/$(APP_DIR); \
+	fi
 
 $(DESTDIR)/$(BINDIST_README): $(APP_SUPPORT_DIR)/README.html
 	@echo "  Copying README..."

--- a/doc/manual/compile.html
+++ b/doc/manual/compile.html
@@ -730,6 +730,27 @@ The final output files will be produced in <code>derived/&lt;cpu&gt;-&lt;os&gt;-
 <p>
 The final output is a DMG file (Mac disk image) containing the openMSX application folder and documentation. This file is internet-enabled, which means it will be automatically mounted after it is downloaded.
 </p>
+<p>
+If you have a Apple Developers ID, you can automatically sign the app bundle by providing the following environment variable in your shell, before building the app bundle:
+</p>
+<div class="commandline">
+    <pre>
+export CODE_SIGN_IDENTITY=&lt;your Apple Application Developer ID here&gt;
+make staticbindist
+    </pre>
+</div>
+<p>
+To find the exact string, needed for the CODE_SIGN_IDENTITY, you can use the command:
+</p>
+<div class="commandline">
+security find-identity
+</div>
+<p>
+Check if the code signing was successful with:
+</p>
+<div class="commandline">
+codesign -dv --verbose=4 derived/&lt;cpu&gt;-&lt;os&gt;-&lt;flavour&gt;-3rd/bindist/openMSX.app
+</div>
 
 <h5>Microsoft Windows (MinGW)</h5>
 

--- a/src/file/FileOperationsMac.mm
+++ b/src/file/FileOperationsMac.mm
@@ -14,9 +14,9 @@ std::string findShareDir()
 			throw FatalError("Failed to get main bundle");
 		}
 
-		NSURL* url = [mainBundle executableURL].URLByResolvingSymlinksInPath.URLByDeletingLastPathComponent;
+		NSURL* url = [mainBundle bundleURL].URLByResolvingSymlinksInPath;
 		while (url != nil) {
-			NSURL* shareURL = [url URLByAppendingPathComponent:@"share" isDirectory:YES];
+			NSURL* shareURL = [url URLByAppendingPathComponent:@"Contents/Resources/share" isDirectory:YES];
 			NSNumber* isDirectory;
 			BOOL success = [shareURL getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:nil];
 			if (success && [isDirectory boolValue]) {


### PR DESCRIPTION
Updates the build process for macOS.

- The folder `share` in the app bundle has been relocated to `Content/Resources` inside the app bundle. This allows codesign to work without errors and enhances compatibility for Macs with Apple Silicon.
- The `build/package-darwin/app.mk` has been adapted to automatically sign the app bundle in case the user has an Apple Developers ID. 
- Small addition to the documentation, on code signing for macOS.