### PR TITLE
Completing slotviewer changes from #1591

### DIFF
--- a/src/imgui/ImGuiDebugger.cc
+++ b/src/imgui/ImGuiDebugger.cc
@@ -679,7 +679,9 @@ void ImGuiDebugger::drawSlots(MSXCPUInterface& cpuInterface, Debugger& debugger)
 						ImGui::StrCat(mapper->getSelectedSegment(page));
 					} else if ((rom = dynamic_cast<MSXRom*>(device)) &&
 						(romBlocks = debugger.findDebuggable(device->getName() + " romblocks"))) {
-						if (unsigned blockSize = RomInfo::getBlockSize(rom->getRomType())) {
+						unsigned blockSize = RomInfo::getBlockSize(rom->getRomType());
+						// Mirrored ROMs are not mappers, so displaying segments doesn't make sense.
+						if (rom->getRomType() != openmsx::ROM_MIRRORED && blockSize > 0) {
 							std::string text;
 							char separator = 'R';
 							for (int offset = 0; offset < 0x4000; offset += blockSize) {


### PR DESCRIPTION
Completing changes introduced in #1591, mirrored ROMs should not display segment information since they are not mappers of any kind, just plain and simple ROM.