### PR TITLE
null Platform_SetWindowFocus called when trying to raise window

### DIFF
--- a/src/imgui/ImGuiCpp.hh
+++ b/src/imgui/ImGuiCpp.hh
@@ -88,7 +88,11 @@ inline void Window(const char* name, WindowStatus& status, ImGuiWindowFlags flag
 		if (status.do_raise) {
 			status.do_raise = false;
 			if (!ImGui::IsWindowAppearing()) { // otherwise crash, viewport not yet initialized???
+			// depending on the backend this could be uninitialized
+			if (ImGui::GetPlatformIO().Platform_SetWindowFocus != nullptr)
 				ImGui::GetPlatformIO().Platform_SetWindowFocus(ImGui::GetWindowViewport());
+			else
+				ImGui::SetWindowFocus();
 			}
 		}
 		next();


### PR DESCRIPTION
Seems like almost all `Platform_XXXXXXX()` functions are not implemented by the backend. So calling `Platform_SetWindowFocus()` crashes when a window is already visible and we try to raise it above the others. Fortunately there is another function that fits the bill.

```
(gdb) print ImGui::GetPlatformIO() 
$1 = (ImGuiPlatformIO &) @0x20f20e8: {Platform_CreateWindow = 0x0, Platform_DestroyWindow = 0x0, Platform_ShowWindow = 0x0, 
  Platform_SetWindowPos = 0x0, Platform_GetWindowPos = 0x0, Platform_SetWindowSize = 0x0, Platform_GetWindowSize = 0x0, 
  Platform_SetWindowFocus = 0x0, Platform_GetWindowFocus = 0x0, Platform_GetWindowMinimized = 0x0, 
  Platform_SetWindowTitle = 0x0, Platform_SetWindowAlpha = 0x0, Platform_UpdateWindow = 0x0, Platform_RenderWindow = 0x0, 
  Platform_SwapBuffers = 0x0, Platform_GetWindowDpiScale = 0x0, Platform_OnChangedViewport = 0x0, 
  Platform_CreateVkSurface = 0x0, Renderer_CreateWindow = 0x0, Renderer_DestroyWindow = 0x0, Renderer_SetWindowSize = 0x0, 
  Renderer_RenderWindow = 0x738240 <ImGui_ImplOpenGL3_RenderWindow(ImGuiViewport*, void*)>, Renderer_SwapBuffers = 0x0, 
  Monitors = {Size = 2, Capacity = 8, Data = 0x2329af0}, Viewports = {Size = 1, Capacity = 8, Data = 0x20265a0}}

```