### PR TITLE
fix window not raising above others in main viewport in some cases

### DIFF
--- a/src/imgui/ImGuiCpp.hh
+++ b/src/imgui/ImGuiCpp.hh
@@ -91,9 +91,10 @@ inline void Window(const char* name, WindowStatus& status, ImGuiWindowFlags flag
 				// depending on the backend (e.g. Wayland) this could be nullptr
 				if (auto* swf = ImGui::GetPlatformIO().Platform_SetWindowFocus) {
 					swf(ImGui::GetWindowViewport());
-				} else {
-					ImGui::SetWindowFocus();
 				}
+				// XWayland/GNOME: when window is inside the main viewport, this function is
+				// needed to raise focus even if Platform_SetWindowFocus exists
+				ImGui::SetWindowFocus();
 			}
 		}
 		next();


### PR DESCRIPTION
XWayland+GNOME: when window is inside the main viewport, `ImGui::SetWindowFocus()` is needed to raise focus even if `Platform_SetWindowFocus()` exists.