### PR TITLE
Add TCP socket settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,14 @@
 *.suo
 *.sdf
 *.opensdf
+*.vcxproj.user
 core.*
 core
 .cproject
 .project
 *.VC.db
 *.VC.VC.opendb
+.vs/
 .vscode/
 __pycache__/
 .DS_Store

--- a/build/msvc/openmsx.sln
+++ b/build/msvc/openmsx.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Express 2013 for Windows Desktop
-VisualStudioVersion = 12.0.30110.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33829.357
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "openmsx", "openmsx.vcxproj", "{9563D96E-BBDC-410C-8BED-189102B0866F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{78FCD58E-62B7-4B6E-91D3-1003B2E85843}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -30,5 +32,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A04FC490-E471-462C-B174-3DC37F0C2480}
 	EndGlobalSection
 EndGlobal

--- a/build/msvc/openmsx.vcxproj
+++ b/build/msvc/openmsx.vcxproj
@@ -850,6 +850,7 @@
     <ClCompile Include="$(OpenMSXSrcDir)\SVIPrinterPort.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\SVIPPI.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\MSXCielTurbo.cc" />
+    <ClCompile Include="$(OpenMSXSrcDir)\SocketSettingsManager.cc" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(OpenMSXSrcDir)\cassette\CasImage.hh" />
@@ -1605,6 +1606,7 @@ popd</Command>
     <None Include="$(OpenMSXSrcDir)\SVIPrinterPort.hh" />
     <None Include="$(OpenMSXSrcDir)\SVIPPI.hh" />
     <None Include="$(OpenMSXSrcDir)\MSXCielTurbo.hh" />
+    <None Include="$(OpenMSXSrcDir)\SocketSettingsManager.hh" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="$(OpenMSXSrcDir)\resource\openmsx.rc" />

--- a/build/msvc/openmsx.vcxproj.filters
+++ b/build/msvc/openmsx.vcxproj.filters
@@ -1402,6 +1402,7 @@
     <ClCompile Include="$(OpenMSXSrcDir)\input\SG1000JoystickIO.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\SC3000PPI.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\SG1000Pause.cc" />
+    <ClCompile Include="$(OpenMSXSrcDir)\SocketSettingsManager.cc" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(OpenMSXSrcDir)\cassette\CasImage.hh">
@@ -2970,6 +2971,7 @@
     <None Include="$(OpenMSXSrcDir)\video\SuperImposedFrame.hh" />
     <None Include="$(OpenMSXSrcDir)\SC3000PPI.hh" />
     <None Include="$(OpenMSXSrcDir)\SG1000Pause.hh" />
+    <None Include="$(OpenMSXSrcDir)\SocketSettingsManager.hh" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="$(OpenMSXSrcDir)\resource\openmsx.rc">

--- a/doc/manual/commands.html
+++ b/doc/manual/commands.html
@@ -165,6 +165,8 @@
         <li><a class="internal" href="#scale_factor">scale_factor</a></li>
         <li><a class="internal" href="#scanline">scanline</a></li>
         <li><a class="internal" href="#socket_auth_mode">socket_auth_mode</a></li>
+        <li><a class="internal" href="#socket_port_number">socket_port_number</a></li>
+        <li><a class="internal" href="#socket_selection_mode">socket_selection_mode</a></li>
         <li><a class="internal" href="#sound_driver">sound_driver</a></li>
         <li><a class="internal" href="#speed">speed</a></li>
         <li><a class="internal" href="#soundchip_balance">&lt;soundchip&gt;_balance</a></li>
@@ -5086,8 +5088,83 @@
   </table>
 
   <div class="note">
+    Note: Changing the authentication mode affects all new connections after the change, but already established connections won't be affected.
+  </div>
+  <div class="note">
     Note: Disabling authentication with the <code>none</code> value is potentially dangerous and is therefore <b>not</b> recommended. See
     <a class="external" href="openmsx-control.html">Controlling openMSX from External Applications</a> for more details.
+  </div>
+
+  <h3><a id="socket_port_number">socket_port_number</a></h3>
+
+  <p>Changes the base port number for applications connecting to openMSX via TCP sockets. This setting is only available in Windows.</p>
+
+  <div class="subsectiontitle">
+    usage:
+  </div>
+
+  <table>
+    <tr>
+      <td><code>set socket_port_number</code></td>
+
+      <td>Shows the current setting</td>
+    </tr>
+
+    <tr>
+      <td><code>set socket_port_number &lt;num&gt;</code></td>
+
+      <td>Set the new value for the base port number for applications connecting to openMSX via TCP sockets (default: 9938)</td>
+    </tr>
+
+  </table>
+
+  <p>How the actual port number is chosen by openMSX depends on the value of the <a href="#socket_selection_mode">socket_selection_mode</a> setting.
+  See also <a class="external" href="openmsx-control.html">Controlling openMSX from External Applications</a>.</p>
+
+  <div class="note">
+    Note: Changing this setting causes openMSX to immediately start using a different port number for all new TCP connections.
+    Connections already established are not affected.
+  </div>
+
+  <h3><a id="socket_selection_mode">socket_selection_mode</a></h3>
+
+  <p>Changes the strategy used to select a port number for applications connecting to openMSX via TCP sockets. This setting is only available in Windows.</p>
+
+  <div class="subsectiontitle">
+    usage:
+  </div>
+
+  <table>
+    <tr>
+      <td><code>set socket_selection_mode</code></td>
+
+      <td>Shows the current setting</td>
+    </tr>
+
+    <tr>
+      <td><code>set socket_selection_mode random</code></td>
+
+      <td>openMSX will select a random port number between the base value (see <a href="#socket_port_number">socket_port_number</a>)
+      and the base value plus 64 (default)</td>
+    </tr>
+
+    <tr>
+      <td><code>set socket_selection_mode fixed</code></td>
+
+      <td>openMSX will use the base port number value (see <a href="#socket_port_number">socket_port_number</a>)
+      as the actual port number</td>
+    </tr>
+
+  </table>
+
+  <p>In both cases, if openMSX is unable to use the chosen port because it's already in use, it will try by increasing the port number value
+    by one; it will repeat this procedure up to 64 times if necessary before giving up and showing an error (the actual port number will always be
+    in the "base+64" range).
+    See also <a class="external" href="openmsx-control.html">Controlling openMSX from External Applications</a>.</p>
+
+  <div class="note">
+    Note: Changing this setting causes openMSX to immediately start using a different port number for all new TCP connections.
+    Connections already established are not affected.
   </div>
 
   <h3><a id="sound_driver">sound_driver</a></h3>

--- a/doc/manual/commands.html
+++ b/doc/manual/commands.html
@@ -164,6 +164,7 @@
         <li><a class="internal" href="#scale_algorithm">scale_algorithm</a></li>
         <li><a class="internal" href="#scale_factor">scale_factor</a></li>
         <li><a class="internal" href="#scanline">scanline</a></li>
+        <li><a class="internal" href="#socket_auth_mode">socket_auth_mode</a></li>
         <li><a class="internal" href="#sound_driver">sound_driver</a></li>
         <li><a class="internal" href="#speed">speed</a></li>
         <li><a class="internal" href="#soundchip_balance">&lt;soundchip&gt;_balance</a></li>
@@ -5052,6 +5053,41 @@
 
   <div class="note">
     Note: Some scalers will not render scanlines at all.
+  </div>
+
+  <h3><a id="socket_auth_mode">socket_auth_mode</a></h3>
+
+  <p>Changes the authentication mode for applications connecting to openMSX via TCP sockets. This setting is only available in Windows.</p>
+
+  <div class="subsectiontitle">
+    usage:
+  </div>
+
+  <table>
+    <tr>
+      <td><code>set socket_auth_mode</code></td>
+
+      <td>Shows the current setting</td>
+    </tr>
+
+    <tr>
+      <td><code>set socket_auth_mode sspi</code></td>
+
+      <td>Applications connecting to openMSX via TCP sockets must authenticate via <a href="https://learn.microsoft.com/en-us/windows/win32/rpc/security-support-provider-interface-sspi-">
+        SSPI</a> (default)</td>
+    </tr>
+
+    <tr>
+      <td><code>set socket_auth_mode none</code></td>
+
+      <td>Applications connecting to openMSX via TCP sockets don't need to authenticate at all</td>
+    </tr>
+
+  </table>
+
+  <div class="note">
+    Note: Disabling authentication with the <code>none</code> value is potentially dangerous and is therefore <b>not</b> recommended. See
+    <a class="external" href="openmsx-control.html">Controlling openMSX from External Applications</a> for more details.
   </div>
 
   <h3><a id="sound_driver">sound_driver</a></h3>

--- a/doc/manual/openmsx-control.html
+++ b/doc/manual/openmsx-control.html
@@ -74,6 +74,9 @@
   <code>C:\WINDOWS\TEMP</code>
   </p>
 
+  <p>Alternatively, you can use the <code>openmsx_info socket_port</code> command from within the openMSX console (press F10 to open 10)
+  to display the TCP port number used for socket connections in the current openMSX instance. This command is only available in Windows.</p>
+
   <p>
     Right after a TCP connection is established openMSX expects the connecting application
     to authenticate itself using <a href="https://learn.microsoft.com/en-us/windows/win32/rpc/security-support-provider-interface-sspi-">

--- a/doc/manual/openmsx-control.html
+++ b/doc/manual/openmsx-control.html
@@ -57,9 +57,13 @@
   </p>
 
   <p>On Windows (which does not support UNIX domain sockets), the socket is a
-  normal TCP socket. The port number is random between 9938 and 10001. This is done
-  to enforce applications to deal with multiple running openMSX processes. The
-  port number will be put in the following text file:</p>
+  normal TCP socket. By default the port number is random between 9938 and 10002, this is done
+  to enforce applications to deal with multiple running openMSX processes.
+  You can change the port numbers range and how the actual port number is chosen with the
+  <code>set <a class="external" href="commands.html#socket_port_number">socket_port_number</a></code> and
+  <code>set <a class="external" href="commands.html#socket_selection_mode">socket_selection_mode</a></code> commands.</p>
+  
+  <p>The sctual port number will be put in the following text file:</p>
 
   <div class="commandline">
   %USERPROFILE%\Documents and Settings\&lt;username&gt;\Local Settings\Temp\openmsx-default\socket.&lt;pid&gt;

--- a/doc/manual/openmsx-control.html
+++ b/doc/manual/openmsx-control.html
@@ -57,7 +57,7 @@
   </p>
 
   <p>On Windows (which does not support UNIX domain sockets), the socket is a
-  normal TCP socket. The port number is random between 9938 and 9958. This is done
+  normal TCP socket. The port number is random between 9938 and 10001. This is done
   to enforce applications to deal with multiple running openMSX processes. The
   port number will be put in the following text file:</p>
 
@@ -74,7 +74,35 @@
   <code>C:\WINDOWS\TEMP</code>
   </p>
 
-  <p>After connecting, openMSX expects XML input on the channel and it will
+  <p>
+    Right after a TCP connection is established openMSX expects the connecting application
+    to authenticate itself using <a href="https://learn.microsoft.com/en-us/windows/win32/rpc/security-support-provider-interface-sspi-">
+    SSPI</a>. You can disable the need for authentication by running a <code>set <a class="external"
+      href="commands.html#socket_auth_mode">socket_auth_mode</a> none</code> command (and go back
+    to requiring authentication by running <code>set socket_auth_mode sspi</code>); changing the authentication mode
+    affects all new connections after the change, but already established connections won't be affected.
+  </p>
+
+  <fieldset>
+    <legend>⚠ WARNING!</legend>
+    <p>
+      TCP connections are inherently insecure as anyone can connect to an open TCP port. openMSX commands allow to perform dangerous operations 
+      like deleting arbitrary files or copying files containing sensitive information, and these commands run with the same privilege level 
+      as the user who started the openMSX process. That's why authentication is required by default.
+    </p>
+
+    <p>
+      Disabling authentication for TCP connections is therefore <b>not</b> recommended and should be done only when absolutely necessary,
+      e.g. when you want to use a connecting application that doesn't support SSPI authentication.
+    </p>
+
+    <p>
+      Also note that when TCP authentication is disabled, applications expecting it to be enabled (e.g. the openMSX debugger)
+      won't be able to connect to openMSX.
+    </p>
+  </fieldset>
+
+  <p>After connecting and once authentication (or lack thereof) is sorted out, openMSX expects XML input on the channel and it will
   also give you output. This is explained in the next section.</p>
 
   <h2>Communication</h2>

--- a/src/GlobalSettings.cc
+++ b/src/GlobalSettings.cc
@@ -45,6 +45,9 @@ GlobalSettings::GlobalSettings(GlobalCommandController& commandController_)
 			{"blip", ResampledSoundDevice::RESAMPLE_BLIP}})
 	, speedManager(commandController)
 	, throttleManager(commandController)
+#ifdef _WIN32
+	, socketSettingsManager(commandController)
+#endif
 {
 	deadZoneSettings = to_vector(
 		view::transform(xrange(SDL_NumJoysticks()), [&](auto i) {

--- a/src/GlobalSettings.hh
+++ b/src/GlobalSettings.hh
@@ -9,6 +9,11 @@
 #include "SpeedManager.hh"
 #include "ThrottleManager.hh"
 #include "ResampledSoundDevice.hh"
+
+#ifdef _WIN32
+#include "SocketSettingsManager.hh"
+#endif
+
 #include <memory>
 #include <vector>
 
@@ -57,6 +62,11 @@ public:
 	[[nodiscard]] ThrottleManager& getThrottleManager() {
 		return throttleManager;
 	}
+#ifdef _WIN32
+	[[nodiscard]] SocketSettingsManager& getSocketSettingsManager() {
+		return socketSettingsManager;
+	}
+#endif
 
 private:
 	// Observer<Setting>
@@ -75,6 +85,9 @@ private:
 	std::vector<std::unique_ptr<IntegerSetting>> deadZoneSettings;
 	SpeedManager speedManager;
 	ThrottleManager throttleManager;
+#ifdef _WIN32
+	SocketSettingsManager socketSettingsManager;
+#endif
 };
 
 } // namespace openmsx

--- a/src/Reactor.hh
+++ b/src/Reactor.hh
@@ -54,6 +54,10 @@ class ConfigInfo;
 class RealTimeInfo;
 class SoftwareInfoTopic;
 
+#ifdef _WIN32
+class SocketPortInfo;
+#endif
+
 extern int exitCode;
 
 /**
@@ -179,6 +183,9 @@ private:
 	std::unique_ptr<ConfigInfo> machineInfo;
 	std::unique_ptr<RealTimeInfo> realTimeInfo;
 	std::unique_ptr<SoftwareInfoTopic> softwareInfoTopic;
+#ifdef _WIN32
+	std::unique_ptr<SocketPortInfo> socketPortInfo;
+#endif
 	std::unique_ptr<TclCallbackMessages> tclCallbackMessages;
 
 	// Locking rules for activeBoard access:

--- a/src/SocketSettingsManager.cc
+++ b/src/SocketSettingsManager.cc
@@ -10,15 +10,40 @@ SocketSettingsManager::SocketSettingsManager(CommandController& commandControlle
 	       SOCKAUTH_SSPI,
 	       EnumSetting<SocketAuthenticationMode>::Map{
 	           { "none", SOCKAUTH_NONE },
-	           { "sspi", SOCKAUTH_SSPI }
-})
+	           { "sspi", SOCKAUTH_SSPI }})
+	, socketPortNumberSetting(commandController, "socket_port_number",
+		   "port number (or base port number, see 'set socket_selection_mode') for socket connections",
+		   DEFAULT_SOCKET_PORT_NUMBER, 1, 65535)
+    , socketSelectionModeSetting(commandController, "socket_selection_mode",
+           "selection mode for the TCP port for socket connections, one of 'random' or 'fixed'",
+		   SOCKSEL_RANDOM,
+		   EnumSetting<SocketAuthenticationMode>::Map{
+			   { "random", SOCKSEL_RANDOM },
+		       { "fixed", SOCKSEL_FIXED }})
 {
 	setCurrentSocketPortNumber(0);
+
+	socketPortNumberSetting.attach(*this);
+	socketSelectionModeSetting.attach(*this);
+
+	//No need to attach socketAuthenticationModeSetting, that setting is explicitly checked
+	//whenever a client attempts to connect.
+}
+
+SocketSettingsManager::~SocketSettingsManager()
+{
+	socketPortNumberSetting.detach(*this);
+	socketSelectionModeSetting.detach(*this);
 }
 
 void SocketSettingsManager::setSocketAuthenticationMode(const SocketAuthenticationMode mode)
 {
 	socketAuthenticationModeSetting.setEnum(mode);
+}
+
+void SocketSettingsManager::update(const Setting& /*setting*/) noexcept
+{
+	notify();
 }
 
 } // namespace openmsx

--- a/src/SocketSettingsManager.cc
+++ b/src/SocketSettingsManager.cc
@@ -1,0 +1,23 @@
+#include "SocketSettingsManager.hh"
+
+namespace openmsx {
+
+// class SocketSettingsManager:
+
+SocketSettingsManager::SocketSettingsManager(CommandController& commandController)
+	: socketAuthenticationModeSetting(commandController, "socket_auth_mode",
+	       "authentication mode for socket connections, one of 'none' or 'sspi'",
+	       SOCKAUTH_SSPI,
+	       EnumSetting<SocketAuthenticationMode>::Map{
+	           { "none", SOCKAUTH_NONE },
+	           { "sspi", SOCKAUTH_SSPI }
+})
+{
+}
+
+void SocketSettingsManager::setSocketAuthenticationMode(const SocketAuthenticationMode mode)
+{
+	socketAuthenticationModeSetting.setEnum(mode);
+}
+
+} // namespace openmsx

--- a/src/SocketSettingsManager.cc
+++ b/src/SocketSettingsManager.cc
@@ -1,3 +1,5 @@
+#ifdef _WIN32
+
 #include "SocketSettingsManager.hh"
 
 namespace openmsx {
@@ -47,3 +49,5 @@ void SocketSettingsManager::update(const Setting& /*setting*/) noexcept
 }
 
 } // namespace openmsx
+
+#endif //_WIN32

--- a/src/SocketSettingsManager.cc
+++ b/src/SocketSettingsManager.cc
@@ -13,6 +13,7 @@ SocketSettingsManager::SocketSettingsManager(CommandController& commandControlle
 	           { "sspi", SOCKAUTH_SSPI }
 })
 {
+	setCurrentSocketPortNumber(0);
 }
 
 void SocketSettingsManager::setSocketAuthenticationMode(const SocketAuthenticationMode mode)

--- a/src/SocketSettingsManager.hh
+++ b/src/SocketSettingsManager.hh
@@ -3,30 +3,44 @@
 #ifndef SOCKETSETTINGSMANAGER_HH
 #define SOCKETSETTINGSMANAGER_HH
 
+#include "Subject.hh"
 #include "EnumSetting.hh"
+#include "IntegerSetting.hh"
 
 namespace openmsx {
 
 enum SocketAuthenticationMode { SOCKAUTH_NONE, SOCKAUTH_SSPI };
+enum SocketSelectionMode { SOCKSEL_RANDOM, SOCKSEL_FIXED };
 
 class CommandController;
 
 /**
 * Manages the Windows socket connections setting.
 */
-class SocketSettingsManager final
+class SocketSettingsManager final : public Subject<SocketSettingsManager>
+                                  , private Observer<Setting>
 {
 	public:
 		explicit SocketSettingsManager(CommandController& commandController);
+		~SocketSettingsManager();
 
 		[[nodiscard]] SocketAuthenticationMode getSocketAuthenticationMode() const { return socketAuthenticationModeSetting.getEnum(); }
+		[[nodiscard]] SocketSelectionMode getSocketSelectionMode() const { return socketSelectionModeSetting.getEnum(); }
+		[[nodiscard]] int getConfiguredSocketPortNumber() const { return socketPortNumberSetting.getInt(); }
 		[[nodiscard]] int getCurrentSocketPortNumber() const { return currentSocketPortNumber; }
 		[[nodiscard]] void setCurrentSocketPortNumber(int port) { currentSocketPortNumber = port; }
 		void setSocketAuthenticationMode(const SocketAuthenticationMode mode);
 
 	private:
+		const int DEFAULT_SOCKET_PORT_NUMBER = 9938;
+
 		EnumSetting<SocketAuthenticationMode> socketAuthenticationModeSetting;
+		EnumSetting<SocketSelectionMode> socketSelectionModeSetting;
+		IntegerSetting socketPortNumberSetting;
 		int currentSocketPortNumber;
+
+		// Observer<Setting>
+		void update(const Setting& setting) noexcept override;
 	};
 
 } // namespace openmsx

--- a/src/SocketSettingsManager.hh
+++ b/src/SocketSettingsManager.hh
@@ -1,0 +1,34 @@
+#ifdef _WIN32
+
+#ifndef SOCKETSETTINGSMANAGER_HH
+#define SOCKETSETTINGSMANAGER_HH
+
+#include "EnumSetting.hh"
+
+namespace openmsx {
+
+enum SocketAuthenticationMode { SOCKAUTH_NONE, SOCKAUTH_SSPI };
+
+class CommandController;
+
+/**
+* Manages the Windows socket connections setting.
+*/
+class SocketSettingsManager final
+{
+	public:
+		explicit SocketSettingsManager(CommandController& commandController);
+
+		[[nodiscard]] SocketAuthenticationMode getSocketAuthenticationMode() const { return socketAuthenticationModeSetting.getEnum(); }
+		void setSocketAuthenticationMode(const SocketAuthenticationMode mode);
+
+	private:
+		EnumSetting<SocketAuthenticationMode> socketAuthenticationModeSetting;
+	};
+
+} // namespace openmsx
+
+#endif
+
+#endif //_WIN32
+

--- a/src/SocketSettingsManager.hh
+++ b/src/SocketSettingsManager.hh
@@ -20,10 +20,13 @@ class SocketSettingsManager final
 		explicit SocketSettingsManager(CommandController& commandController);
 
 		[[nodiscard]] SocketAuthenticationMode getSocketAuthenticationMode() const { return socketAuthenticationModeSetting.getEnum(); }
+		[[nodiscard]] int getCurrentSocketPortNumber() const { return currentSocketPortNumber; }
+		[[nodiscard]] void setCurrentSocketPortNumber(int port) { currentSocketPortNumber = port; }
 		void setSocketAuthenticationMode(const SocketAuthenticationMode mode);
 
 	private:
 		EnumSetting<SocketAuthenticationMode> socketAuthenticationModeSetting;
+		int currentSocketPortNumber;
 	};
 
 } // namespace openmsx

--- a/src/events/CliConnection.cc
+++ b/src/events/CliConnection.cc
@@ -13,6 +13,7 @@
 #include "TclObject.hh"
 #include "TemporaryString.hh"
 #include "XMLEscape.hh"
+#include "GlobalSettings.hh"
 #include "cstdiop.hh"
 #include "ranges.hh"
 #include "unistdp.hh"
@@ -273,9 +274,11 @@ void PipeConnection::close()
 
 SocketConnection::SocketConnection(CommandController& commandController_,
                                    EventDistributor& eventDistributor_,
-                                   SOCKET sd_)
+                                   SOCKET sd_,
+                                   GlobalSettings& globalSettings_)
 	: CliConnection(commandController_, eventDistributor_)
 	, sd(sd_)
+	, globalSettings(globalSettings_)
 {
 }
 
@@ -288,17 +291,19 @@ void SocketConnection::run()
 {
 	// runs in helper thread
 #ifdef _WIN32
-	bool ok;
-	{
-		std::lock_guard<std::mutex> lock(sdMutex);
-		// Authenticate and authorize the caller
-		SocketStreamWrapper stream(sd);
-		SspiNegotiateServer server(stream);
-		ok = server.Authenticate() && server.Authorize();
-	}
-	if (!ok) {
-		closeSocket();
-		return;
+	if (globalSettings.getSocketSettingsManager().getSocketAuthenticationMode() != SOCKAUTH_NONE) {
+		bool ok;
+		{
+			std::lock_guard<std::mutex> lock(sdMutex);
+			// Authenticate and authorize the caller
+			SocketStreamWrapper stream(sd);
+			SspiNegotiateServer server(stream);
+			ok = server.Authenticate() && server.Authorize();
+		}
+		if (!ok) {
+			closeSocket();
+			return;
+		}
 	}
 #endif
 	// Start output element

--- a/src/events/CliConnection.hh
+++ b/src/events/CliConnection.hh
@@ -16,6 +16,7 @@ namespace openmsx {
 
 class CommandController;
 class EventDistributor;
+class GlobalSettings;
 
 class CliConnection : public CliListener, private EventListener
 {
@@ -122,7 +123,8 @@ class SocketConnection final : public CliConnection
 public:
 	SocketConnection(CommandController& commandController,
 	                 EventDistributor& eventDistributor,
-	                 SOCKET sd);
+	                 SOCKET sd,
+	                 GlobalSettings& globalSettings_);
 	~SocketConnection() override;
 
 	void output(std::string_view message) override;
@@ -131,10 +133,13 @@ private:
 	void close() override;
 	void run() override;
 	void closeSocket();
+	[[nodiscard]] GlobalSettings& getGlobalSettings() { return globalSettings; }
 
 	std::mutex sdMutex;
 	SOCKET sd;
 	bool established = false;
+
+	GlobalSettings& globalSettings;
 };
 
 } // namespace openmsx

--- a/src/events/CliServer.cc
+++ b/src/events/CliServer.cc
@@ -193,9 +193,11 @@ static void deleteSocket(const std::string& socket)
 
 
 CliServer::CliServer(CommandController& commandController_,
-                     EventDistributor& eventDistributor_,
-                     GlobalCliComm& cliComm_)
-	: commandController(commandController_)
+					EventDistributor& eventDistributor_,
+					GlobalCliComm& cliComm_,
+					GlobalSettings& globalSettings_)
+	: globalSettings(globalSettings_)
+	, commandController(commandController_)
 	, eventDistributor(eventDistributor_)
 	, cliComm(cliComm_)
 	, listenSock(OPENMSX_INVALID_SOCKET)
@@ -256,7 +258,7 @@ void CliServer::mainLoop()
 		fcntl(sd, F_SETFL, 0);
 #endif
 		cliComm.addListener(std::make_unique<SocketConnection>(
-			commandController, eventDistributor, sd));
+			commandController, eventDistributor, sd, globalSettings));
 	}
 }
 

--- a/src/events/CliServer.cc
+++ b/src/events/CliServer.cc
@@ -95,10 +95,12 @@ namespace openmsx {
 }
 
 #ifdef _WIN32
-[[nodiscard]] static int openPort(SOCKET listenSock)
+[[nodiscard]] int CliServer::openPort(SOCKET listenSock)
 {
 	const int BASE = 9938;
 	const int RANGE = 64;
+
+	setCurrentSocketPortNumber(0);
 
 	int first = random_int(0, RANGE - 1); // [0, RANGE)
 
@@ -111,6 +113,7 @@ namespace openmsx {
 		server_address.sin_port = htons(port);
 		if (bind(listenSock, reinterpret_cast<sockaddr*>(&server_address),
 		         sizeof(server_address)) != -1) {
+			setCurrentSocketPortNumber(port);
 			return port;
 		}
 	}

--- a/src/events/CliServer.hh
+++ b/src/events/CliServer.hh
@@ -3,6 +3,7 @@
 
 #include "Poller.hh"
 #include "Socket.hh"
+#include "GlobalSettings.hh"
 #include <string>
 #include <thread>
 
@@ -11,13 +12,15 @@ namespace openmsx {
 class CommandController;
 class EventDistributor;
 class GlobalCliComm;
+class GlobalSettings;
 
 class CliServer final
 {
 public:
 	CliServer(CommandController& commandController,
 	          EventDistributor& eventDistributor,
-	          GlobalCliComm& cliComm);
+	          GlobalCliComm& cliCom,
+	          GlobalSettings& globalSettings);
 	~CliServer();
 
 private:
@@ -29,6 +32,7 @@ private:
 	CommandController& commandController;
 	EventDistributor& eventDistributor;
 	GlobalCliComm& cliComm;
+	GlobalSettings& globalSettings;
 
 	std::thread thread;
 	std::string socketName;

--- a/src/events/CliServer.hh
+++ b/src/events/CliServer.hh
@@ -26,6 +26,8 @@ public:
 private:
 	void mainLoop();
 	[[nodiscard]] SOCKET createSocket();
+	[[nodiscard]] int openPort(SOCKET listenSock);
+	[[nodiscard]] void setCurrentSocketPortNumber(int port) { globalSettings.getSocketSettingsManager().setCurrentSocketPortNumber(port); }
 	void exitAcceptLoop();
 
 private:

--- a/src/events/CliServer.hh
+++ b/src/events/CliServer.hh
@@ -39,8 +39,10 @@ public:
 private:
 	void mainLoop();
 	[[nodiscard]] SOCKET createSocket();
+#ifdef _WIN32
 	[[nodiscard]] int openPort(SOCKET listenSock);
 	[[nodiscard]] void setCurrentSocketPortNumber(int port) { globalSettings.getSocketSettingsManager().setCurrentSocketPortNumber(port); }
+#endif
 	void exitAcceptLoop();
 	void deleteSocketFile(const std::string& socket);
 

--- a/src/events/CliServer.hh
+++ b/src/events/CliServer.hh
@@ -4,6 +4,12 @@
 #include "Poller.hh"
 #include "Socket.hh"
 #include "GlobalSettings.hh"
+
+#ifdef _WIN32
+#include "Observer.hh"
+#include "SocketSettingsManager.hh"
+#endif
+
 #include <string>
 #include <thread>
 
@@ -14,7 +20,14 @@ class EventDistributor;
 class GlobalCliComm;
 class GlobalSettings;
 
-class CliServer final
+#ifdef _WIN32
+class SocketSettingsManager;
+#endif
+
+class CliServer final 
+#ifdef _WIN32
+	: private Observer<SocketSettingsManager>
+#endif
 {
 public:
 	CliServer(CommandController& commandController,
@@ -29,6 +42,12 @@ private:
 	[[nodiscard]] int openPort(SOCKET listenSock);
 	[[nodiscard]] void setCurrentSocketPortNumber(int port) { globalSettings.getSocketSettingsManager().setCurrentSocketPortNumber(port); }
 	void exitAcceptLoop();
+	void deleteSocketFile(const std::string& socket);
+
+#ifdef _WIN32
+	// Observer<SpeedManager>
+	void update(const SocketSettingsManager& socketSettingsManager) noexcept override;
+#endif
 
 private:
 	CommandController& commandController;

--- a/src/main.cc
+++ b/src/main.cc
@@ -139,7 +139,8 @@ static int main(int argc, char **argv)
 			if (parseStatus != CommandLineParser::TEST) {
 				CliServer cliServer(reactor.getCommandController(),
 				                    reactor.getEventDistributor(),
-				                    reactor.getGlobalCliComm());
+				                    reactor.getGlobalCliComm(),
+				                    reactor.getGlobalSettings());
 				reactor.run(parser);
 			}
 		}


### PR DESCRIPTION
openMSX allows being externally controlled by applications connecting to it. In the Windows operating system, openMSX accepts connections to a TCP socket on a port number chosen at random between 9938 and 10002, and SSPI authentication is mandatory before actual commands are accepted.

This pull request adds some (Windows-only) settings and a new argument for the `openmsx_info` command that allow altering the behavior of openMSX related to TCP sockets. All the settings have sensible defaults that are backwards compatible with the current behavior.

## set socket_auth_mode

An enumeration type setting that accepts two values: `sspi` (default) and `none`. When `none` is set, openMSX will skip the authentication phase and will start to accept commands immediately after a connection is established.

Changing the value of the setting affects new connections, already established connections are unaffected.

## set socket_port_number

An integer setting that sets the base value of the TCP port in which openMSX will listen for incoming connections. The default value is 9938.

## set socket_selection_mode

An enumeration type setting that accepts two values: `random` (default) and `fixed`.

`random` keeps the current behavior: the port number is chosen randomly between the base value (set with `set socket_port_number`) and the base value plus 64; with the default base value that means between 9938 and 10002. `fixed` simply uses the base value as the actual port number.

In both cases, if openMSX is unable to use the chosen port because it's already in use, it will keep the current behavior: trying again after increasing the port number value by one; this procedure will be repeated up to 64 times if necessary before giving up and showing an error (the actual port number will always be in the "base+64" range).

When the value of `socket_port_number` or `socket_selection_mode` changes, the socket is closed and re-opened with a new port number according to the new values of the settings, so new connections are expected to happen in the new port number. This also updates the `socket.<pid>` socket file accordingly.

## openmsx_info socket_port

This will just print the port number in which openMSX currently accepts TCP connections. This is the same value that is written to the `socket.<pid>`, but with the convenience of being available as a command that can be executed from the openMSX built-in console.

## Documentation updates

The commands reference and the "Controlling openMSX from External Applications" guide are updated to reflect the new settings. Additionally, the later mentions the need for SSPI authentication by default (this was missing in the original document) and adds a warning about the risks of disabling authentication with `set socket_auth_mode none`.