### PR TITLE
Stop user from changing segment on generic 8K ROM when emulation paused

### DIFF
--- a/src/memory/RomGeneric8kB.cc
+++ b/src/memory/RomGeneric8kB.cc
@@ -1,4 +1,6 @@
 #include "RomGeneric8kB.hh"
+#include "MSXMotherBoard.hh"
+#include "MSXCPUInterface.hh"
 #include "serialize.hh"
 #include "xrange.hh"
 
@@ -23,7 +25,9 @@ void RomGeneric8kB::reset(EmuTime::param /*time*/)
 
 void RomGeneric8kB::writeMem(word address, byte value, EmuTime::param /*time*/)
 {
-	setRom(address >> 13, value);
+	if (!getMotherBoard().getCPUInterface().isBreaked()) {
+		setRom(address >> 13, value);
+	}
 }
 
 byte* RomGeneric8kB::getWriteCacheLine(word address) const


### PR DESCRIPTION
Setting the current mapper segment is a feature of the ROM mapper and should not be triggered by the user directly. I think that if the user wants to inspect the contents of another segment, there should be a standard and user-friendly way to do it that is independent of the romtype.