### PR TITLE
Add MIDI input support to ALSA

### DIFF
--- a/src/PluggableFactory.cc
+++ b/src/PluggableFactory.cc
@@ -118,7 +118,7 @@ void PluggableFactory::createAll(PluggingController& controller,
 	MidiOutCoreMIDI::registerAll(controller);
 #endif
 #if COMPONENT_ALSAMIDI
-	MidiSessionALSA::registerAll(controller, reactor.getCliComm());
+	MidiSessionALSA::registerAll(controller, reactor.getCliComm(), eventDistributor, scheduler);
 #endif
 
 	// Printers

--- a/src/events/Event.hh
+++ b/src/events/Event.hh
@@ -454,6 +454,7 @@ class MidiInReaderEvent          final : public SimpleEvent {};
 class MidiInWindowsEvent         final : public SimpleEvent {};
 class MidiInCoreMidiEvent        final : public SimpleEvent {};
 class MidiInCoreMidiVirtualEvent final : public SimpleEvent {};
+class MidiInALSAEvent            final : public SimpleEvent {};
 class Rs232TesterEvent           final : public SimpleEvent {};
 
 
@@ -493,6 +494,7 @@ using EventVariant = std::variant<
 	MidiInWindowsEvent,
 	MidiInCoreMidiEvent,
 	MidiInCoreMidiVirtualEvent,
+	MidiInALSAEvent,
 	Rs232TesterEvent
 >;
 
@@ -537,6 +539,7 @@ enum class EventType : uint8_t
 	MIDI_IN_WINDOWS          = event_index<MidiInWindowsEvent>,
 	MIDI_IN_COREMIDI         = event_index<MidiInCoreMidiEvent>,
 	MIDI_IN_COREMIDI_VIRTUAL = event_index<MidiInCoreMidiVirtualEvent>,
+	MIDI_IN_ALSA             = event_index<MidiInALSAEvent>,
 	RS232_TESTER             = event_index<Rs232TesterEvent>,
 
 	NUM_EVENT_TYPES // must be last

--- a/src/serial/MidiSessionALSA.cc
+++ b/src/serial/MidiSessionALSA.cc
@@ -315,9 +315,7 @@ void MidiInALSA::run()
 	std::vector<struct pollfd> pfd(npfd);
 	snd_seq_poll_descriptors(&seq, pfd.data(), npfd, POLLIN);
 
-	while (true) {
-		if (stop)
-			break;
+	while (!stop) {
 		if (poll(pfd.data(), npfd, 1000) > 0) {
 			snd_seq_event_t *ev = NULL;
 

--- a/src/serial/MidiSessionALSA.cc
+++ b/src/serial/MidiSessionALSA.cc
@@ -343,7 +343,7 @@ void MidiInALSA::run()
 					std::cerr << "Error decoding MIDI event: "
 						<< snd_strerror(size) << '\n';
 					snd_seq_free_event(ev);
-					break;
+					continue;
 				}
 
 				std::lock_guard<std::mutex> lock(mutex);

--- a/src/serial/MidiSessionALSA.hh
+++ b/src/serial/MidiSessionALSA.hh
@@ -18,7 +18,8 @@ class PluggingController;
 class MidiSessionALSA final
 {
 public:
-	static void registerAll(PluggingController& controller, CliComm& cliComm);
+	static void registerAll(PluggingController& controller, CliComm& cliComm,
+							EventDistributor& eventDistributor, Scheduler& scheduler);
 
 	~MidiSessionALSA();
 
@@ -26,7 +27,9 @@ private:
 	static std::unique_ptr<MidiSessionALSA> instance;
 
 	explicit MidiSessionALSA(snd_seq_t& seq);
-	void scanClients(PluggingController& controller);
+	void scanClients(PluggingController& controller,
+					 EventDistributor& eventDistributor,
+					 Scheduler& scheduler);
 
 	snd_seq_t& seq;
 };


### PR DESCRIPTION
This PR adds MIDI input support to ALSA.

I couldn't ever get MIDI In Reader to work properly with my Fedora installation since the OSS emulation layer of ALSA do not work well with applications expecting `/dev/midi*` to be there and readable. Therefore, this is meant largely as a replacement for it on Linux systems.