### PR TITLE
Feature/fix build

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -315,7 +315,7 @@ LINK_FLAGS+=$(TARGET_FLAGS)
 CXX?=g++
 WINDRES?=windres
 DEPEND_FLAGS:=
-ifneq ($(filter %clang++,$(CXX))$(filter clang++%,$(CXX)),)
+ifneq ($(filter %clang++,$(CXX))$(filter clang++%,$(CXX))$(findstring /clang++-,$(CXX)),)
   # Enable C++20 (partially supported since clang-8)
   COMPILE_FLAGS+=-std=c++20 -fconstexpr-steps=2000000
   #COMPILE_FLAGS+=-Wall -Wextra -Wundef -Wno-invalid-offsetof -Wunused-macros -Wdouble-promotion -Wmissing-declarations -Wshadow -Wold-style-cast -Wzero-as-null-pointer-constant

--- a/build/makeutils.py
+++ b/build/makeutils.py
@@ -40,7 +40,7 @@ def joinContinuedLines(lines):
 	if buf:
 		raise ValueError('Continuation on last line')
 
-_reEval = re.compile('(\$\(|\))')
+_reEval = re.compile(r'(\$\(|\))')
 def evalMakeExpr(expr, makeVars):
 	'''Evaluates variable references in an expression.
 	Raises ValueError if there is a syntax error in the expression.


### PR DESCRIPTION
The change in `build/main.mk` removes the error that appears when the `CXX` environment variable for clang++ contains a path and version number.

The change in `build/makeutils.py` removes the warning `Unsupported escape sequence in string literal`. The change has been tested and the function gives the expected output:

```python
>>> import re
>>> _reEval = re.compile(r'(\$\(|\))')
>>> test = "abc $(def)"
>>> _reEval.split(test)
['abc ', '$(', 'def', ')', '']
```