### PR TITLE
Fix implicit conversion warning from unsigned int to float

### DIFF
--- a/src/imgui/ImGuiCharacter.cc
+++ b/src/imgui/ImGuiCharacter.cc
@@ -377,7 +377,7 @@ void ImGuiCharacter::paint(MSXMotherBoard* motherBoard)
 								gl::vec2 p1 = scrnPos + charZoom * gl::vec2{float(column), float(row)};
 								gl::vec2 p2 = p1 + digitOffset;
 								auto pattern = getPattern(column, row);
-								gl::vec2 uv1{(pattern >> 4) * texDigitWidth, 0.0f};
+								gl::vec2 uv1{narrow_cast<float>(pattern >> 4) * texDigitWidth, 0.0f};
 								gl::vec2 uv2{(pattern & 15) * texDigitWidth, 0.0f};
 								drawList->PrimRectUV(p1, p1 + digitSize, uv1, uv1 + texDigitSize, 0xffffffff);
 								drawList->PrimRectUV(p2, p2 + digitSize, uv2, uv2 + texDigitSize, 0xffffffff);


### PR DESCRIPTION
```
$ ./compile.sh 
Using Python: python3
Build configuration:
Up to date: derived/x86_64-linux-debug/config/Version.ii
  Platform: x86_64-linux
  Flavour:  debug
  Compiler: clang++
  Subset:   full build
Compiling imgui/ImGuiCharacter.cc...
src/imgui/ImGuiCharacter.cc:381:31: warning: implicit conversion from 'unsigned int' to 'float' may lose precision [-Wimplicit-int-float-conversion]
  381 |                                                                 gl::vec2 uv1{(pattern >> 4) * texDigitWidth, 0.0f};
      |                                                                               ~~~~~~~~^~~~  ~
1 warning generated.
Linking openmsx...
```