### PR TITLE
Avoid pkg-config compiler error with Clang 15 (in XCode 15)

### DIFF
--- a/build/3rdparty.mk
+++ b/build/3rdparty.mk
@@ -167,6 +167,7 @@ $(BUILD_DIR)/$(PACKAGE_PKG_CONFIG)/Makefile: \
 		--program-prefix=$(TARGET_TRIPLE)- \
 		--prefix=$(PWD)/$(TOOLS_DIR) \
 		--libdir=$(PWD)/$(INSTALL_DIR)/lib \
+		CFLAGS="-Wno-error=int-conversion" \
 		CC= LD= AR= RANLIB= STRIP=
 
 # Configure SDL2.


### PR DESCRIPTION
In several places in pkg-config’s glib code Clang 15 fails with:

> error: incompatible integer to pointer conversion passing 'gssize'
> (aka 'long') to parameter of type 'gpointer' (aka 'void *')

This is because Clang no longer allows C programs to implicitly convert integers to pointers and pointers to integers, see [1].

Since this code is not under our control, we avoid the compilation failure by turning the error into a warning, like it used to be.

[1] https://reviews.llvm.org/D129881