### PR TITLE
Simulate unplugged RS-232 input control lines with configurable 'pull-up'/'pull-down' behaviour

### DIFF
--- a/src/serial/MSXRS232.hh
+++ b/src/serial/MSXRS232.hh
@@ -87,6 +87,7 @@ private:
 
 	const bool hasMemoryBasedIo;
 	const bool hasRIPin;
+	const bool inputsPullup;
 	bool ioAccessEnabled;
 
 	const std::unique_ptr<BooleanSetting> switchSetting; // can be nullptr

--- a/src/serial/RS232Device.cc
+++ b/src/serial/RS232Device.cc
@@ -33,25 +33,30 @@ void RS232Device::setParityBit(bool /*enable*/, ParityBit /*parity*/)
 // This has been tested to be true for the SVI-738 and Toshiba HX-22,
 // for the other devices the info comes from manuals, schematics, or
 // circuit board pictures.
+// 
+// Return an empty optional to indicate an unplugged input, in which case
+// the configuration tag 'rs232_pullup' will be used as the
+// effective value.
 
-bool RS232Device::getCTS(EmuTime::param /*time*/) const
+
+std::optional<bool> RS232Device::getCTS(EmuTime::param /*time*/) const
 {
-	return false; // TODO return the inverse of config tag 'rs232_pullup'
+	return {};
 }
 
-bool RS232Device::getDSR(EmuTime::param /*time*/) const
+std::optional<bool> RS232Device::getDSR(EmuTime::param /*time*/) const
 {
-	return false; // TODO return the inverse of config tag 'rs232_pullup'
+	return {};
 }
 
-bool RS232Device::getDCD(EmuTime::param /*time*/) const
+std::optional<bool> RS232Device::getDCD(EmuTime::param /*time*/) const
 {
-	return false; // TODO return the inverse of config tag 'rs232_pullup'
+	return {};
 }
 
-bool RS232Device::getRI(EmuTime::param /*time*/) const
+std::optional<bool> RS232Device::getRI(EmuTime::param /*time*/) const
 {
-	return false; // TODO return the inverse of config tag 'rs232_pullup'
+	return {};
 }
 
 void RS232Device::setDTR(bool /*status*/, EmuTime::param /*time*/)

--- a/src/serial/RS232Device.hh
+++ b/src/serial/RS232Device.hh
@@ -21,10 +21,10 @@ public:
 	void setParityBit(bool enable, ParityBit parity) override;
 
 	// control
-	[[nodiscard]] virtual bool getCTS(EmuTime::param time) const;
-	[[nodiscard]] virtual bool getDSR(EmuTime::param time) const;
-	[[nodiscard]] virtual bool getDCD(EmuTime::param time) const;
-	[[nodiscard]] virtual bool getRI(EmuTime::param time) const;
+	[[nodiscard]] virtual std::optional<bool> getCTS(EmuTime::param time) const;
+	[[nodiscard]] virtual std::optional<bool> getDSR(EmuTime::param time) const;
+	[[nodiscard]] virtual std::optional<bool> getDCD(EmuTime::param time) const;
+	[[nodiscard]] virtual std::optional<bool> getRI(EmuTime::param time) const;
 	virtual void setDTR(bool status, EmuTime::param time);
 	virtual void setRTS(bool status, EmuTime::param time);
 };

--- a/src/serial/RS232Net.cc
+++ b/src/serial/RS232Net.cc
@@ -304,22 +304,22 @@ void RS232Net::recvByte(uint8_t value_, EmuTime::param /*time*/)
 
 // Control lines
 
-bool RS232Net::getDSR(EmuTime::param /*time*/) const
+std::optional<bool> RS232Net::getDSR(EmuTime::param /*time*/) const
 {
 	return true; // Needed to set this line in the correct state for a plugged device
 }
 
-bool RS232Net::getCTS(EmuTime::param /*time*/) const
+std::optional<bool> RS232Net::getCTS(EmuTime::param /*time*/) const
 {
 	return true; // TODO: Implement when IP232 adds support for CTS
 }
 
-bool RS232Net::getDCD(EmuTime::param /*time*/) const
+std::optional<bool> RS232Net::getDCD(EmuTime::param /*time*/) const
 {
 	return DCD;
 }
 
-bool RS232Net::getRI(EmuTime::param /*time*/) const
+std::optional<bool> RS232Net::getRI(EmuTime::param /*time*/) const
 {
 	return RI;
 }

--- a/src/serial/RS232Net.hh
+++ b/src/serial/RS232Net.hh
@@ -54,10 +54,10 @@ public:
 	// output
 	void recvByte(uint8_t value, EmuTime::param time) override;
 
-	[[nodiscard]] bool getDSR(EmuTime::param time) const override;
-	[[nodiscard]] bool getCTS(EmuTime::param time) const override;
-	[[nodiscard]] bool getDCD(EmuTime::param time) const override;
-	[[nodiscard]] bool getRI(EmuTime::param time) const override;
+	[[nodiscard]] std::optional<bool> getDSR(EmuTime::param time) const override;
+	[[nodiscard]] std::optional<bool> getCTS(EmuTime::param time) const override;
+	[[nodiscard]] std::optional<bool> getDCD(EmuTime::param time) const override;
+	[[nodiscard]] std::optional<bool> getRI(EmuTime::param time) const override;
 	void setDTR(bool status, EmuTime::param time) override;
 	void setRTS(bool status, EmuTime::param time) override;
 

--- a/src/serial/RS232Tester.cc
+++ b/src/serial/RS232Tester.cc
@@ -113,12 +113,12 @@ void RS232Tester::run()
 // Control lines
 // Needed to set these lines in the correct state for a plugged device
 
-bool RS232Tester::getDSR(EmuTime::param /*time*/) const
+std::optional<bool> RS232Tester::getDSR(EmuTime::param /*time*/) const
 {
 	return true;
 }
 
-bool RS232Tester::getCTS(EmuTime::param /*time*/) const
+std::optional<bool> RS232Tester::getCTS(EmuTime::param /*time*/) const
 {
 	return true;
 }

--- a/src/serial/RS232Tester.hh
+++ b/src/serial/RS232Tester.hh
@@ -31,8 +31,8 @@ public:
 	void unplugHelper(EmuTime::param time) override;
 	[[nodiscard]] std::string_view getName() const override;
 	[[nodiscard]] std::string_view getDescription() const override;
-	[[nodiscard]] bool getDSR(EmuTime::param time) const override;
-	[[nodiscard]] bool getCTS(EmuTime::param time) const override;
+	[[nodiscard]] std::optional<bool> getDSR(EmuTime::param time) const override;
+	[[nodiscard]] std::optional<bool> getCTS(EmuTime::param time) const override;
 
 	// input
 	void signal(EmuTime::param time) override;


### PR DESCRIPTION

RS232Device.cc input control lines methods now return a boolean optional.
An empty return value means the input is unplugged, and it should default to the value of the configuration tag 'rs232_pullup'.
This configuration tag defaults to false and reflects the hardware implementation of the RS-232 port.
As of now only the SVI-738 is known to need this tag set to true.