### PR TITLE
build/flavour-unittest: space between CXXFLAGS assignment operator

### DIFF
--- a/build/flavour-unittest.mk
+++ b/build/flavour-unittest.mk
@@ -2,7 +2,7 @@
 # Build executable that runs unit tests.
 
 # Debug flags.
-CXXFLAGS+=-O3 -g -DUNITTEST -IContrib/catch2 -fsanitize=address
+CXXFLAGS += -O3 -g -DUNITTEST -IContrib/catch2 -fsanitize=address
 
 # Strip executable?
 OPENMSX_STRIP:=false


### PR DESCRIPTION
Without this, GNU Make (at least) seems to treat the variable as `CXXFLAGS+` as the variable when CXXFLAGS is already defined, resulting in the unittest CXXFLAGS being effectively ignored rather than appending to the already existing CXXFLAGS.