### PR TITLE
V9990: warns about writes (reads) to read-only (write-only) registers

### DIFF
--- a/share/scripts/callbackprocs.tcl
+++ b/share/scripts/callbackprocs.tcl
@@ -107,6 +107,14 @@ proc sensorkidacquirecallback {port} {
 set sensor_kid_port_status_callback sensorkidportstatuscallback
 set sensor_kid_acquire_callback     sensorkidacquirecallback
 
+proc default_V9990_invalid_register_read_callback {reg} {
+	message [format "Reading from V9990 write-only register 0x%x" $reg] warning
+}
+proc default_V9990_invalid_register_write_callback {reg value} {
+	message [format "Writing 0x%x to V9990 read-only register %i" $value $reg] warning
+}
+#set v9990_invalid_register_read_callback  default_V9990_invalid_register_read_callback
+#set v9990_invalid_register_write_callback default_V9990_invalid_register_write_callback
 
 # show message (also) as OSD message
 interp alias {} default_message_callback {} osd::display_message

--- a/src/commands/TclCallback.cc
+++ b/src/commands/TclCallback.cc
@@ -33,7 +33,7 @@ TclObject TclCallback::getValue() const
 	return getSetting().getValue();
 }
 
-TclObject TclCallback::execute()
+TclObject TclCallback::execute() const
 {
 	const auto& callback = getValue();
 	if (callback.empty()) return {};
@@ -42,7 +42,7 @@ TclObject TclCallback::execute()
 	return executeCommon(command);
 }
 
-TclObject TclCallback::execute(int arg1)
+TclObject TclCallback::execute(int arg1) const
 {
 	const auto& callback = getValue();
 	if (callback.empty()) return {};
@@ -51,7 +51,7 @@ TclObject TclCallback::execute(int arg1)
 	return executeCommon(command);
 }
 
-TclObject TclCallback::execute(int arg1, int arg2)
+TclObject TclCallback::execute(int arg1, int arg2) const
 {
 	const auto& callback = getValue();
 	if (callback.empty()) return {};
@@ -60,7 +60,7 @@ TclObject TclCallback::execute(int arg1, int arg2)
 	return executeCommon(command);
 }
 
-TclObject TclCallback::execute(int arg1, std::string_view arg2)
+TclObject TclCallback::execute(int arg1, std::string_view arg2) const
 {
 	const auto& callback = getValue();
 	if (callback.empty()) return {};
@@ -69,7 +69,7 @@ TclObject TclCallback::execute(int arg1, std::string_view arg2)
 	return executeCommon(command);
 }
 
-TclObject TclCallback::execute(std::string_view arg1, std::string_view arg2)
+TclObject TclCallback::execute(std::string_view arg1, std::string_view arg2) const
 {
 	const auto& callback = getValue();
 	if (callback.empty()) return {};
@@ -78,7 +78,7 @@ TclObject TclCallback::execute(std::string_view arg1, std::string_view arg2)
 	return executeCommon(command);
 }
 
-TclObject TclCallback::executeCommon(TclObject& command)
+TclObject TclCallback::executeCommon(TclObject& command) const
 {
 	try {
 		return command.executeCommand(callbackSetting.getInterpreter());

--- a/src/commands/TclCallback.hh
+++ b/src/commands/TclCallback.hh
@@ -22,17 +22,17 @@ public:
 	            bool useCliComm = true);
 	explicit TclCallback(StringSetting& setting);
 
-	TclObject execute();
-	TclObject execute(int arg1);
-	TclObject execute(int arg1, int arg2);
-	TclObject execute(int arg1, std::string_view arg2);
-	TclObject execute(std::string_view arg1, std::string_view arg2);
+	TclObject execute() const;
+	TclObject execute(int arg1) const;
+	TclObject execute(int arg1, int arg2) const;
+	TclObject execute(int arg1, std::string_view arg2) const;
+	TclObject execute(std::string_view arg1, std::string_view arg2) const;
 
 	[[nodiscard]] TclObject getValue() const;
 	[[nodiscard]] StringSetting& getSetting() const { return callbackSetting; }
 
 private:
-	TclObject executeCommon(TclObject& command);
+	TclObject executeCommon(TclObject& command) const;
 
 	std::optional<StringSetting> callbackSetting2;
 	StringSetting& callbackSetting;

--- a/src/video/v9990/V9990.hh
+++ b/src/video/v9990/V9990.hh
@@ -3,6 +3,7 @@
 
 #include "MSXDevice.hh"
 #include "Schedulable.hh"
+#include "TclCallback.hh"
 #include "VideoSystemChangeListener.hh"
 #include "IRQHelper.hh"
 #include "V9990CmdEngine.hh"
@@ -528,6 +529,9 @@ private:
 	IRQHelper irq;
 
 	Display& display;
+
+	TclCallback   invalidRegisterReadCallback;
+	TclCallback   invalidRegisterWriteCallback;
 
 	/** VRAM
 	  */


### PR DESCRIPTION
Useful for debugging new v9990 software.