### PR TITLE
DiskManipulator: Transcode file names to Unicode.

### DIFF
--- a/src/MSXPPI.cc
+++ b/src/MSXPPI.cc
@@ -33,6 +33,10 @@ MSXPPI::~MSXPPI()
 	powerDown(EmuTime::dummy());
 }
 
+const Keyboard& MSXPPI::getKeyboard() const {
+	return keyboard;
+}
+
 void MSXPPI::reset(EmuTime::param time)
 {
 	i8255.reset(time);

--- a/src/MSXPPI.hh
+++ b/src/MSXPPI.hh
@@ -42,6 +42,8 @@ public:
 	explicit MSXPPI(const DeviceConfig& config);
 	~MSXPPI() override;
 
+	[[nodiscard]] const Keyboard& getKeyboard() const;
+
 	void reset(EmuTime::param time) override;
 	void powerDown(EmuTime::param time) override;
 	[[nodiscard]] byte readIO(word port, EmuTime::param time) override;

--- a/src/fdc/DiskManipulator.hh
+++ b/src/fdc/DiskManipulator.hh
@@ -15,6 +15,7 @@ class SectorAccessibleDisk;
 class DiskPartition;
 class MSXtar;
 class Reactor;
+class MsxChar2Unicode;
 enum class MSXBootSectorType;
 
 class DiskManipulator final : public Command
@@ -46,12 +47,13 @@ private:
 	void tabCompletion(std::vector<std::string>& tokens) const override;
 
 	[[nodiscard]] std::string getMachinePrefix() const;
+	[[nodiscard]] const MsxChar2Unicode& getMsxChar2Unicode() const;
 	[[nodiscard]] Drives::iterator findDriveSettings(DiskContainer& drive);
 	[[nodiscard]] Drives::iterator findDriveSettings(std::string_view driveName);
 	[[nodiscard]] DriveSettings& getDriveSettings(std::string_view diskName);
 	[[nodiscard]] static DiskPartition getPartition(
 		const DriveSettings& driveData);
-	[[nodiscard]] static MSXtar getMSXtar(SectorAccessibleDisk& disk,
+	[[nodiscard]] MSXtar getMSXtar(SectorAccessibleDisk& disk,
 	                                      DriveSettings& driveData);
 
 	static void create(std::span<const TclObject> tokens);

--- a/src/fdc/MSXtar.cc
+++ b/src/fdc/MSXtar.cc
@@ -453,14 +453,14 @@ MSXtar::DirEntry MSXtar::addEntryToDir(unsigned sector)
 	}
 }
 
-// create an MSX filename 8.3 format, if needed in vfat like abbreviation
-static char toMSXChr(char a)
+// filters out unsupported characters and upper-cases
+static char toFileNameChar(char a)
 {
-	a = narrow<char>(toupper(a));
-	if (a == one_of(' ', '.')) {
+	if ((a >= 0x00 && a < 0x20) || a == one_of(
+		' ', '"', '*', '+', ',', '.', '/', ':', ';', '<', '=', '>', '?', '[', '\\', ']', '|', 0x7F, 0xFF)) {
 		a = '_';
 	}
-	return a;
+	return narrow<char>(toupper(a));
 }
 
 // Transform a long hostname in a 8.3 uppercase filename as used in the
@@ -486,8 +486,8 @@ static FileName hostToMSXFileName(string_view hostName)
 	// put in major case and create '_' if needed
 	string fileS(file.data(), std::min<size_t>(8, file.size()));
 	string extS (ext .data(), std::min<size_t>(3, ext .size()));
-	transform_in_place(fileS, toMSXChr);
-	transform_in_place(extS,  toMSXChr);
+	transform_in_place(fileS, toFileNameChar);
+	transform_in_place(extS,  toFileNameChar);
 
 	// add correct number of spaces
 	ranges::copy(fileS, subspan<8>(result, 0));

--- a/src/fdc/MSXtar.hh
+++ b/src/fdc/MSXtar.hh
@@ -16,6 +16,7 @@
 namespace openmsx {
 
 class SectorAccessibleDisk;
+class MsxChar2Unicode;
 
 namespace FAT {
 	struct Free {
@@ -40,7 +41,7 @@ namespace FAT {
 class MSXtar
 {
 public:
-	explicit MSXtar(SectorAccessibleDisk& disk);
+	explicit MSXtar(SectorAccessibleDisk& disk, const MsxChar2Unicode& msxChars_);
 	MSXtar(MSXtar&& other) noexcept;
 	~MSXtar();
 
@@ -90,8 +91,12 @@ private:
 	[[nodiscard]] FAT::DirCluster getStartCluster(const MSXDirEntry& entry) const;
 	void setStartCluster(MSXDirEntry& entry, FAT::DirCluster cluster) const;
 
+	[[nodiscard]] FAT::FileName hostToMSXFileName(std::string_view hostName) const;
+	[[nodiscard]] std::string msxToHostFileName(const FAT::FileName& msxName) const;
+
 	SectorAccessibleDisk& disk;
 	MemBuffer<SectorBuffer> fatBuffer;
+	const MsxChar2Unicode& msxChars;
 
 	unsigned clusterCount;
 	unsigned fatCount;

--- a/src/fdc/MSXtar.hh
+++ b/src/fdc/MSXtar.hh
@@ -33,6 +33,8 @@ namespace FAT {
 
 	using DirCluster = std::variant<Free, Cluster>;
 	using FatCluster = std::variant<Free, EndOfChain, Cluster>;
+
+	using FileName = decltype(MSXDirEntry::filename);
 }
 
 class MSXtar
@@ -69,12 +71,12 @@ private:
 	unsigned getNextSector(unsigned sector);
 	unsigned appendClusterToSubdir(unsigned sector);
 	DirEntry addEntryToDir(unsigned sector);
-	unsigned addSubdir(std::string_view msxName,
+	unsigned addSubdir(const FAT::FileName& msxName,
 	                   uint16_t t, uint16_t d, unsigned sector);
 	void alterFileInDSK(MSXDirEntry& msxDirEntry, const std::string& hostName);
 	unsigned addSubdirToDSK(zstring_view hostName,
-	                        std::string_view msxName, unsigned sector);
-	DirEntry findEntryInDir(const std::string& name, unsigned sector,
+	                        const FAT::FileName& msxName, unsigned sector);
+	DirEntry findEntryInDir(const FAT::FileName& msxName, unsigned sector,
 	                        SectorBuffer& sectorBuf);
 	std::string addFileToDSK(const std::string& fullHostName, unsigned sector);
 	std::string recurseDirFill(std::string_view dirName, unsigned sector);

--- a/src/input/Keyboard.cc
+++ b/src/input/Keyboard.cc
@@ -352,6 +352,11 @@ Keyboard::~Keyboard()
 	msxEventDistributor.unregisterEventListener(*this);
 }
 
+const MsxChar2Unicode& Keyboard::getMsxChar2Unicode() const
+{
+	return unicodeKeymap.getMsxChars();
+}
+
 static constexpr void doKeyGhosting(std::span<uint8_t, KeyMatrixPosition::NUM_ROWS> matrix,
                                     bool protectRow6)
 {

--- a/src/input/Keyboard.hh
+++ b/src/input/Keyboard.hh
@@ -58,6 +58,8 @@ public:
 
 	~Keyboard();
 
+	[[nodiscard]] const MsxChar2Unicode& getMsxChar2Unicode() const;
+
 	/** Returns a pointer to the current KeyBoard matrix
 	 */
 	[[nodiscard]] std::span<const uint8_t, KeyMatrixPosition::NUM_ROWS> getKeys() const;

--- a/src/input/MsxChar2Unicode.cc
+++ b/src/input/MsxChar2Unicode.cc
@@ -181,4 +181,15 @@ std::vector<uint8_t> MsxChar2Unicode::utf8ToMsx(
 	return msx;
 }
 
+std::string MsxChar2Unicode::msxToUtf8(std::span<const uint8_t> msx, char fallback) const
+{
+	return msxToUtf8(msx, [&](uint32_t) { return fallback; });
+}
+
+std::vector<uint8_t> MsxChar2Unicode::utf8ToMsx(std::string_view utf8, char fallback) const
+{
+	return utf8ToMsx(utf8, [&](uint8_t) { return fallback; });
+}
+
+
 } // namespace openmsx

--- a/src/input/MsxChar2Unicode.hh
+++ b/src/input/MsxChar2Unicode.hh
@@ -25,6 +25,9 @@ public:
 		std::string_view utf8,
 		const std::function<uint8_t(uint32_t)>& fallback) const;
 
+	[[nodiscard]] std::string msxToUtf8(std::span<const uint8_t> msx, char fallback) const;
+	[[nodiscard]] std::vector<uint8_t> utf8ToMsx(std::string_view utf8, char fallback) const;
+
 private:
 	void parseVid(std::string_view file);
 

--- a/src/input/UnicodeKeymap.cc
+++ b/src/input/UnicodeKeymap.cc
@@ -88,6 +88,9 @@ UnicodeKeymap::UnicodeKeymap(string_view keyboardType)
 		auto buf = file.mmap();
 		parseUnicodeKeyMapFile(
 			string_view(reinterpret_cast<const char*>(buf.data()), buf.size()));
+		if (!msxChars.has_value()) {
+			msxChars.emplace("MSXVID.TXT");
+		}
 	} catch (FileException&) {
 		throw MSXException("Couldn't load unicode keymap file: ", filename);
 	}


### PR DESCRIPTION
With this patch series DiskManipulator properly translates the encoding from the host system’s local character encoding to the specific MSX’s character encoding. This applies to `import`, `export`, `dir`, `chdir` and `mkdir`. See https://github.com/openMSX/openMSX/issues/1478.

@wouterv The MsxChar2Unicode is not easily accessible so it turns into this kind of mess. Any recommendations welcome.

Ideally I can retrieve it a bit easier, perhaps from the `Reactor` or the `MSXMotherBoard`, and assume it is always available (defaulting to a mapping of ASCII only).

I think the MSX character encoding is not a property of the keyboard, but a property of the BIOS. E.g. MSX-DOS (Nextor) also [relies on](https://github.com/Konamiman/Nextor/blob/v2.1/source/kernel/bank2/path.mac#L1418) the region specified in the BIOS at address `0x002B` for its upper-casing.

So maybe rather than to be located somewhere deep in the PPI / Keyboard systems, it would be better if it lived at a higher level. The encoding value is currently also not specified in the machine config, nor read from the BIOS ROM, but indirectly specified in the keyboard mapping config, reinforcing the dependency on it.

I also think a better name for the class would be `MSXCharacterEncoding` or something like that.

p.s. C++20 has `std::u8string` and `std::u8string_view`, which have an explicit UTF-8 encoding. Might be interesting to see if that can be used in the openMSX code base, though that would be a massive patch.