### PR TITLE
Fix MacOSX INSERT keybinding

### DIFF
--- a/doc/manual/user.html
+++ b/doc/manual/user.html
@@ -767,7 +767,7 @@ The program is encoded on the right audio channel which will not be audible. Wit
   <tr> <td>実行 ('execute') key</td> <td>R-Windows</td><td></td>           </tr>
   <tr> <td>SELECT key</td>           <td>F7</td>       <td>F7</td>         </tr>
   <tr> <td>STOP key</td>             <td>F8</td>       <td>F8</td>         </tr>
-  <tr> <td>INS key</td>              <td>Insert</td>   <td>Cmd+I</td>      </tr>
+  <tr> <td>INS key</td>              <td>Insert</td>   <td>L-CTRL+I</td>      </tr>
 </table>
 
 <h4><a id="cvkeymapping">5.1.2 ColecoVision Key Mapping</a></h4>


### PR DESCRIPTION
Fixed incorrect keybinding on MacOSX for INSERT to Ctrl+I