### PR TITLE
DiskManipulator: Add partition command

### DIFF
--- a/doc/manual/diskmanipulator.html
+++ b/doc/manual/diskmanipulator.html
@@ -70,6 +70,8 @@
 
     <li><a class="internal" href="#mkdir">mkdir</a></li>
 
+    <li><a class="internal" href="#partition">partition</a></li>
+
     <li><a class="internal" href="#savedsk">savedsk</a></li>
   </ol>
 
@@ -101,7 +103,7 @@
   </div>
 
   <p><code>diskmanipulator create &lt;dskfilename&gt;
-  &lt;size|option&gt; &lt;size|option&gt; ...</code></p>
+  &lt;size|option&gt; [&lt;size|option&gt; ...]</code></p>
 
   <div class="subsectiontitle">
     explanation:
@@ -255,6 +257,34 @@
     syntax:
   </div>
 
+  <p><code>diskmanipulator partition &lt;disk name&gt;
+    [&lt;size|option&gt; ...]</code></p>
+  
+    <div class="subsectiontitle">
+      explanation:
+    </div>
+  
+    <p>You can (re)partition existing disk images using this command.</p>
+  
+    <p>As many partitions as specified will be created, using either the Sunrise
+    IDE partition table format, or the Nextor format (standard MBR / EBR) if the
+    <code>-nextor</code> option is specified. The Sunrise IDE partition table
+    supports up to 31 partitions. Nextor's MBR / EBR partition table has no
+    partition count limit, but Nextor only handles the first 256.</p>
+
+    <p>After partitioning each partition will also be formatted appropriately,
+    see <a href="#format">format</a> for more details on that.</p>
+  
+    <p>You can specify the disk/partition sizes by using the following
+    postfixes:</p>
+  
+    <ul>
+      <li>S or s -&gt; size in sectors</li>
+      <li>B or b -&gt; size in bytes</li>
+      <li>K or k -&gt; size in kilobytes (default)</li>
+      <li>M or m -&gt; size in megabytes</li>
+    </ul>
+  
   <p><code>diskmanipulator savedsk &lt;disk name&gt;
   &lt;dskfilename&gt;</code></p>
 

--- a/doc/manual/diskmanipulator.html
+++ b/doc/manual/diskmanipulator.html
@@ -120,9 +120,10 @@
   in a Sunrise IDE hard disk image, or a Nextor one if the <code>-nextor</code>
   option is specified.</p>
 
-  <p>You can specify multiple sizes in which case a Sunrise IDE or Nextor
-  compatible partitioned image will be created. Each partition will be formatted
-  as required.</p>
+  <p>You can specify multiple sizes in which case a Beer IDE 1.9, Sunrise IDE
+  or Nextor compatible partitioned image will be created, see
+  <code><a class="internal" href="#partition">partition</a></code> for more
+  information. Each partition will be formatted as required.</p>
 
   <p>You can specify the disk/partition sizes by using the
   following postfixes:</p>
@@ -266,12 +267,18 @@
   
     <p>You can (re)partition existing disk images using this command.</p>
   
-    <p>As many partitions as specified will be created, using either the Sunrise
-    IDE partition table format, or the Nextor format (standard MBR / EBR) if the
-    <code>-nextor</code> option is specified. The Sunrise IDE partition table
-    supports up to 31 partitions. Nextor's MBR / EBR partition table has no
-    partition count limit, but Nextor only handles the first 256.</p>
-
+    <p>As many partitions as specified will be created, using one of the
+    following partition table formats according to the option given:</p>
+  
+    <ul>
+      <li><code>-dos1</code>: Standard MBR, Beer IDE 1.9 and Nextor compatible.
+          Max 4 partitions.</li>
+      <li><code>-dos2</code> (default): Sunrise IDE MBR, Sunrise IDE compatible.
+          Max 31 partitions.</li>
+      <li><code>-nextor</code>: Standard MBR / EBR, Nextor compatible.
+          Max 256 partitions.</li>
+    </ul>
+  
     <p>After partitioning each partition will also be formatted appropriately,
     see <a href="#format">format</a> for more details on that.</p>
   

--- a/doc/manual/diskmanipulator.html
+++ b/doc/manual/diskmanipulator.html
@@ -18,8 +18,8 @@
   in openMSX. It implements the basic stuff needed to handle files
   and subdirectories on MSX media. It also helps one creating new disk
   image files, both simple 360 kB and 720 kB disks as well as
-  hard disk images containing up to 31 partitions of 32 MB each for
-  Sunrise IDE, or up to 4 GB for Nextor.
+  hard disk images containing partitions of 32 MB each for Sunrise IDE,
+  or up to 4 GB for Nextor.
   Creating disk images and manipulating the files on them can be
   done without the need of a running emulated MSX (<code>set power
   off</code>).</p>
@@ -45,7 +45,7 @@
   <p><code>&lt;command&gt;</code> specifies the action to be performed. The next section lists the commands available and explains them.</p>
 
   <p><code>&lt;disk name&gt;</code> specifies the disk to operate on. Typical values are: <code><a class="external" href="commands.html#disk">diska</a></code>, <code>diskb</code>, <code><a class="external" href="commands.html#hd">hda</a></code> or the special <code><a class="external" href="commands.html#disk">virtual_drive</a></code> device. <code>disk&lt;x&gt;</code> and <code>hd&lt;x&gt;</code> are the drives available to the running emulated MSX machine. This allows interaction with the currently used disk images.<br />
-  In case the disk contains a Sunrise IDE, Beer IDE 1.9RC1 or Nextor compatible partition table you can add a partition number (from 1 till 31) to the disk name to specify on which partition the command will act. For example <code>hda2</code> is the second partition on the master IDE disk, <code>hdb3</code> is the third partition on the slave IDE disk.</p>
+  In case the disk contains a Sunrise IDE, Beer IDE 1.9RC1 or Nextor compatible partition table you can add a partition number (starting at 1) to the disk name to specify on which partition the command will act. For example <code>hda2</code> is the second partition on the master IDE disk, <code>hdb3</code> is the third partition on the slave IDE disk.</p>
 
   <p><code>&lt;command arguments&gt;</code> depend upon the command involved, see the detailed descriptions of the commands below.</p>
 

--- a/doc/manual/diskmanipulator.html
+++ b/doc/manual/diskmanipulator.html
@@ -174,7 +174,7 @@
     syntax:
   </div>
 
-  <p><code>diskmanipulator format &lt;disk name&gt;</code></p>
+  <p><code>diskmanipulator format &lt;disk name&gt; [&lt;size|option&gt;]</code></p>
 
   <div class="subsectiontitle">
     explanation:

--- a/doc/manual/user.html
+++ b/doc/manual/user.html
@@ -666,14 +666,13 @@ As announced above, there is (limited) support for CD-ROM with the 'ide' extensi
 
 <h4><a id="beeride">4.4.2 Beer IDE</a></h4>
 
-<p>The Beer IDE interface, as brought to us by SOLID, is emulated by openMSX, too. This interfaces only offers a single device (no master and slave) and can only handle up to 5 partitions of 32MB. But the up side is that it doesn't need MSX-DOS2, and thus it can run on any MSX (with 64kB RAM to run MSX-DOS). Emulation of this interface is quite recent, so consider it experimental.</p>
+<p>The Beer IDE interface, as brought to us by SOLID, is emulated by openMSX, too. This interface only offers a single device (no master and slave) and can only handle up to 4 (version 1.9) or 5 (version 1.8) partitions of 32MB. But the upside is that it doesn't need MSX-DOS2, and thus it can run on any MSX (with 64kB RAM to run MSX-DOS). Emulation of this interface is quite recent, so consider it experimental.</p>
 
 <p>Usage is identical to using the Sunrise hard disk interface: you can use the <a class="external" href="commands.html#hd">hda</a> command and the matching command line parameter <code>-hda</code> to control which image will be used.</p>
 
-<p>By default, the image is 170MB, so that 5 partitions of 32MB fit easily. Firmware version 1.9RC1 is selected by default, because we could not get the 1.8 firmware to work: the MSXFDISK program didn't create partitions which actually worked with the 1.8 firmware. If you want to experiment with it, you can change the firmware to use by editing the extension file in <code>share/extensions/Beer_IDE.xml</code>.</p>
+<p>By default, the image is 128MB, so that it fits 4 partitions of 32MB. Firmware version 1.9RC1 is selected by default, because we could not get the 1.8 firmware to work: the MSXFDISK program didn't create partitions which actually worked with the 1.8 firmware. If you want to experiment with it, you can change the firmware to use by editing the extension file in <code>share/extensions/Beer_IDE.xml</code>.</p>
 
-<p>With the 1.9RC1 firmware, we were able to work with an existing harddisk image, partitioned with the Windows tools that come with that firmware. Using this firmware, you can also partly work with Sunrise IDE compatible hard disk images, so you can use diskmanipulator to create a hard disk image and to import and export to them. Be careful though, this has not been extensively tested. Always back-up your hard disk image before doing this, in case something goes wrong. Important note: the Sunrise partition format numbers partitions the other way around as what Beer IDE 1.9RC1 firmware expects. This also means that you can't boot from Sunrise IDE images (and thus also not from images created by diskmanipulator).
-</p>
+<p>With the 1.9RC1 firmware, you can use <code><a class="external" href="diskmanipulator.html">diskmanipulator</a></code> to create a hard disk image and import from and export to them. To get started, partition the default drive with <code>diskmanipulator partition hda -dos1 32M 32M 32M 32M</code>. Then import MSX-DOS system files onto the first partition using <code>diskmanipulator import hda1 &lt;host-path&gt;</code>, and now you should be able to boot into MSX-DOS.</p>
 
 <p>
 Unfortunately, the Beer IDE is hardly documented and the software is hard to find. So, it's for experts only!

--- a/share/extensions/Beer_IDE.xml
+++ b/share/extensions/Beer_IDE.xml
@@ -24,7 +24,7 @@
           <idedevice>
             <type>IDEHD</type>
             <filename>hd.dsk</filename>
-            <size>170</size>
+            <size>128</size>
           </idedevice>
         </BeerIDE>
       </secondary>

--- a/src/fdc/DiskImageUtils.cc
+++ b/src/fdc/DiskImageUtils.cc
@@ -401,8 +401,13 @@ static SetBootSectorResult setBootSector(
 
 void format(SectorAccessibleDisk& disk, MSXBootSectorType bootType)
 {
+	format(disk, bootType, disk.getNbSectors());
+}
+
+void format(SectorAccessibleDisk& disk, MSXBootSectorType bootType, size_t nbSectors)
+{
 	// first create a boot sector for given partition size
-	size_t nbSectors = disk.getNbSectors();
+	nbSectors = std::min(nbSectors, disk.getNbSectors());
 	SectorBuffer buf;
 	SetBootSectorResult result = setBootSector(buf.bootSector, bootType, nbSectors);
 	disk.writeSector(0, buf);

--- a/src/fdc/DiskImageUtils.hh
+++ b/src/fdc/DiskImageUtils.hh
@@ -158,6 +158,7 @@ namespace DiskImageUtils {
 	 * @param bootType The boot sector type to use.
 	 */
 	void format(SectorAccessibleDisk& disk, MSXBootSectorType bootType);
+	void format(SectorAccessibleDisk& disk, MSXBootSectorType bootType, size_t nbSectors);
 
 	/** Write a partition table to the given disk and format each partition
 	 * @param disk The disk to partition.

--- a/src/fdc/DiskImageUtils.hh
+++ b/src/fdc/DiskImageUtils.hh
@@ -165,7 +165,7 @@ namespace DiskImageUtils {
 	 * @param sizes The number of sectors for each partition.
 	 * @param bootType The boot sector type to use.
 	 */
-	void partition(SectorAccessibleDisk& disk,
+	unsigned partition(SectorAccessibleDisk& disk,
 	               std::span<const unsigned> sizes, MSXBootSectorType bootType);
 };
 

--- a/src/fdc/DiskManipulator.cc
+++ b/src/fdc/DiskManipulator.cc
@@ -380,8 +380,8 @@ void DiskManipulator::create(std::span<const TclObject> tokens)
 	size_t totalSectors = 0;
 	MSXBootSectorType bootType = MSXBootSectorType::DOS2;
 
-	for (const auto& token : view::drop(tokens, 3)) {
-		if (auto t = parseBootSectorType(token.getString())) {
+	for (const auto& token_ : view::drop(tokens, 3)) {
+		if (auto t = parseBootSectorType(token_.getString())) {
 			bootType = *t;
 			continue;
 		}
@@ -390,7 +390,7 @@ void DiskManipulator::create(std::span<const TclObject> tokens)
 			throw CommandException(
 				"Maximum number of partitions is ", MAX_PARTITIONS);
 		}
-		auto tok = token.getString();
+		auto tok = token_.getString();
 		char* q;
 		size_t sectors = strtoull(tok.c_str(), &q, 0);
 		int scale = 1024; // default is kilobytes

--- a/src/fdc/DiskManipulator.hh
+++ b/src/fdc/DiskManipulator.hh
@@ -58,7 +58,7 @@ private:
 
 	static void create(std::span<const TclObject> tokens);
 	void savedsk(const DriveSettings& driveData, std::string filename);
-	void format(DriveSettings& driveData, MSXBootSectorType bootType);
+	void format(std::span<const TclObject> tokens);
 	std::string chdir(DriveSettings& driveData, std::string_view filename);
 	void mkdir(DriveSettings& driveData, std::string_view filename);
 	[[nodiscard]] std::string dir(DriveSettings& driveData);

--- a/src/fdc/DiskManipulator.hh
+++ b/src/fdc/DiskManipulator.hh
@@ -59,7 +59,8 @@ private:
 	[[nodiscard]] MSXtar getMSXtar(SectorAccessibleDisk& disk,
 	                                      DriveSettings& driveData);
 
-	static void create(std::span<const TclObject> tokens);
+	void create(std::span<const TclObject> tokens);
+	void partition(std::span<const TclObject> tokens);
 	void savedsk(const DriveSettings& driveData, std::string filename);
 	void format(std::span<const TclObject> tokens);
 	std::string chdir(DriveSettings& driveData, std::string_view filename);

--- a/src/fdc/DiskManipulator.hh
+++ b/src/fdc/DiskManipulator.hh
@@ -29,14 +29,17 @@ public:
 	void unregisterDrive(DiskContainer& drive);
 
 private:
-	static constexpr unsigned MAX_PARTITIONS = 31;
 	struct DriveSettings
 	{
+		std::string getWorkingDir(unsigned p);
+		void setWorkingDir(unsigned p, std::string_view dir);
+
 		DiskContainer* drive;
 		std::string driveName; // includes machine prefix
-		std::array<std::string, MAX_PARTITIONS + 1> workingDir;
-		/** 0 = whole disk, 1..MAX_PARTITIONS = partition number */
+		/** 0 = whole disk, 1.. = partition number */
 		unsigned partition;
+	private:
+		std::vector<std::string> workingDir;
 	};
 	using Drives = std::vector<DriveSettings>;
 	Drives drives; // unordered


### PR DESCRIPTION
With this command you can (re)partition an existing disk image.

Unlike `create`, `partition` always creates a partition table, and also accepts a zero-length list of sizes in which case it will create an empty partition table.

If not all partitions can be created given the disk size, it will throw an exception to print out in the console after creating the partitions that it could. If the last partition is too large to fit on the disk, its size will be clamped to the available space, no exceptions are thrown.

See (very old) issue https://github.com/openMSX/openMSX/issues/170.