### PR TITLE
Reorder key event priority so ImGui can capture them

### DIFF
--- a/share/scripts/keybindings.tcl
+++ b/share/scripts/keybindings.tcl
@@ -23,8 +23,8 @@ if {$is_dingux} {
 # reverse
 #  note: you can't use bindings with modifiers like SHIFT, because they
 #        will already stop the replay, as they are MSX keys as well
-bind_default PAGEUP   -repeat "go_back_one_step"
-bind_default PAGEDOWN -repeat "go_forward_one_step"
+bind_default PAGEUP   -global "go_back_one_step"
+bind_default PAGEDOWN -global "go_forward_one_step"
 
 # savestate
 if {$tcl_platform(os) eq "Darwin"} {

--- a/src/config/SettingsConfig.cc
+++ b/src/config/SettingsConfig.cc
@@ -39,6 +39,7 @@ struct SettingsParser : rapidsax::NullHandler
 		std::string_view cmd;
 		bool repeat = false;
 		bool event = false;
+		bool global = false;
 	};
 	std::vector<Bind> binds;
 	std::vector<std::string_view> unbinds;
@@ -116,9 +117,9 @@ void SettingsConfig::loadSetting(const FileContext& context, std::string_view fi
 	}
 
 	hotKey.loadInit();
-	for (const auto& [key, cmd, repeat, event] : parser.binds) {
+	for (const auto& [key, cmd, repeat, event, global] : parser.binds) {
 		try {
-			hotKey.loadBind(key, cmd, repeat, event);
+			hotKey.loadBind(key, cmd, repeat, event, global);
 		} catch (MSXException& e) {
 			commandController.getCliComm().printWarning(
 				"Couldn't restore key-binding: ", e.getMessage());

--- a/src/events/EventDistributor.cc
+++ b/src/events/EventDistributor.cc
@@ -22,8 +22,6 @@ void EventDistributor::registerEventListener(
 {
 	std::lock_guard<std::mutex> lock(mutex);
 	auto& priorityMap = listeners[size_t(type)];
-	// a listener may only be registered once for each type
-	assert(!contains(priorityMap, &listener, &Entry::listener));
 	// insert at highest position that keeps listeners sorted on priority
 	auto it = ranges::upper_bound(priorityMap, priority, {}, &Entry::priority);
 	priorityMap.emplace(it, Entry{priority, &listener});
@@ -100,7 +98,6 @@ void EventDistributor::deliverEvents()
 
 				// This might throw, e.g. when failing to initialize video system
 				if (int block = e.listener->signalEvent(event)) {
-					assert(block > e.priority);
 					blockPriority = block;
 				}
 			}

--- a/src/events/EventDistributor.hh
+++ b/src/events/EventDistributor.hh
@@ -20,8 +20,9 @@ public:
 	  */
 	enum Priority {
 		OTHER,
-		HOTKEY,
+		HOTKEY, // global hot keys are resolved here
 		IMGUI,
+		POSTPONED, // normal hot keys are resolved after ImGui
 		MSX,
 		LOWEST, // should only be used internally in EventDistributor
 	};

--- a/src/events/HotKey.cc
+++ b/src/events/HotKey.cc
@@ -168,10 +168,10 @@ void HotKey::loadInit()
 	cmdMap = defaultMap;
 }
 
-void HotKey::loadBind(std::string_view key, std::string_view cmd, bool repeat, bool event)
+void HotKey::loadBind(std::string_view key, std::string_view cmd, bool repeat, bool event, bool global)
 {
 	bind(HotKeyInfo(createEvent(key, commandController.getInterpreter()),
-			std::string(cmd), repeat, event));
+			std::string(cmd), repeat, event, global));
 }
 
 void HotKey::loadUnbind(std::string_view key)
@@ -441,11 +441,13 @@ void HotKey::BindCmd::execute(std::span<const TclObject> tokens, TclObject& resu
 	bool layers = false;
 	bool repeat = false;
 	bool passEvent = false;
+	bool global = false;
 	std::array parserInfo = {
 		valueArg("-layer", layer),
 		flagArg("-layers", layers),
 		flagArg("-repeat", repeat),
 		flagArg("-event", passEvent),
+		flagArg("-global", global),
 	};
 	auto arguments = parseTclArgs(getInterpreter(), tokens.subspan<1>(), parserInfo);
 	if (defaultCmd && !layer.empty()) {
@@ -496,7 +498,7 @@ void HotKey::BindCmd::execute(std::span<const TclObject> tokens, TclObject& resu
 		}
 		HotKey::HotKeyInfo info(
 			createEvent(arguments[0], getInterpreter()),
-			command, repeat, passEvent);
+			command, repeat, passEvent, global);
 		if (defaultCmd) {
 			hotKey.bindDefault(std::move(info));
 		} else if (layer.empty()) {
@@ -514,9 +516,9 @@ string HotKey::BindCmd::help(std::span<const TclObject> /*tokens*/) const
 	return strCat(
 		cmd, "                       : show all bounded keys\n",
 		cmd, " <key>                 : show binding for this key\n",
-		cmd, " <key> [-repeat] [-event] <cmd> : bind key to command, optionally "
-		"repeat command while key remains pressed and also optionally "
-		"give back the event as argument (a list) to <cmd>\n"
+		cmd, " <key> [-global] [-repeat] [-event] <cmd> : bind key to command, optionally "
+		"setting the highest priority, optionally repeat command while key remains "
+		"pressed and also optionally give back the event as argument (a list) to <cmd>\n"
 		"These 3 take an optional '-layer <layername>' option, "
 		"see activate_input_layer.\n",
 		cmd, " -layers               : show a list of layers with bound keys\n");

--- a/src/events/HotKey.hh
+++ b/src/events/HotKey.hh
@@ -155,6 +155,7 @@ private:
 	GlobalCommandController& commandController;
 	EventDistributor& eventDistributor;
 	std::optional<Event> lastEvent;
+	std::optional<std::tuple<HotKeyInfo, Event>> postponedEvent;
 };
 
 } // namespace openmsx

--- a/src/events/HotKey.hh
+++ b/src/events/HotKey.hh
@@ -24,15 +24,17 @@ class HotKey final : public RTSchedulable, public EventListener
 {
 public:
 	struct HotKeyInfo {
-		HotKeyInfo(Event event_, std::string command_,
-		           bool repeat_ = false, bool passEvent_ = false)
+		HotKeyInfo(Event event_, std::string command_, bool repeat_ = false,
+			   bool passEvent_ = false, bool global_ = false)
 			: event(std::move(event_)), command(std::move(command_))
 			, repeat(repeat_)
-			, passEvent(passEvent_) {}
+			, passEvent(passEvent_)
+			, global(global_) {}
 		Event event;
 		std::string command;
 		bool repeat;
 		bool passEvent; // whether to pass event with args back to command
+		bool global; // whether event has highest priority
 	};
 	using BindMap = std::vector<HotKeyInfo>; // unsorted
 	using KeySet  = std::vector<Event>;   // unsorted
@@ -43,7 +45,7 @@ public:
 	~HotKey();
 
 	void loadInit();
-	void loadBind(std::string_view key, std::string_view cmd, bool repeat, bool event);
+	void loadBind(std::string_view key, std::string_view cmd, bool repeat, bool event, bool global);
 	void loadUnbind(std::string_view key);
 
 	template<typename XmlStream>
@@ -60,6 +62,9 @@ public:
 			}
 			if (info.passEvent) {
 				xml.attribute("event", "true");
+			}
+			if (info.global) {
+				xml.attribute("global", "true");
 			}
 			xml.data(info.command);
 			xml.end("bind");

--- a/src/imgui/ImGuiManager.cc
+++ b/src/imgui/ImGuiManager.cc
@@ -371,7 +371,7 @@ int ImGuiManager::signalEvent(const Event& event)
 		                             SDL_MOUSEBUTTONDOWN, SDL_MOUSEBUTTONUP)) ||
 		    (io.WantCaptureKeyboard &&
 		     sdlEvent.type == one_of(SDL_KEYDOWN, SDL_KEYUP, SDL_TEXTINPUT))) {
-			return EventDistributor::MSX; // block event for the MSX
+			return EventDistributor::POSTPONED; // block postponed events
 		}
 	} else {
 		switch (getType(event)) {


### PR DESCRIPTION
This seems to fix duplicate keyboard events affecting both emulation and ImGui widgets. For instance: pressing PgDown inside memory window debuggable and also rewinding emulation (go_back_one_step).

reference: https://github.com/ocornut/imgui/blob/master/docs/FAQ.md#q-how-can-i-tell-whether-to-dispatch-mousekeyboard-to-dear-imgui-or-my-application

TODO: need to check if it works for mouse events.
