### PR TITLE
Using ImGui Shortcuts in Debuggables

### DIFF
--- a/src/Reactor.cc
+++ b/src/Reactor.cc
@@ -233,7 +233,7 @@ void Reactor::init()
 		*globalCommandController, *eventDistributor, *globalSettings);
 	symbolManager = make_unique<SymbolManager>(
 		*globalCommandController);
-	imGuiManager = make_unique<ImGuiManager>(*this);
+	imGuiManager = make_unique<ImGuiManager>(*this, globalCommandController->getSettingsConfig());
 	diskFactory = make_unique<DiskFactory>(
 		*this);
 	diskManipulator = make_unique<DiskManipulator>(

--- a/src/config/SettingsConfig.hh
+++ b/src/config/SettingsConfig.hh
@@ -3,6 +3,7 @@
 
 #include "SettingsManager.hh"
 #include "Command.hh"
+#include "Shortcuts.hh"
 #include "hash_map.hh"
 #include "xxhash.hh"
 #include <string>
@@ -34,8 +35,11 @@ public:
 	void setValueForSetting(std::string_view setting, std::string_view value);
 	void removeValueForSetting(std::string_view setting);
 
+	void setShortcuts(Shortcuts& shortcuts_) { shortcuts = &shortcuts_; };
+
 private:
 	CommandController& commandController;
+	Shortcuts* shortcuts;
 
 	struct SaveSettingsCommand final : Command {
 		explicit SaveSettingsCommand(CommandController& commandController);

--- a/src/events/HotKey.hh
+++ b/src/events/HotKey.hh
@@ -57,7 +57,7 @@ public:
 	void saveBindings(XmlStream& xml) const
 	{
 		xml.begin("bindings");
-		// add explicit bind's
+		// add explicit binds
 		for (const auto& k : boundKeys) {
 			xml.begin("bind");
 			xml.attribute("key", toString(k));

--- a/src/imgui/DebuggableEditor.cc
+++ b/src/imgui/DebuggableEditor.cc
@@ -19,7 +19,6 @@
 #include "unreachable.hh"
 
 #include "imgui_stdlib.h"
-#include "imgui_internal.h"
 
 #include <algorithm>
 #include <array>
@@ -242,20 +241,16 @@ void DebuggableEditor::drawContents(const Sizes& s, Debuggable& debuggable, unsi
 
 	std::optional<unsigned> nextAddr;
 	// Move cursor but only apply on next frame so scrolling with be synchronized (because currently we can't change the scrolling while the window is being rendered)
-	if (addrMode == CURSOR && ImGui::IsWindowFocused(ImGuiFocusedFlags_ChildWindows)) {
-		if (ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_UpArrow)) &&
-			int(currentAddr) >= columns) {
+	if (addrMode == CURSOR) {
+		auto& shortcuts = manager.getShortcuts();
+		if (shortcuts.checkShortcut(ShortcutIndex::HEX_MOVE_UP) && int(currentAddr) >= columns)
 			nextAddr = currentAddr - columns;
-		} else if (ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_DownArrow)) &&
-				int(currentAddr) < int(memSize - columns)) {
+		if (shortcuts.checkShortcut(ShortcutIndex::HEX_MOVE_DOWN) && int(currentAddr) < int(memSize - columns))
 			nextAddr = currentAddr + columns;
-		} else if (ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_LeftArrow)) &&
-				int(currentAddr) > 0) {
+		if (shortcuts.checkShortcut(ShortcutIndex::HEX_MOVE_LEFT) && int(currentAddr) > 0)
 			nextAddr = currentAddr - 1;
-		} else if (ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_RightArrow)) &&
-				int(currentAddr) < int(memSize - 1)) {
+		if (shortcuts.checkShortcut(ShortcutIndex::HEX_MOVE_RIGHT) && int(currentAddr) < int(memSize - 1))
 			nextAddr = currentAddr + 1;
-		}
 	}
 
 	// Draw vertical separator
@@ -488,7 +483,7 @@ void DebuggableEditor::drawContents(const Sizes& s, Debuggable& debuggable, unsi
 					dataEditingTakeFocus = true;
 				}
 			}
-			if (manager.getShortcuts().checkShortcut(ShortcutIndex::GOTO_MEMORY_ADDRESS)) {
+			if (manager.getShortcuts().checkShortcut(ShortcutIndex::HEX_GOTO_ADDR)) {
 				ImGui::SetKeyboardFocusHere(-1);
 			}
 			simpleToolTip([&]{

--- a/src/imgui/DebuggableEditor.cc
+++ b/src/imgui/DebuggableEditor.cc
@@ -4,6 +4,7 @@
 #include "ImGuiManager.hh"
 #include "ImGuiSettings.hh"
 #include "ImGuiUtils.hh"
+#include "Shortcuts.hh"
 
 #include "CommandException.hh"
 #include "Debuggable.hh"
@@ -487,11 +488,8 @@ void DebuggableEditor::drawContents(const Sizes& s, Debuggable& debuggable, unsi
 					dataEditingTakeFocus = true;
 				}
 			}
-			// invalid shortcut causes SIGTRAP
-			if (auto shortcut = manager.settings.get()->getShortcut(ImGuiSettings::GOTO_ADDRESS)) {
-				if (ImGui::Shortcut(shortcut, 0, ImGuiInputFlags_RouteGlobalLow | ImGuiInputFlags_RouteUnlessBgFocused)) {
-					ImGui::SetKeyboardFocusHere(-1);
-				}
+			if (manager.getShortcuts().checkShortcut(ShortcutIndex::GOTO_MEMORY_ADDRESS)) {
+				ImGui::SetKeyboardFocusHere(-1);
 			}
 			simpleToolTip([&]{
 				return r.error.empty() ? strCat("0x", formatAddr(s, r.addr))

--- a/src/imgui/DebuggableEditor.cc
+++ b/src/imgui/DebuggableEditor.cc
@@ -2,6 +2,7 @@
 
 #include "ImGuiCpp.hh"
 #include "ImGuiManager.hh"
+#include "ImGuiSettings.hh"
 #include "ImGuiUtils.hh"
 
 #include "CommandException.hh"
@@ -486,8 +487,11 @@ void DebuggableEditor::drawContents(const Sizes& s, Debuggable& debuggable, unsi
 					dataEditingTakeFocus = true;
 				}
 			}
-			if (ImGui::Shortcut(manager.getShortcut(ImGuiManager::GOTO_ADDRESS), 0, ImGuiInputFlags_RouteGlobalLow | ImGuiInputFlags_RouteUnlessBgFocused)) {
-				ImGui::SetKeyboardFocusHere(-1);
+			// invalid shortcut causes SIGTRAP
+			if (auto shortcut = manager.settings.get()->getShortcut(ImGuiSettings::GOTO_ADDRESS)) {
+				if (ImGui::Shortcut(shortcut, 0, ImGuiInputFlags_RouteGlobalLow | ImGuiInputFlags_RouteUnlessBgFocused)) {
+					ImGui::SetKeyboardFocusHere(-1);
+				}
 			}
 			simpleToolTip([&]{
 				return r.error.empty() ? strCat("0x", formatAddr(s, r.addr))

--- a/src/imgui/DebuggableEditor.cc
+++ b/src/imgui/DebuggableEditor.cc
@@ -17,6 +17,7 @@
 #include "unreachable.hh"
 
 #include "imgui_stdlib.h"
+#include "imgui_internal.h"
 
 #include <algorithm>
 #include <array>
@@ -484,6 +485,9 @@ void DebuggableEditor::drawContents(const Sizes& s, Debuggable& debuggable, unsi
 					scrollAddr(s, debuggable, memSize, r2.addr);
 					dataEditingTakeFocus = true;
 				}
+			}
+			if (ImGui::Shortcut(manager.getShortcut(ImGuiManager::GOTO_ADDRESS), 0, ImGuiInputFlags_RouteGlobalLow | ImGuiInputFlags_RouteUnlessBgFocused)) {
+				ImGui::SetKeyboardFocusHere(-1);
 			}
 			simpleToolTip([&]{
 				return r.error.empty() ? strCat("0x", formatAddr(s, r.addr))

--- a/src/imgui/ImGuiDebugger.cc
+++ b/src/imgui/ImGuiDebugger.cc
@@ -221,12 +221,19 @@ void ImGuiDebugger::drawControl(MSXCPUInterface& cpuInterface)
 			return result;
 		};
 
+		auto& shortcuts = manager.getShortcuts();
 		bool breaked = cpuInterface.isBreaked();
 		if (breaked) {
+			if (shortcuts.checkShortcut(ShortcutIndex::BREAK)) {
+				cpuInterface.doContinue();
+			}
 			if (ButtonGlyph("run", DEBUGGER_ICON_RUN)) {
 				cpuInterface.doContinue();
 			}
 		} else {
+			if (shortcuts.checkShortcut(ShortcutIndex::BREAK)) {
+				cpuInterface.doBreak();
+			}
 			if (ButtonGlyph("break", DEBUGGER_ICON_BREAK)) {
 				cpuInterface.doBreak();
 			}
@@ -235,6 +242,9 @@ void ImGuiDebugger::drawControl(MSXCPUInterface& cpuInterface)
 		ImGui::SetCursorPosX(50.0f);
 
 		im::Disabled(!breaked, [&]{
+			if (shortcuts.checkShortcut(ShortcutIndex::STEP)) {
+				cpuInterface.doStep();
+			}
 			if (ButtonGlyph("step-in", DEBUGGER_ICON_STEP_IN)) {
 				cpuInterface.doStep();
 			}
@@ -493,9 +503,13 @@ void ImGuiDebugger::drawDisassembly(CPURegs& regs, MSXCPUInterface& cpuInterface
 							auto pos = ImGui::GetCursorPos();
 							ImGui::Selectable("##row", false,
 									ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowOverlap);
+							if (manager.getShortcuts().checkShortcut(ShortcutIndex::DISASM_GOTO_ADDR)) {
+								ImGui::OpenPopup("disassembly-context");
+							}
 							if (!bpRightClick && ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
 								ImGui::OpenPopup("disassembly-context");
 							}
+
 							auto addrStr = tmpStrCat(hex_string<4>(addr));
 							im::Popup("disassembly-context", [&]{
 								auto addrToolTip = [&](const std::string& str) {

--- a/src/imgui/ImGuiManager.cc
+++ b/src/imgui/ImGuiManager.cc
@@ -152,8 +152,9 @@ static void cleanupImGui()
 }
 
 
-ImGuiManager::ImGuiManager(Reactor& reactor_)
+ImGuiManager::ImGuiManager(Reactor& reactor_, SettingsConfig& config_)
 	: reactor(reactor_)
+	, shortcuts(config_)
 	, fontPropFilename(reactor.getCommandController(), "gui_font_default_filename", "TTF font filename for the default GUI font", "DejaVuSans.ttf.gz")
 	, fontMonoFilename(reactor.getCommandController(), "gui_font_mono_filename", "TTF font filename for the monospaced GUI font", "DejaVuSansMono.ttf.gz")
 	, fontPropSize(reactor.getCommandController(), "gui_font_default_size", "size for the default GUI font", 13, 9, 72)

--- a/src/imgui/ImGuiManager.cc
+++ b/src/imgui/ImGuiManager.cc
@@ -241,19 +241,6 @@ ImGuiManager::ImGuiManager(Reactor& reactor_)
 	fontMonoFilename.attach(*this);
 	fontPropSize.attach(*this);
 	fontMonoSize.attach(*this);
-
-	// shortcuts
-	initDefaultShortcuts();
-}
-
-void ImGuiManager::initDefaultShortcuts()
-{
-	shortcuts[GOTO_ADDRESS] = ImGuiMod_Ctrl | ImGuiKey_G; // Ctrl+G
-}
-
-ImGuiKeyChord ImGuiManager::getShortcut(ShortcutIndex index)
-{
-	return shortcuts[index];
 }
 
 ImGuiManager::~ImGuiManager()

--- a/src/imgui/ImGuiManager.cc
+++ b/src/imgui/ImGuiManager.cc
@@ -241,6 +241,19 @@ ImGuiManager::ImGuiManager(Reactor& reactor_)
 	fontMonoFilename.attach(*this);
 	fontPropSize.attach(*this);
 	fontMonoSize.attach(*this);
+
+	// shortcuts
+	initDefaultShortcuts();
+}
+
+void ImGuiManager::initDefaultShortcuts()
+{
+	shortcuts[GOTO_ADDRESS] = ImGuiMod_Ctrl | ImGuiKey_G; // Ctrl+G
+}
+
+ImGuiKeyChord ImGuiManager::getShortcut(ShortcutIndex index)
+{
+	return shortcuts[index];
 }
 
 ImGuiManager::~ImGuiManager()

--- a/src/imgui/ImGuiManager.hh
+++ b/src/imgui/ImGuiManager.hh
@@ -158,6 +158,10 @@ public:
 	bool needReloadFont = false;
 	std::string loadIniFile;
 
+	// Shortcuts
+	enum ShortcutIndex { GOTO_ADDRESS, NUM };
+	ImGuiKeyChord getShortcut(ShortcutIndex index);
+
 private:
 	std::vector<std::function<void()>> delayedActionQueue;
 	float menuAlpha = 1.0f;
@@ -180,6 +184,10 @@ private:
 		PersistentElement{"mainMenuBarFade",     &ImGuiManager::menuFade},
 		PersistentElement{"windowPos",           &ImGuiManager::windowPos}
 	};
+
+	// Shortcuts
+	void initDefaultShortcuts();
+	std::array<ImGuiKeyChord, ShortcutIndex::NUM> shortcuts;
 };
 
 // Parse machine or extension config files:

--- a/src/imgui/ImGuiManager.hh
+++ b/src/imgui/ImGuiManager.hh
@@ -3,6 +3,7 @@
 
 #include "ImGuiPartInterface.hh"
 #include "ImGuiUtils.hh"
+#include "Shortcuts.hh"
 
 #include "EventListener.hh"
 #include "FilenameSetting.hh"
@@ -59,13 +60,14 @@ public:
 	ImGuiManager(const ImGuiManager&) = delete;
 	ImGuiManager& operator=(const ImGuiManager&) = delete;
 
-	explicit ImGuiManager(Reactor& reactor_);
+	explicit ImGuiManager(Reactor& reactor_, SettingsConfig& config_);
 	~ImGuiManager();
 
 	void   registerPart(ImGuiPartInterface* part);
 	void unregisterPart(ImGuiPartInterface* part);
 
 	[[nodiscard]] Reactor& getReactor() { return reactor; }
+	[[nodiscard]] Shortcuts& getShortcuts() { return shortcuts; }
 	[[nodiscard]] Interpreter& getInterpreter();
 	[[nodiscard]] CliComm& getCliComm();
 	std::optional<TclObject> execute(TclObject command);
@@ -119,6 +121,7 @@ private:
 	std::vector<ImGuiPartInterface*> parts;
 	std::vector<ImGuiPartInterface*> toBeAddedParts;
 	bool removeParts = false;
+	Shortcuts shortcuts;
 
 public:
 	FilenameSetting fontPropFilename;
@@ -180,7 +183,6 @@ private:
 		PersistentElement{"mainMenuBarFade",     &ImGuiManager::menuFade},
 		PersistentElement{"windowPos",           &ImGuiManager::windowPos}
 	};
-
 };
 
 // Parse machine or extension config files:

--- a/src/imgui/ImGuiManager.hh
+++ b/src/imgui/ImGuiManager.hh
@@ -158,10 +158,6 @@ public:
 	bool needReloadFont = false;
 	std::string loadIniFile;
 
-	// Shortcuts
-	enum ShortcutIndex { GOTO_ADDRESS, NUM };
-	ImGuiKeyChord getShortcut(ShortcutIndex index);
-
 private:
 	std::vector<std::function<void()>> delayedActionQueue;
 	float menuAlpha = 1.0f;
@@ -185,9 +181,6 @@ private:
 		PersistentElement{"windowPos",           &ImGuiManager::windowPos}
 	};
 
-	// Shortcuts
-	void initDefaultShortcuts();
-	std::array<ImGuiKeyChord, ShortcutIndex::NUM> shortcuts;
 };
 
 // Parse machine or extension config files:

--- a/src/imgui/ImGuiSettings.hh
+++ b/src/imgui/ImGuiSettings.hh
@@ -47,7 +47,6 @@ private:
 	bool showFont = false;
 	bool showShortcut = false;
 	bool showDemoWindow = false;
-	bool showShortcutModal = false;
 
 	unsigned joystick = 0;
 	unsigned popupForKey = unsigned(-1);

--- a/src/imgui/ImGuiSettings.hh
+++ b/src/imgui/ImGuiSettings.hh
@@ -4,6 +4,7 @@
 #include "ImGuiPart.hh"
 
 #include "EventListener.hh"
+#include "Shortcuts.hh"
 
 #include <functional>
 #include <span>
@@ -16,7 +17,7 @@ class ImGuiSettings final : public ImGuiPart, private EventListener
 {
 public:
 	explicit ImGuiSettings(ImGuiManager& manager_)
-		: ImGuiPart(manager_) { initDefaultShortcuts(); }
+		: ImGuiPart(manager_) { }
 	~ImGuiSettings();
 
 	[[nodiscard]] zstring_view iniName() const override { return "settings"; }
@@ -27,13 +28,7 @@ public:
 	void showMenu(MSXMotherBoard* motherBoard) override;
 	void paint(MSXMotherBoard* motherBoard) override;
 
-	// Shortcuts
-	enum ShortcutIndex { GOTO_ADDRESS, SOMETHING_ELSE, NUM };
-	ImGuiKeyChord getShortcut(ShortcutIndex index);
-	void setShortcut(ShortcutIndex index, ImGuiKeyChord keychord);
-
 private:
-	void initDefaultShortcuts();
 	int signalEvent(const Event& event) override;
 	void initListener();
 	void deinitListener();
@@ -41,11 +36,11 @@ private:
 	void setStyle();
 	void paintJoystick(MSXMotherBoard& motherBoard);
 	void paintFont();
+	void paintShortcut();
 
 	std::span<const std::string> getAvailableFonts();
-	void openShortcutPopup(ShortcutIndex index, std::string keychord);
+	void paintShortcutTableItem(ShortcutIndex index);
 	bool shortcutAction(ShortcutIndex index);
-	std::string getShortcutName(ShortcutIndex index) const;
 
 private:
 	bool showConfigureJoystick = false;
@@ -66,9 +61,6 @@ private:
 	std::function<void()> confirmAction;
 
 	std::vector<std::string> availableFonts;
-
-	// Shortcuts
-	std::array<ImGuiKeyChord, ShortcutIndex::NUM> shortcuts;
 
 	static constexpr auto persistentElements = std::tuple{
 		PersistentElement{"style", &ImGuiSettings::selectedStyle},

--- a/src/imgui/ImGuiSettings.hh
+++ b/src/imgui/ImGuiSettings.hh
@@ -16,7 +16,7 @@ class ImGuiSettings final : public ImGuiPart, private EventListener
 {
 public:
 	explicit ImGuiSettings(ImGuiManager& manager_)
-		: ImGuiPart(manager_) {}
+		: ImGuiPart(manager_) { initDefaultShortcuts(); }
 	~ImGuiSettings();
 
 	[[nodiscard]] zstring_view iniName() const override { return "settings"; }
@@ -27,7 +27,13 @@ public:
 	void showMenu(MSXMotherBoard* motherBoard) override;
 	void paint(MSXMotherBoard* motherBoard) override;
 
+	// Shortcuts
+	enum ShortcutIndex { GOTO_ADDRESS, SOMETHING_ELSE, NUM };
+	ImGuiKeyChord getShortcut(ShortcutIndex index);
+	void setShortcut(ShortcutIndex index, ImGuiKeyChord keychord);
+
 private:
+	void initDefaultShortcuts();
 	int signalEvent(const Event& event) override;
 	void initListener();
 	void deinitListener();
@@ -37,11 +43,16 @@ private:
 	void paintFont();
 
 	std::span<const std::string> getAvailableFonts();
+	void openShortcutPopup(ShortcutIndex index, std::string keychord);
+	bool shortcutAction(ShortcutIndex index);
+	std::string getShortcutName(ShortcutIndex index) const;
 
 private:
 	bool showConfigureJoystick = false;
 	bool showFont = false;
+	bool showShortcut = false;
 	bool showDemoWindow = false;
+	bool showShortcutModal = false;
 
 	unsigned joystick = 0;
 	unsigned popupForKey = unsigned(-1);
@@ -55,6 +66,9 @@ private:
 	std::function<void()> confirmAction;
 
 	std::vector<std::string> availableFonts;
+
+	// Shortcuts
+	std::array<ImGuiKeyChord, ShortcutIndex::NUM> shortcuts;
 
 	static constexpr auto persistentElements = std::tuple{
 		PersistentElement{"style", &ImGuiSettings::selectedStyle},

--- a/src/imgui/ImGuiUtils.cc
+++ b/src/imgui/ImGuiUtils.cc
@@ -293,7 +293,6 @@ std::string getKeyChordName(ImGuiKeyChord keychord)
 		ImGui::GetKeyName(ImGuiKey(keychord & ~ImGuiMod_Mask_)));
 }
 
-
 void setColors(int style)
 {
 	// style: 0->dark, 1->light, 2->classic

--- a/src/imgui/ImGuiUtils.cc
+++ b/src/imgui/ImGuiUtils.cc
@@ -283,6 +283,17 @@ std::string getShortCutForCommand(const HotKey& hotkey, std::string_view command
 	return "";
 }
 
+// adapted from imgui_internal.h
+std::string getKeyChordName(ImGuiKeyChord keychord)
+{
+	return strCat((keychord & ImGuiMod_Ctrl ? "Ctrl+" : ""),
+		(keychord & ImGuiMod_Shift ? "Shift+" : ""),
+		(keychord & ImGuiMod_Alt ? "Alt+" : ""),
+		(keychord & ImGuiMod_Super ? (ImGui::GetIO().ConfigMacOSXBehaviors ? "Cmd+" : "Super+") : ""),
+		ImGui::GetKeyName(ImGuiKey(keychord & ~ImGuiMod_Mask_)));
+}
+
+
 void setColors(int style)
 {
 	// style: 0->dark, 1->light, 2->classic

--- a/src/imgui/ImGuiUtils.hh
+++ b/src/imgui/ImGuiUtils.hh
@@ -235,7 +235,9 @@ static void chunk_by(Range&& range, BinaryPred pred, Action action)
 
 std::string getShortCutForCommand(const HotKey& hotkey, std::string_view command);
 
-std::string getKeyChordName(ImGuiKeyChord keychord);
+std::string getKeyChordName(ImGuiKeyChord keyChord);
+
+std::optional<ImGuiKeyChord> getKeyChordValue(std::string_view name);
 
 enum class imColor : unsigned {
 	TRANSPARENT,

--- a/src/imgui/ImGuiUtils.hh
+++ b/src/imgui/ImGuiUtils.hh
@@ -235,6 +235,7 @@ static void chunk_by(Range&& range, BinaryPred pred, Action action)
 
 std::string getShortCutForCommand(const HotKey& hotkey, std::string_view command);
 
+std::string getKeyChordName(ImGuiKeyChord keychord);
 
 enum class imColor : unsigned {
 	TRANSPARENT,

--- a/src/imgui/KeyMappings.hh
+++ b/src/imgui/KeyMappings.hh
@@ -1,0 +1,167 @@
+#ifndef KEYMAPPINGS_HH
+#define KEYMAPPINGS_HH
+
+#include "ranges.hh"
+
+#include <imgui.h>
+#include <array>
+
+#include <SDL.h>
+
+namespace openmsx {
+
+// Here we define th mapping between ImGui and SDL (just once).
+// This will be used to generate two mapping functions (for both directions).
+struct ImGui_SDL_Key {
+	ImGuiKey imgui;
+	SDL_Keycode sdl;
+};
+
+static constexpr auto unsortedKeys = std::to_array<ImGui_SDL_Key>({
+	{ImGuiKey_Tab,            SDLK_TAB},
+	{ImGuiKey_LeftArrow,      SDLK_LEFT},
+	{ImGuiKey_RightArrow,     SDLK_RIGHT},
+	{ImGuiKey_UpArrow,        SDLK_UP},
+	{ImGuiKey_DownArrow,      SDLK_DOWN},
+	{ImGuiKey_PageUp,         SDLK_PAGEUP},
+	{ImGuiKey_PageDown,       SDLK_PAGEDOWN},
+	{ImGuiKey_Home,           SDLK_HOME},
+	{ImGuiKey_End,            SDLK_END},
+	{ImGuiKey_Insert,         SDLK_INSERT},
+	{ImGuiKey_Delete,         SDLK_DELETE},
+	{ImGuiKey_Backspace,      SDLK_BACKSPACE},
+	{ImGuiKey_Space,          SDLK_SPACE},
+	{ImGuiKey_Enter,          SDLK_RETURN},
+	{ImGuiKey_Escape,         SDLK_ESCAPE},
+	{ImGuiKey_Apostrophe,     SDLK_QUOTE},
+	{ImGuiKey_Comma,          SDLK_COMMA},
+	{ImGuiKey_Minus,          SDLK_MINUS},
+	{ImGuiKey_Period,         SDLK_PERIOD},
+	{ImGuiKey_Slash,          SDLK_SLASH},
+	{ImGuiKey_Semicolon,      SDLK_SEMICOLON},
+	{ImGuiKey_Equal,          SDLK_EQUALS},
+	{ImGuiKey_LeftBracket,    SDLK_LEFTBRACKET},
+	{ImGuiKey_Backslash,      SDLK_BACKSLASH},
+	{ImGuiKey_RightBracket,   SDLK_RIGHTBRACKET},
+	{ImGuiKey_GraveAccent,    SDLK_BACKQUOTE},
+	{ImGuiKey_CapsLock,       SDLK_CAPSLOCK},
+	{ImGuiKey_ScrollLock,     SDLK_SCROLLLOCK},
+	{ImGuiKey_NumLock,        SDLK_NUMLOCKCLEAR},
+	{ImGuiKey_PrintScreen,    SDLK_PRINTSCREEN},
+	{ImGuiKey_Pause,          SDLK_PAUSE},
+	{ImGuiKey_Keypad0,        SDLK_KP_0},
+	{ImGuiKey_Keypad1,        SDLK_KP_1},
+	{ImGuiKey_Keypad2,        SDLK_KP_2},
+	{ImGuiKey_Keypad3,        SDLK_KP_3},
+	{ImGuiKey_Keypad4,        SDLK_KP_4},
+	{ImGuiKey_Keypad5,        SDLK_KP_5},
+	{ImGuiKey_Keypad6,        SDLK_KP_6},
+	{ImGuiKey_Keypad7,        SDLK_KP_7},
+	{ImGuiKey_Keypad8,        SDLK_KP_8},
+	{ImGuiKey_Keypad9,        SDLK_KP_9},
+	{ImGuiKey_KeypadDecimal,  SDLK_KP_PERIOD},
+	{ImGuiKey_KeypadDivide,   SDLK_KP_DIVIDE},
+	{ImGuiKey_KeypadMultiply, SDLK_KP_MULTIPLY},
+	{ImGuiKey_KeypadSubtract, SDLK_KP_MINUS},
+	{ImGuiKey_KeypadAdd,      SDLK_KP_PLUS},
+	{ImGuiKey_KeypadEnter,    SDLK_KP_ENTER},
+	{ImGuiKey_KeypadEqual,    SDLK_KP_EQUALS},
+	{ImGuiKey_LeftCtrl,       SDLK_LCTRL},
+	{ImGuiKey_LeftShift,      SDLK_LSHIFT},
+	{ImGuiKey_LeftAlt,        SDLK_LALT},
+	{ImGuiKey_LeftSuper,      SDLK_LGUI},
+	{ImGuiKey_RightCtrl,      SDLK_RCTRL},
+	{ImGuiKey_RightShift,     SDLK_RSHIFT},
+	{ImGuiKey_RightAlt,       SDLK_RALT},
+	{ImGuiKey_RightSuper,     SDLK_RGUI},
+	{ImGuiKey_Menu,           SDLK_APPLICATION},
+	{ImGuiKey_0,              SDLK_0},
+	{ImGuiKey_1,              SDLK_1},
+	{ImGuiKey_2,              SDLK_2},
+	{ImGuiKey_3,              SDLK_3},
+	{ImGuiKey_4,              SDLK_4},
+	{ImGuiKey_5,              SDLK_5},
+	{ImGuiKey_6,              SDLK_6},
+	{ImGuiKey_7,              SDLK_7},
+	{ImGuiKey_8,              SDLK_8},
+	{ImGuiKey_9,              SDLK_9},
+	{ImGuiKey_A,              SDLK_a},
+	{ImGuiKey_B,              SDLK_b},
+	{ImGuiKey_C,              SDLK_c},
+	{ImGuiKey_D,              SDLK_d},
+	{ImGuiKey_E,              SDLK_e},
+	{ImGuiKey_F,              SDLK_f},
+	{ImGuiKey_G,              SDLK_g},
+	{ImGuiKey_H,              SDLK_h},
+	{ImGuiKey_I,              SDLK_i},
+	{ImGuiKey_J,              SDLK_j},
+	{ImGuiKey_K,              SDLK_k},
+	{ImGuiKey_L,              SDLK_l},
+	{ImGuiKey_M,              SDLK_m},
+	{ImGuiKey_N,              SDLK_n},
+	{ImGuiKey_O,              SDLK_o},
+	{ImGuiKey_P,              SDLK_p},
+	{ImGuiKey_Q,              SDLK_q},
+	{ImGuiKey_R,              SDLK_r},
+	{ImGuiKey_S,              SDLK_s},
+	{ImGuiKey_T,              SDLK_t},
+	{ImGuiKey_U,              SDLK_u},
+	{ImGuiKey_V,              SDLK_v},
+	{ImGuiKey_W,              SDLK_w},
+	{ImGuiKey_X,              SDLK_x},
+	{ImGuiKey_Y,              SDLK_y},
+	{ImGuiKey_Z,              SDLK_z},
+	{ImGuiKey_F1,             SDLK_F1},
+	{ImGuiKey_F2,             SDLK_F2},
+	{ImGuiKey_F3,             SDLK_F3},
+	{ImGuiKey_F4,             SDLK_F4},
+	{ImGuiKey_F5,             SDLK_F5},
+	{ImGuiKey_F6,             SDLK_F6},
+	{ImGuiKey_F7,             SDLK_F7},
+	{ImGuiKey_F8,             SDLK_F8},
+	{ImGuiKey_F9,             SDLK_F9},
+	{ImGuiKey_F10,            SDLK_F10},
+	{ImGuiKey_F11,            SDLK_F11},
+	{ImGuiKey_F12,            SDLK_F12},
+	{ImGuiKey_F13,            SDLK_F13},
+	{ImGuiKey_F14,            SDLK_F14},
+	{ImGuiKey_F15,            SDLK_F15},
+	{ImGuiKey_F16,            SDLK_F16},
+	{ImGuiKey_F17,            SDLK_F17},
+	{ImGuiKey_F18,            SDLK_F18},
+	{ImGuiKey_F19,            SDLK_F19},
+	{ImGuiKey_F20,            SDLK_F20},
+	{ImGuiKey_F21,            SDLK_F21},
+	{ImGuiKey_F22,            SDLK_F22},
+	{ImGuiKey_F23,            SDLK_F23},
+	{ImGuiKey_F24,            SDLK_F24},
+	{ImGuiKey_AppBack,        SDLK_AC_BACK},
+	{ImGuiKey_AppForward,     SDLK_AC_FORWARD},
+	// ... order doesn't matter  (this table does not end up in the final executable)
+});
+
+[[nodiscard]] inline SDL_Keycode ImGuiKey2SDL(ImGuiKey imgui)
+{
+	static constexpr auto lookup = []{
+	    auto result = unsortedKeys;
+	    ranges::sort(result, {}, &ImGui_SDL_Key::imgui);
+	    return result;
+	}();
+	auto it = ranges::lower_bound(lookup, imgui, {}, &ImGui_SDL_Key::imgui);
+	return ((it != lookup.end()) && (it->imgui == imgui)) ? it->sdl : SDLK_UNKNOWN;
+}
+
+[[nodiscard]] inline ImGuiKey SDLKey2ImGui(SDL_Keycode sdl)
+{
+	static constexpr auto lookup = []{
+	    auto result = unsortedKeys;
+	    ranges::sort(result, {}, &ImGui_SDL_Key::sdl);
+	    return result;
+	}();
+	auto it = ranges::lower_bound(lookup, sdl, {}, &ImGui_SDL_Key::sdl);
+	return ((it != lookup.end()) && (it->sdl == sdl)) ? it->imgui : ImGuiKey_None;
+}
+
+} // namespace openmsx
+
+#endif

--- a/src/imgui/Shortcuts.cc
+++ b/src/imgui/Shortcuts.cc
@@ -7,10 +7,85 @@
 
 namespace openmsx {
 
-static constexpr auto defaultShortcuts = std::array{
-	Shortcuts::Data{ImGuiMod_Ctrl | ImGuiKey_G, ShortcutType::LOCAL, false},
-	Shortcuts::Data{ImGuiMod_None             , ShortcutType::LOCAL, false},
+//-- (Only) the table in this section will be edited when adding new shortcuts
+
+struct AllShortcutInfo {
+    ShortcutIndex index;
+    ImGuiKeyChord keyChord;
+    ShortcutType type;
+    bool repeat;
+    std::string_view name; // used in settings.xml
+    std::string_view description; // shown in GUI
 };
+
+// When adding a new Shortcut, we only:
+//  * Add a new value in the above 'enum ShortcutIndex'
+//  * Add a single line in this table
+// Note: if you look at the generated code on the right, this table does NOT end up in the generated code
+//       instead it's only used to calculate various other tables (that do end up in the generated code)
+//       those 'calculations' are all done at compile-time
+// Note: the first column is ONLY used to verify (at-compile-time) whether the rows in this
+//       table are in the same order as the values in ShortcutIndex
+static constexpr auto allShortcutInfo = std::to_array<AllShortcutInfo>({
+//   Index             keychord                    global                repeat name                       description
+    {HEX_GOTO_ADDR,    ImGuiMod_Ctrl | ImGuiKey_G, ShortcutType::LOCAL,  false, "hex_editor_goto_address", "Go to address in hex viewer"},
+    {STEP,             ImGuiKey_F6,                ShortcutType::GLOBAL, true,  "step",                    "Single step in debugger"},
+    {BREAK,            ImGuiKey_F7,                ShortcutType::GLOBAL, false, "break",                   "Break CPU emulation in debugger"},
+    {DISASM_GOTO_ADDR, ImGuiMod_Ctrl | ImGuiKey_G, ShortcutType::LOCAL,  false, "disasm_goto_address",     "Go to address in dissassembler"},
+    {HEX_MOVE_UP,      ImGuiKey_UpArrow,           ShortcutType::LOCAL,  true,  "hex_editor_move_up",      "Move up in hex viewer"},
+    {HEX_MOVE_DOWN,    ImGuiKey_DownArrow,         ShortcutType::LOCAL,  true,  "hex_editor_move_down",    "Move down in hex viewer"},
+    {HEX_MOVE_LEFT,    ImGuiKey_LeftArrow,         ShortcutType::LOCAL,  true,  "hex_editor_move_left",    "Move left in hex viewer"},
+    {HEX_MOVE_RIGHT,   ImGuiKey_RightArrow,        ShortcutType::LOCAL,  true,  "hex_editor_move_right",   "Move right hex viewer"},
+});
+static_assert(allShortcutInfo.size() == ShortcutIndex::NUM_SHORTCUTS);
+
+std::string_view Shortcuts::getLargerDescription()
+{
+	static constexpr auto MAX_DESCRIPTION = []{
+		size_t max = 0;
+		size_t imax = 0;
+		for (size_t i = 0; i < allShortcutInfo.size(); ++i) {
+			const auto& info = allShortcutInfo[i];
+			if (info.description.size() > max) {
+				max = info.description.size();
+				imax = i;
+			}
+		}
+		return std::string_view(allShortcutInfo[imax].description);
+	}();
+	return MAX_DESCRIPTION;
+}
+
+// Note: if we forget a row we get a compile error.
+//       if we swap the order of some rows we also get a compile error (when asserts are enabled)
+
+static constexpr auto defaultShortcuts = []{
+    std::array<Shortcuts::Data, ShortcutIndex::NUM_SHORTCUTS> result = {};
+    for (int i = 0; i < ShortcutIndex::NUM_SHORTCUTS; ++i) {
+        auto& all = allShortcutInfo[i];
+        assert(all.index == i); // verify that table is in-order
+        result[i].keyChord = all.keyChord;
+        result[i].type     = all.type;
+        result[i].repeat   = all.repeat;
+    }
+    return result;
+}();
+
+static constexpr auto shortcutNames = []{
+    std::array<std::string_view, ShortcutIndex::NUM_SHORTCUTS> result = {};
+    for (int i = 0; i < ShortcutIndex::NUM_SHORTCUTS; ++i) {
+        result[i] = allShortcutInfo[i].name;
+    }
+    return result;
+}();
+
+static constexpr auto shortcutDescriptions = []{
+    std::array<std::string_view, ShortcutIndex::NUM_SHORTCUTS> result = {};
+    for (int i = 0; i < ShortcutIndex::NUM_SHORTCUTS; ++i) {
+        result[i] = allShortcutInfo[i].description;
+    }
+    return result;
+}();
 
 Shortcuts::Shortcuts(SettingsConfig& config)
 	: shortcuts{}
@@ -21,59 +96,69 @@ Shortcuts::Shortcuts(SettingsConfig& config)
 
 void Shortcuts::setDefaultShortcuts()
 {
-	int index = 0;
-	for (const auto& shortcut : defaultShortcuts) {
-		setShortcut(static_cast<ShortcutIndex>(index++), shortcut.keychord, shortcut.local, shortcut.repeat);
-	}
+	shortcuts = defaultShortcuts;
 }
 
-Shortcuts::Data& Shortcuts::getShortcut(ShortcutIndex index)
+const Shortcuts::Data& Shortcuts::getDefaultShortcut(ShortcutIndex index)
+{
+	assert(index < ShortcutIndex::NUM_SHORTCUTS);
+	return defaultShortcuts[index];
+}
+
+const Shortcuts::Data& Shortcuts::getShortcut(ShortcutIndex index)
 {
 	assert(index < ShortcutIndex::NUM_SHORTCUTS);
 	return shortcuts[index];
 }
 
-void Shortcuts::setShortcut(ShortcutIndex index, std::optional<ImGuiKeyChord> keychord, std::optional<bool> local, std::optional<bool> repeat)
+void Shortcuts::setShortcut(ShortcutIndex index, std::optional<ImGuiKeyChord> keyChord, std::optional<ShortcutType> type, std::optional<bool> repeat)
 {
 	assert(index < ShortcutIndex::NUM_SHORTCUTS);
-	if (keychord) shortcuts[index].keychord = *keychord;
-	if (local) shortcuts[index].local = *local;
-	if (repeat) shortcuts[index].repeat = *repeat;
+	if (keyChord) shortcuts[index].keyChord = *keyChord;
+	if (type)     shortcuts[index].type     = *type;
+	if (repeat)   shortcuts[index].repeat   = *repeat;
 }
 
 void Shortcuts::setDefaultShortcut(ShortcutIndex index)
 {
-	const auto& shortcut = defaultShortcuts[index];
-	setShortcut(index, shortcut.keychord, shortcut.local, shortcut.repeat);
+	assert(index < ShortcutIndex::NUM_SHORTCUTS);
+	shortcuts[index] = defaultShortcuts[index];
 }
 
-std::string Shortcuts::getShortcutName(ShortcutIndex index)
+std::string_view Shortcuts::getShortcutName(ShortcutIndex index)
 {
 	assert(index < ShortcutIndex::NUM_SHORTCUTS);
-	static constexpr auto shortcutNames = std::array{
-		"GotoMemoryAddress", "GotoDisasmAddress"
-	};
 	return shortcutNames[index];
 }
 
-std::string Shortcuts::getShortcutDescription(ShortcutIndex index)
+std::optional<ShortcutIndex> Shortcuts::getShortcutIndex(std::string_view name)
+{
+        auto it = ranges::find(shortcutNames, name);
+        if (it == shortcutNames.end()) return {};
+        return static_cast<ShortcutIndex>(std::distance(shortcutNames.begin(), it));
+}
+
+std::optional<ShortcutType> Shortcuts::getShortcutTypeValue(std::string_view name)
+{
+	static constexpr auto typeNames = std::array{ "local", "global" };
+        auto it = ranges::find(typeNames, name);
+        if (it == typeNames.end()) return {};
+        return static_cast<ShortcutType>(std::distance(typeNames.begin(), it));
+}
+
+std::string_view Shortcuts::getShortcutDescription(ShortcutIndex index)
 {
 	assert(index < ShortcutIndex::NUM_SHORTCUTS);
-	static constexpr auto shortcutNames = std::array{
-		"go to memory widget address",
-		"go to disassembler widget address",
-	};
-	return shortcutNames[index];
+	return shortcutDescriptions[index];
 }
 
 bool Shortcuts::checkShortcut(ShortcutIndex index)
 {
 	assert(index < ShortcutIndex::NUM_SHORTCUTS);
 	auto& shortcut = shortcuts[index];
-	auto flags = (shortcut.local ? ImGuiInputFlags_RouteUnlessBgFocused : ImGuiInputFlags_RouteGlobalLow | ImGuiInputFlags_RouteUnlessBgFocused)
-		| (shortcut.repeat ? ImGuiInputFlags_Repeat : 0);
-	// invalid shortcut causes SIGTRAP so we test if keychord is valid
-	return shortcut.keychord && ImGui::Shortcut(shortcut.keychord, 0, flags);
+	auto flags = (shortcut.type == GLOBAL ? ImGuiInputFlags_RouteGlobalLow | ImGuiInputFlags_RouteUnlessBgFocused : ImGuiInputFlags_RouteUnlessBgFocused) | (shortcut.repeat ? ImGuiInputFlags_Repeat : 0);
+	// invalid shortcut causes SIGTRAP so we test if keyChord is valid
+	return shortcut.keyChord && ImGui::Shortcut(shortcut.keyChord, 0, flags);
 }
 
 }

--- a/src/imgui/Shortcuts.cc
+++ b/src/imgui/Shortcuts.cc
@@ -1,0 +1,79 @@
+#include "Shortcuts.hh"
+#include "imgui_internal.h"
+
+#include "SettingsConfig.hh"
+
+#include <array>
+
+namespace openmsx {
+
+static constexpr auto defaultShortcuts = std::array{
+	Shortcuts::Data{ImGuiMod_Ctrl | ImGuiKey_G, ShortcutType::LOCAL, false},
+	Shortcuts::Data{ImGuiMod_None             , ShortcutType::LOCAL, false},
+};
+
+Shortcuts::Shortcuts(SettingsConfig& config)
+	: shortcuts{}
+{
+	config.setShortcuts(*this);
+	setDefaultShortcuts();
+}
+
+void Shortcuts::setDefaultShortcuts()
+{
+	int index = 0;
+	for (const auto& shortcut : defaultShortcuts) {
+		setShortcut(static_cast<ShortcutIndex>(index++), shortcut.keychord, shortcut.local, shortcut.repeat);
+	}
+}
+
+Shortcuts::Data& Shortcuts::getShortcut(ShortcutIndex index)
+{
+	assert(index < ShortcutIndex::NUM_SHORTCUTS);
+	return shortcuts[index];
+}
+
+void Shortcuts::setShortcut(ShortcutIndex index, std::optional<ImGuiKeyChord> keychord, std::optional<bool> local, std::optional<bool> repeat)
+{
+	assert(index < ShortcutIndex::NUM_SHORTCUTS);
+	if (keychord) shortcuts[index].keychord = *keychord;
+	if (local) shortcuts[index].local = *local;
+	if (repeat) shortcuts[index].repeat = *repeat;
+}
+
+void Shortcuts::setDefaultShortcut(ShortcutIndex index)
+{
+	const auto& shortcut = defaultShortcuts[index];
+	setShortcut(index, shortcut.keychord, shortcut.local, shortcut.repeat);
+}
+
+std::string Shortcuts::getShortcutName(ShortcutIndex index)
+{
+	assert(index < ShortcutIndex::NUM_SHORTCUTS);
+	static constexpr auto shortcutNames = std::array{
+		"GotoMemoryAddress", "GotoDisasmAddress"
+	};
+	return shortcutNames[index];
+}
+
+std::string Shortcuts::getShortcutDescription(ShortcutIndex index)
+{
+	assert(index < ShortcutIndex::NUM_SHORTCUTS);
+	static constexpr auto shortcutNames = std::array{
+		"go to memory widget address",
+		"go to disassembler widget address",
+	};
+	return shortcutNames[index];
+}
+
+bool Shortcuts::checkShortcut(ShortcutIndex index)
+{
+	assert(index < ShortcutIndex::NUM_SHORTCUTS);
+	auto& shortcut = shortcuts[index];
+	auto flags = (shortcut.local ? ImGuiInputFlags_RouteUnlessBgFocused : ImGuiInputFlags_RouteGlobalLow | ImGuiInputFlags_RouteUnlessBgFocused)
+		| (shortcut.repeat ? ImGuiInputFlags_Repeat : 0);
+	// invalid shortcut causes SIGTRAP so we test if keychord is valid
+	return shortcut.keychord && ImGui::Shortcut(shortcut.keychord, 0, flags);
+}
+
+}

--- a/src/imgui/Shortcuts.hh
+++ b/src/imgui/Shortcuts.hh
@@ -1,0 +1,78 @@
+#ifndef IMGUI_SHORTCUTS_HH
+#define IMGUI_SHORTCUTS_HH
+
+#include "ImGuiUtils.hh"
+
+#include "strCat.hh"
+#include "imgui_stdlib.h"
+
+#include <functional>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+namespace openmsx {
+
+class ImGuiManager;
+class GlobalSettings;
+class SettingsConfig;
+
+enum ShortcutIndex {
+	GOTO_MEMORY_ADDRESS = 0,
+	GOTO_DISASM_ADDRESS,
+	NUM_SHORTCUTS,
+};
+
+enum ShortcutType {
+	LOCAL,    // if ImGui widget has focus
+	GLOBAL,   // inside ImGui layer only
+};
+
+class Shortcuts final
+{
+public:
+	Shortcuts(const Shortcuts&) = delete;
+	Shortcuts& operator=(const Shortcuts&) = delete;
+	explicit Shortcuts(SettingsConfig& config_);
+
+	// Shortcuts
+	struct Data {
+		ImGuiKeyChord keychord;
+		bool local = false;
+		bool repeat = false;
+	};
+	static std::string getShortcutName(ShortcutIndex index);
+	static std::string getShortcutDescription(ShortcutIndex index);
+	Shortcuts::Data& getShortcut(ShortcutIndex index);
+	void setShortcut(ShortcutIndex index, std::optional<ImGuiKeyChord> keychord = {}, std::optional<bool> local = {}, std::optional<bool> repeat = {});
+	void setDefaultShortcut(ShortcutIndex index);
+	bool checkShortcut(ShortcutIndex index);
+
+	template<typename XmlStream>
+	void saveShortcuts(XmlStream& xml) const
+	{
+		int index = 0;
+		xml.begin("shortcuts");
+		for (const auto& data : shortcuts) {
+			xml.begin("shortcut");
+			if (data.keychord != ImGuiKey_None) {
+				xml.attribute("keychord", std::to_string(static_cast<int>(data.keychord)));
+			}
+			if (data.repeat) xml.attribute("repeat", "true");
+			if (data.local) xml.attribute("local", "true");
+			xml.data(std::to_string(static_cast<int>(index++)));
+			xml.end("shortcut");
+		}
+		xml.end("shortcuts");
+	}
+
+	void setDefaultShortcuts();
+
+private:
+	// Shortcuts
+	std::array<Shortcuts::Data, ShortcutIndex::NUM_SHORTCUTS> shortcuts;
+};
+
+} // namespace openmsx
+
+#endif


### PR DESCRIPTION
WIP: **Ctrl+G** focus address text input in memory view. It works but...

### Known issues:
ImGui Shortcuts won't stop MSX from receiving the same event if the MSX root window has focus. It repeats Ctrl+G nonstop because I am not blocking the MSX from receiving events. I need to extend `bind` (should I create a `bind <key> -imgui <command>`?) to stop that from happening. So I created a key binding in **keybindinds.tcl** that does nothing but stops MSX from receiving this shortcut.