### PR TITLE
compilers: Fix Python 3 TypeError

### DIFF
--- a/build/compilers.py
+++ b/build/compilers.py
@@ -86,7 +86,7 @@ class _Command(object):
 			if inputText is not None:
 				log.write('input:\n')
 				log.write(str(inputText))
-				if not inputText.endswith('\n'):
+				if not inputText.endswith(b'\n'):
 					log.write('\n')
 				log.write('end input.\n')
 			# pylint 0.18.0 somehow thinks 'messages' is a list, not a string.


### PR DESCRIPTION
Python complains with the following error:

```
Traceback (most recent call last):
  File "/Users/grauw/Development/openmsx/build/probe.py", line 391, in <module>
    main(*sys.argv[1 : ])
  File "/Users/grauw/Development/openmsx/build/probe.py", line 386, in main
    ).everything()
  File "/Users/grauw/Development/openmsx/build/probe.py", line 164, in everything
    self.checkAll()
  File "/Users/grauw/Development/openmsx/build/probe.py", line 136, in checkAll
    self.checkLibrary(library)
  File "/Users/grauw/Development/openmsx/build/probe.py", line 263, in checkLibrary
    version = versionGet(compileCommand, self.log)
  File "/Users/grauw/Development/openmsx/build/libraries.py", line 244, in execute
    version = cmd.expand(log, cls.getHeaders(platform), *(
  File "/Users/grauw/Development/openmsx/build/compilers.py", line 120, in expand
    output = self._run(
  File "/Users/grauw/Development/openmsx/build/compilers.py", line 90, in _run
    if not inputText.endswith('\n'):
TypeError: endswith first arg must be bytes or a tuple of bytes, not str
```

They are correctly complaining, since inputText is a byte string and thus
so must the argument, which is what this fix does.

Unfortunately, this file was not modified since 7e0f3f1 in 2019 (which
probably introduced the error since it converts to Python 3, and this type
error was introduced in Python 3), so I can not explain why I’m now suddenly
getting this error when I have never before, and why the rest of the team is
not getting it either.

Regardless, the error’s legit, so I guess the code path is just rarely hit.