### PR TITLE
Add RS232 Ring Indicator handling, fix levels for unused bits in port 0x82 and active level for I8254 counter output pins.

### DIFF
--- a/share/extensions/Sanyo_MRS-001.xml
+++ b/share/extensions/Sanyo_MRS-001.xml
@@ -15,6 +15,7 @@
         <MSX-RS232 id="Generic MSX RS-232">
           <io base="0x80" num="8"/>
           <mem base="0x4000" size="0x4000"/>
+          <has_ri_pin>false</has_ri_pin>
           <rom>
             <sha1>41c4810ec56ed0f61e0fc8b355d2aae91de12d99</sha1>
             <filename>mrs-001.rom</filename>

--- a/share/machines/Spectravideo_SVI-738.xml
+++ b/share/machines/Spectravideo_SVI-738.xml
@@ -70,6 +70,7 @@
 
       <secondary slot="0">
         <MSX-RS232 id="MSX RS-232">
+          <ripinpresent>false</ripinpresent>
           <rom>
             <filename>svi-738_rs232.rom</filename>
             <sha1>4e9384c9d137f0ab65ffc5a78f04cd8c9df6c8b7</sha1>

--- a/share/machines/Spectravideo_SVI-738.xml
+++ b/share/machines/Spectravideo_SVI-738.xml
@@ -70,7 +70,8 @@
 
       <secondary slot="0">
         <MSX-RS232 id="MSX RS-232">
-          <ripinpresent>false</ripinpresent>
+          <has_ri_pin>false</has_ri_pin>
+          <rs232_pullup>true</rs232_pullup>
           <rom>
             <filename>svi-738_rs232.rom</filename>
             <sha1>4e9384c9d137f0ab65ffc5a78f04cd8c9df6c8b7</sha1>

--- a/share/machines/Spectravideo_SVI-738_DE.xml
+++ b/share/machines/Spectravideo_SVI-738_DE.xml
@@ -72,7 +72,8 @@
 
       <secondary slot="0">
         <MSX-RS232 id="MSX RS-232">
-          <ripinpresent>false</ripinpresent>
+          <has_ri_pin>false</has_ri_pin>
+          <rs232_pullup>true</rs232_pullup>
           <rom>
             <filename>svi-738_rs232.rom</filename>
             <sha1>4e9384c9d137f0ab65ffc5a78f04cd8c9df6c8b7</sha1>

--- a/share/machines/Spectravideo_SVI-738_DE.xml
+++ b/share/machines/Spectravideo_SVI-738_DE.xml
@@ -72,6 +72,7 @@
 
       <secondary slot="0">
         <MSX-RS232 id="MSX RS-232">
+          <ripinpresent>false</ripinpresent>
           <rom>
             <filename>svi-738_rs232.rom</filename>
             <sha1>4e9384c9d137f0ab65ffc5a78f04cd8c9df6c8b7</sha1>

--- a/share/machines/Spectravideo_SVI-738_PL.xml
+++ b/share/machines/Spectravideo_SVI-738_PL.xml
@@ -73,7 +73,8 @@
 
       <secondary slot="0">
         <MSX-RS232 id="MSX RS-232">
-          <ripinpresent>false</ripinpresent>
+          <has_ri_pin>false</has_ri_pin>
+          <rs232_pullup>true</rs232_pullup>
           <rom>
             <filename>svi-738_rs232.rom</filename>
             <sha1>4e9384c9d137f0ab65ffc5a78f04cd8c9df6c8b7</sha1>

--- a/share/machines/Spectravideo_SVI-738_PL.xml
+++ b/share/machines/Spectravideo_SVI-738_PL.xml
@@ -73,6 +73,7 @@
 
       <secondary slot="0">
         <MSX-RS232 id="MSX RS-232">
+          <ripinpresent>false</ripinpresent>
           <rom>
             <filename>svi-738_rs232.rom</filename>
             <sha1>4e9384c9d137f0ab65ffc5a78f04cd8c9df6c8b7</sha1>

--- a/share/machines/Spectravideo_SVI-738_SE.xml
+++ b/share/machines/Spectravideo_SVI-738_SE.xml
@@ -70,7 +70,8 @@
 
       <secondary slot="0">
         <MSX-RS232 id="MSX RS-232">
-          <ripinpresent>false</ripinpresent>
+          <has_ri_pin>false</has_ri_pin>
+          <rs232_pullup>true</rs232_pullup>
           <rom>
             <filename>svi-738_rs232.rom</filename>
             <sha1>4e9384c9d137f0ab65ffc5a78f04cd8c9df6c8b7</sha1> <!-- confirmed by NYYRIKKI -->

--- a/share/machines/Spectravideo_SVI-738_SE.xml
+++ b/share/machines/Spectravideo_SVI-738_SE.xml
@@ -70,6 +70,7 @@
 
       <secondary slot="0">
         <MSX-RS232 id="MSX RS-232">
+          <ripinpresent>false</ripinpresent>
           <rom>
             <filename>svi-738_rs232.rom</filename>
             <sha1>4e9384c9d137f0ab65ffc5a78f04cd8c9df6c8b7</sha1> <!-- confirmed by NYYRIKKI -->

--- a/share/machines/Toshiba_HX-22.xml
+++ b/share/machines/Toshiba_HX-22.xml
@@ -56,6 +56,7 @@
     <MSX-RS232 id="RS-232">
       <io base="0x80" num="8"/>
       <toshiba_rs232c_switch>true</toshiba_rs232c_switch>
+      <has_ri_pin>false</has_ri_pin>
     </MSX-RS232>
 
     <primary slot="0">

--- a/share/machines/Toshiba_HX-22I.xml
+++ b/share/machines/Toshiba_HX-22I.xml
@@ -52,6 +52,7 @@
     <MSX-RS232 id="RS-232">
       <io base="0x80" num="8"/>
       <toshiba_rs232c_switch>true</toshiba_rs232c_switch>
+      <has_ri_pin>false</has_ri_pin>
     </MSX-RS232>
 
     <primary slot="0">

--- a/src/serial/I8251.hh
+++ b/src/serial/I8251.hh
@@ -20,6 +20,7 @@ public:
 	virtual void setRTS(bool status, EmuTime::param time) = 0;
 
 	[[nodiscard]] virtual bool getDCD(EmuTime::param time) = 0; // This is not an I8251 signal
+	[[nodiscard]] virtual bool getRI(EmuTime::param time) = 0; // This is not an I8251 signal
 	[[nodiscard]] virtual bool getDSR(EmuTime::param time) = 0;
 	[[nodiscard]] virtual bool getCTS(EmuTime::param time) = 0; // TODO use this
 	virtual void signal(EmuTime::param time) = 0;

--- a/src/serial/I8251.hh
+++ b/src/serial/I8251.hh
@@ -19,8 +19,6 @@ public:
 	virtual void setDTR(bool status, EmuTime::param time) = 0;
 	virtual void setRTS(bool status, EmuTime::param time) = 0;
 
-	[[nodiscard]] virtual bool getDCD(EmuTime::param time) = 0; // This is not an I8251 signal
-	[[nodiscard]] virtual bool getRI(EmuTime::param time) = 0; // This is not an I8251 signal
 	[[nodiscard]] virtual bool getDSR(EmuTime::param time) = 0;
 	[[nodiscard]] virtual bool getCTS(EmuTime::param time) = 0; // TODO use this
 	virtual void signal(EmuTime::param time) = 0;

--- a/src/serial/MSXFacMidiInterface.cc
+++ b/src/serial/MSXFacMidiInterface.cc
@@ -65,6 +65,11 @@ bool MSXFacMidiInterface::Interface::getDSR(EmuTime::param /*time*/)
 	return true;
 }
 
+bool MSXFacMidiInterface::Interface::getRI(EmuTime::param /*time*/)
+{
+	return true;
+}
+
 bool MSXFacMidiInterface::Interface::getCTS(EmuTime::param /*time*/)
 {
 	return true;

--- a/src/serial/MSXFacMidiInterface.cc
+++ b/src/serial/MSXFacMidiInterface.cc
@@ -55,17 +55,7 @@ void MSXFacMidiInterface::Interface::setRTS(bool /*status*/, EmuTime::param /*ti
 {
 }
 
-bool MSXFacMidiInterface::Interface::getDCD(EmuTime::param /*time*/)
-{
-	return true;
-}
-
 bool MSXFacMidiInterface::Interface::getDSR(EmuTime::param /*time*/)
-{
-	return true;
-}
-
-bool MSXFacMidiInterface::Interface::getRI(EmuTime::param /*time*/)
 {
 	return true;
 }

--- a/src/serial/MSXFacMidiInterface.hh
+++ b/src/serial/MSXFacMidiInterface.hh
@@ -36,6 +36,7 @@ private:
 		void setRTS(bool status, EmuTime::param time) override;
 		[[nodiscard]] bool getDCD(EmuTime::param time) override;
 		[[nodiscard]] bool getDSR(EmuTime::param time) override;
+		[[nodiscard]] bool getRI(EmuTime::param time) override;
 		[[nodiscard]] bool getCTS(EmuTime::param time) override;
 		void setDataBits(DataBits bits) override;
 		void setStopBits(StopBits bits) override;

--- a/src/serial/MSXFacMidiInterface.hh
+++ b/src/serial/MSXFacMidiInterface.hh
@@ -34,9 +34,7 @@ private:
 		void setRxRDY(bool status, EmuTime::param time) override;
 		void setDTR(bool status, EmuTime::param time) override;
 		void setRTS(bool status, EmuTime::param time) override;
-		[[nodiscard]] bool getDCD(EmuTime::param time) override;
 		[[nodiscard]] bool getDSR(EmuTime::param time) override;
-		[[nodiscard]] bool getRI(EmuTime::param time) override;
 		[[nodiscard]] bool getCTS(EmuTime::param time) override;
 		void setDataBits(DataBits bits) override;
 		void setStopBits(StopBits bits) override;

--- a/src/serial/MSXMidi.cc
+++ b/src/serial/MSXMidi.cc
@@ -279,16 +279,6 @@ void MSXMidi::Interface::setRTS(bool status, EmuTime::param /*time*/)
 	midi.enableRxRDYIRQ(status);
 }
 
-bool MSXMidi::Interface::getDCD(EmuTime::param /*time*/)
-{
-	return true;
-}
-
-bool MSXMidi::Interface::getRI(EmuTime::param /*time*/)
-{
-	return true;
-}
-
 bool MSXMidi::Interface::getDSR(EmuTime::param /*time*/)
 {
 	auto& midi = OUTER(MSXMidi, interface);

--- a/src/serial/MSXMidi.cc
+++ b/src/serial/MSXMidi.cc
@@ -284,6 +284,11 @@ bool MSXMidi::Interface::getDCD(EmuTime::param /*time*/)
 	return true;
 }
 
+bool MSXMidi::Interface::getRI(EmuTime::param /*time*/)
+{
+	return true;
+}
+
 bool MSXMidi::Interface::getDSR(EmuTime::param /*time*/)
 {
 	auto& midi = OUTER(MSXMidi, interface);

--- a/src/serial/MSXMidi.hh
+++ b/src/serial/MSXMidi.hh
@@ -59,6 +59,7 @@ private:
 		void setDTR(bool status, EmuTime::param time) override;
 		void setRTS(bool status, EmuTime::param time) override;
 		[[nodiscard]] bool getDCD(EmuTime::param time) override;
+		[[nodiscard]] bool getRI(EmuTime::param time) override;
 		[[nodiscard]] bool getDSR(EmuTime::param time) override;
 		[[nodiscard]] bool getCTS(EmuTime::param time) override;
 		void setDataBits(DataBits bits) override;

--- a/src/serial/MSXMidi.hh
+++ b/src/serial/MSXMidi.hh
@@ -58,8 +58,6 @@ private:
 		void setRxRDY(bool status, EmuTime::param time) override;
 		void setDTR(bool status, EmuTime::param time) override;
 		void setRTS(bool status, EmuTime::param time) override;
-		[[nodiscard]] bool getDCD(EmuTime::param time) override;
-		[[nodiscard]] bool getRI(EmuTime::param time) override;
 		[[nodiscard]] bool getDSR(EmuTime::param time) override;
 		[[nodiscard]] bool getCTS(EmuTime::param time) override;
 		void setDataBits(DataBits bits) override;

--- a/src/serial/MSXRS232.cc
+++ b/src/serial/MSXRS232.cc
@@ -33,7 +33,7 @@ MSXRS232::MSXRS232(const DeviceConfig& config)
 		: nullptr)
 	, rxrdyIRQ(getMotherBoard(), MSXDevice::getName() + ".IRQrxrdy")
 	, hasMemoryBasedIo(config.getChildDataAsBool("memorybasedio", false))
-	, hasRIPin(config.getChildDataAsBool("ripinpresent",true))
+	, hasRIPin(config.getChildDataAsBool("has_ri_pin",true))
 	, ioAccessEnabled(!hasMemoryBasedIo)
 	, switchSetting(config.getChildDataAsBool("toshiba_rs232c_switch",
 		false) ? std::make_unique<BooleanSetting>(getCommandController(),
@@ -225,7 +225,8 @@ byte MSXRS232::readStatus(EmuTime::param time)
 	//
 	//  Bit Name  Expl.
 	//  0   CD    Carrier Detect   (0=Active, 1=Not active)
-	//  1   RI    Ring Indicator   (0=Active, 1=Not active) (N/C in MSX)
+	//  1   RI    Ring Indicator   (0=Active, 1=Not active)
+	//            (Not connected on many RS232 BIOS v1 implementations)
 	//  6         Timer Output from i8253 Counter 2
 	//  7   CTS   Clear to Send    (0=Active, 1=Not active)
 	//
@@ -236,26 +237,30 @@ byte MSXRS232::readStatus(EmuTime::param time)
 	//   on this I/O port, if CN1 is open. If CN1 is closed, it always
 	//   reads back as "0". ...
 
-	byte result = 0; // TODO check unused bits
+	byte result = 0xFF;	// Start with 0xFF, open lines on the data bus pull to 1
+	auto& dev = getPluggedRS232Dev();
 
-	if (!interface.getDCD(time)) {
-		result |= 0x01;
+	// Mask out (active low) bits
+	if (dev.getDCD(time)) {
+		result &= 0xFE;
 	}
 
-	if (!interface.getRI(time) && hasRIPin) {
-		result |=0x02;
+	if (hasRIPin && dev.getRI(time)) {
+		result &= 0xFD;
 	}
 
-	if (!rxrdyIRQenabled && switchSetting && switchSetting->getBoolean()) {
-		result |= 0x08;
+	if (rxrdyIRQenabled && switchSetting && switchSetting->getBoolean()) {
+		result &= 0xF7;
 	}
 
-	if (!interface.getCTS(time)) {
-		result |= 0x80;
+	if (interface.getCTS(time)) {
+		result &= 0x7F;
 	}
+
 	if (i8254.getOutputPin(2).getState(time)) {
-		result |= 0x40;
+		result &= 0xBF;
 	}
+
 	return result;
 }
 
@@ -307,18 +312,6 @@ void MSXRS232::Interface::setRTS(bool status, EmuTime::param time)
 {
 	auto& rs232 = OUTER(MSXRS232, interface);
 	rs232.getPluggedRS232Dev().setRTS(status, time);
-}
-
-bool MSXRS232::Interface::getDCD(EmuTime::param time)
-{
-	auto& rs232 = OUTER(MSXRS232, interface);
-	return rs232.getPluggedRS232Dev().getDCD(time);
-}
-
-bool MSXRS232::Interface::getRI(EmuTime::param time)
-{
-	auto& rs232 = OUTER(MSXRS232, interface);
-	return rs232.getPluggedRS232Dev().getRI(time);
 }
 
 bool MSXRS232::Interface::getDSR(EmuTime::param time)

--- a/src/serial/MSXRS232.cc
+++ b/src/serial/MSXRS232.cc
@@ -33,6 +33,7 @@ MSXRS232::MSXRS232(const DeviceConfig& config)
 		: nullptr)
 	, rxrdyIRQ(getMotherBoard(), MSXDevice::getName() + ".IRQrxrdy")
 	, hasMemoryBasedIo(config.getChildDataAsBool("memorybasedio", false))
+	, hasRIPin(config.getChildDataAsBool("ripinpresent",true))
 	, ioAccessEnabled(!hasMemoryBasedIo)
 	, switchSetting(config.getChildDataAsBool("toshiba_rs232c_switch",
 		false) ? std::make_unique<BooleanSetting>(getCommandController(),
@@ -241,6 +242,10 @@ byte MSXRS232::readStatus(EmuTime::param time)
 		result |= 0x01;
 	}
 
+	if (!interface.getRI(time) && hasRIPin) {
+		result |=0x02;
+	}
+
 	if (!rxrdyIRQenabled && switchSetting && switchSetting->getBoolean()) {
 		result |= 0x08;
 	}
@@ -308,6 +313,12 @@ bool MSXRS232::Interface::getDCD(EmuTime::param time)
 {
 	auto& rs232 = OUTER(MSXRS232, interface);
 	return rs232.getPluggedRS232Dev().getDCD(time);
+}
+
+bool MSXRS232::Interface::getRI(EmuTime::param time)
+{
+	auto& rs232 = OUTER(MSXRS232, interface);
+	return rs232.getPluggedRS232Dev().getRI(time);
 }
 
 bool MSXRS232::Interface::getDSR(EmuTime::param time)

--- a/src/serial/MSXRS232.hh
+++ b/src/serial/MSXRS232.hh
@@ -68,8 +68,6 @@ private:
 		void setRxRDY(bool status, EmuTime::param time) override;
 		void setDTR(bool status, EmuTime::param time) override;
 		void setRTS(bool status, EmuTime::param time) override;
-		[[nodiscard]] bool getDCD(EmuTime::param time) override;
-		[[nodiscard]] bool getRI(EmuTime::param time) override;
 		[[nodiscard]] bool getDSR(EmuTime::param time) override;
 		[[nodiscard]] bool getCTS(EmuTime::param time) override;
 		void setDataBits(DataBits bits) override;

--- a/src/serial/MSXRS232.hh
+++ b/src/serial/MSXRS232.hh
@@ -69,6 +69,7 @@ private:
 		void setDTR(bool status, EmuTime::param time) override;
 		void setRTS(bool status, EmuTime::param time) override;
 		[[nodiscard]] bool getDCD(EmuTime::param time) override;
+		[[nodiscard]] bool getRI(EmuTime::param time) override;
 		[[nodiscard]] bool getDSR(EmuTime::param time) override;
 		[[nodiscard]] bool getCTS(EmuTime::param time) override;
 		void setDataBits(DataBits bits) override;
@@ -87,6 +88,7 @@ private:
 	bool rxrdyIRQenabled = false;
 
 	const bool hasMemoryBasedIo;
+	const bool hasRIPin;
 	bool ioAccessEnabled;
 
 	const std::unique_ptr<BooleanSetting> switchSetting; // can be nullptr

--- a/src/serial/RS232Device.cc
+++ b/src/serial/RS232Device.cc
@@ -22,24 +22,36 @@ void RS232Device::setParityBit(bool /*enable*/, ParityBit /*parity*/)
 	// ignore
 }
 
+// The input lines of the RS-232 port without any plugged in device
+// are left floating (bits read as 1 in the IO ports), with the exception
+// of the following devices:
+//
+// Spectravideo SVI-738 : Inputs are pull-up (Read as 0 in the IO ports)
+// Spectravideo SVI-737 and SVI-757: Inputs are pull-down, behave 
+//                                   the same as left floating.
+//
+// This has been tested to be true for the SVI-738 and Toshiba HX-22,
+// for the other devices the info comes from manuals, schematics, or
+// circuit board pictures.
+
 bool RS232Device::getCTS(EmuTime::param /*time*/) const
 {
-	return true; // TODO check
+	return false; // TODO return the inverse of config tag 'rs232_pullup'
 }
 
 bool RS232Device::getDSR(EmuTime::param /*time*/) const
 {
-	return true; // TODO check
+	return false; // TODO return the inverse of config tag 'rs232_pullup'
 }
 
 bool RS232Device::getDCD(EmuTime::param /*time*/) const
 {
-	return true; // TODO check
+	return false; // TODO return the inverse of config tag 'rs232_pullup'
 }
 
 bool RS232Device::getRI(EmuTime::param /*time*/) const
 {
-	return true; // TODO check
+	return false; // TODO return the inverse of config tag 'rs232_pullup'
 }
 
 void RS232Device::setDTR(bool /*status*/, EmuTime::param /*time*/)

--- a/src/serial/RS232Device.cc
+++ b/src/serial/RS232Device.cc
@@ -37,6 +37,11 @@ bool RS232Device::getDCD(EmuTime::param /*time*/) const
 	return true; // TODO check
 }
 
+bool RS232Device::getRI(EmuTime::param /*time*/) const
+{
+	return true; // TODO check
+}
+
 void RS232Device::setDTR(bool /*status*/, EmuTime::param /*time*/)
 {
 	// ignore

--- a/src/serial/RS232Device.hh
+++ b/src/serial/RS232Device.hh
@@ -24,6 +24,7 @@ public:
 	[[nodiscard]] virtual bool getCTS(EmuTime::param time) const;
 	[[nodiscard]] virtual bool getDSR(EmuTime::param time) const;
 	[[nodiscard]] virtual bool getDCD(EmuTime::param time) const;
+	[[nodiscard]] virtual bool getRI(EmuTime::param time) const;
 	virtual void setDTR(bool status, EmuTime::param time);
 	virtual void setRTS(bool status, EmuTime::param time);
 };

--- a/src/serial/RS232Net.cc
+++ b/src/serial/RS232Net.cc
@@ -308,6 +308,11 @@ bool RS232Net::getDCD(EmuTime::param /*time*/) const
 	return DCD;
 }
 
+bool RS232Net::getRI(EmuTime::param /*time*/) const
+{
+	return RI;
+} 
+
 void RS232Net::setDTR(bool status, EmuTime::param /*time*/)
 {
 	if (DTR == status) return;

--- a/src/serial/RS232Net.cc
+++ b/src/serial/RS232Net.cc
@@ -303,6 +303,18 @@ void RS232Net::recvByte(uint8_t value_, EmuTime::param /*time*/)
 }
 
 // Control lines
+
+bool RS232Net::getDSR(EmuTime::param /*time*/) const
+{
+	return true;	// Needed to set this line in the correct state for a plugged device
+}
+
+bool RS232Net::getCTS(EmuTime::param /*time*/) const
+{
+	return true;	// TODO: Implement when IP232 adds support for CTS
+}
+
+
 bool RS232Net::getDCD(EmuTime::param /*time*/) const
 {
 	return DCD;

--- a/src/serial/RS232Net.hh
+++ b/src/serial/RS232Net.hh
@@ -55,6 +55,7 @@ public:
 	void recvByte(uint8_t value, EmuTime::param time) override;
 
 	[[nodiscard]] bool getDCD(EmuTime::param time) const override;
+	[[nodiscard]] bool getRI(EmuTime::param time) const override;
 	void setDTR(bool status, EmuTime::param time) override;
 	void setRTS(bool status, EmuTime::param time) override;
 

--- a/src/serial/RS232Net.hh
+++ b/src/serial/RS232Net.hh
@@ -37,7 +37,6 @@ public:
 		} address;
 	};
 
-public:
 	RS232Net(EventDistributor& eventDistributor, Scheduler& scheduler,
 	         CommandController& commandController);
 	~RS232Net() override;
@@ -54,6 +53,8 @@ public:
 	// output
 	void recvByte(uint8_t value, EmuTime::param time) override;
 
+	[[nodiscard]] bool getDSR(EmuTime::param time) const override;
+	[[nodiscard]] bool getCTS(EmuTime::param time) const override;
 	[[nodiscard]] bool getDCD(EmuTime::param time) const override;
 	[[nodiscard]] bool getRI(EmuTime::param time) const override;
 	void setDTR(bool status, EmuTime::param time) override;

--- a/src/serial/RS232Tester.cc
+++ b/src/serial/RS232Tester.cc
@@ -110,6 +110,19 @@ void RS232Tester::run()
 	}
 }
 
+// Control lines
+// Needed to set these lines in the correct state for a plugged device
+
+bool RS232Tester::getDSR(EmuTime::param /*time*/) const
+{
+	return true;
+}
+
+bool RS232Tester::getCTS(EmuTime::param /*time*/) const
+{
+	return true;
+}
+
 // input
 void RS232Tester::signal(EmuTime::param time)
 {

--- a/src/serial/RS232Tester.hh
+++ b/src/serial/RS232Tester.hh
@@ -31,6 +31,8 @@ public:
 	void unplugHelper(EmuTime::param time) override;
 	[[nodiscard]] std::string_view getName() const override;
 	[[nodiscard]] std::string_view getDescription() const override;
+	[[nodiscard]] bool getDSR(EmuTime::param time) const override;
+	[[nodiscard]] bool getCTS(EmuTime::param time) const override;
 
 	// input
 	void signal(EmuTime::param time) override;


### PR DESCRIPTION
This adds Ring Indicator (RI) line handling to the RS232net pluggable (with IP232 protocol enabled).
Current release of TCPSer (1.1.4) doesn't support RI emulation, but TCPSer v1.1.6_beta from the official repository (https://github.com/go4retro/tcpser) does.

Also added 'ripinpresent' configuration tag, which defaults to true.
Set to false for machines with no RI pin present in the RS232 port (SVI-738 and its variants).

I don't know of any software that reads the status of the RI line, but a simple BASIC program can be made to test it:

```
10 CALLCOMINI("0:8n1nnnnn",1200,1200,0)
20 OPEN"com0:"AS#1
30 P=0:R=3
40 A=INP(&H82)AND2:IFA<>PTHENP=A:IFA=0THENPRINT"RING!":R=R-1
50 IF R>0THEN40
60 PRINT#1,"ATA";CHR$(13):CLS:CLOSE1
70 CALLCOMTERM
```

Running that program in OpenMSX (with the R232 pluggable correctly setup and TCPser running), and connecting to TCPSer's listening port from another terminal program (ie PuTTY) should result in three 'rings' and then the program answering the 'call' and calling the ROM terminal.
