### PR TITLE
Create breakpoints with slot/subslot info in symbol manager

### DIFF
--- a/src/debugger/SymbolManager.cc
+++ b/src/debugger/SymbolManager.cc
@@ -114,38 +114,51 @@ SymbolManager::SymbolManager(CommandController& commandController_)
 	return result;
 }
 
-[[nodiscard]] std::optional<uint16_t> SymbolManager::parseValue(std::string_view str)
+template<typename T>
+[[nodiscard]] std::optional<T> SymbolManager::parseValue(std::string_view str)
 {
 	if (str.ends_with('h') || str.ends_with('H')) { // hex
 		str.remove_suffix(1);
-		return StringOp::stringToBase<16, uint16_t>(str);
+		return StringOp::stringToBase<16, T>(str);
 	}
 	if (str.starts_with('$') || str.starts_with('#')) { // hex
 		str.remove_prefix(1);
-		return StringOp::stringToBase<16, uint16_t>(str);
+		return StringOp::stringToBase<16, T>(str);
 	}
 	if (str.starts_with('%')) { // bin
 		str.remove_prefix(1);
-		return StringOp::stringToBase<2, uint16_t>(str);
+		return StringOp::stringToBase<2, T>(str);
 	}
 	// this recognizes the prefixes "0x" or "0X" (for hexadecimal)
 	//                          and "0b" or "0B" (for binary)
 	// no prefix in interpreted as decimal
 	// "0" as a prefix for octal is intentionally NOT supported
-	return StringOp::stringTo<uint16_t>(str);
+	return StringOp::stringTo<T>(str);
 }
 
-[[nodiscard]] std::optional<Symbol> SymbolManager::checkLabel(std::string_view label, uint16_t value)
+// explicitly instantiate for uint16_t and uint32_t (needed for unittest)
+template std::optional<uint16_t> SymbolManager::parseValue<uint16_t>(std::string_view);
+template std::optional<uint32_t> SymbolManager::parseValue<uint32_t>(std::string_view);
+
+[[nodiscard]] std::optional<Symbol> SymbolManager::checkLabel(std::string_view label, uint32_t value)
 {
 	if (label.ends_with(':')) label.remove_suffix(1);
 	if (label.empty()) return {};
 
-	return Symbol{std::string(label), value};
+	return Symbol{std::string(label), static_cast<uint16_t>(value), {}, static_cast<uint16_t>(value >> 16)};
 }
 
 [[nodiscard]] std::optional<Symbol> SymbolManager::checkLabelAndValue(std::string_view label, std::string_view value)
 {
-	if (auto num = parseValue(value)) {
+	if (auto num = parseValue<uint16_t>(value)) {
+		return checkLabel(label, *num);
+	}
+	return {};
+}
+
+[[nodiscard]] std::optional<Symbol> SymbolManager::checkLabelSegmentAndValue(std::string_view label, std::string_view value)
+{
+	if (auto num = parseValue<uint32_t>(value)) {
 		return checkLabel(label, *num);
 	}
 	return {};
@@ -168,13 +181,14 @@ SymbolManager::SymbolManager(CommandController& commandController_)
 
 [[nodiscard]] SymbolFile SymbolManager::loadNoICE(std::string_view filename, std::string_view buffer)
 {
-	auto parseLine = [](std::span<std::string_view> tokens) -> std::optional<Symbol> {
+	auto parseLine = [&](std::span<std::string_view> tokens) -> std::optional<Symbol> {
 		if (tokens.size() != 3) return {};
 		auto def   = tokens[0];
 		auto label = tokens[1];
 		auto value = tokens[2];
 		if (StringOp::casecmp cmp; !cmp(def, "def")) return {};
-		return checkLabelAndValue(label, value);
+		// detecting segment information above 16bits
+		return checkLabelSegmentAndValue(label, value);
 	};
 	return loadLines(filename, buffer, SymbolFile::Type::NOICE, parseLine);
 }
@@ -324,7 +338,7 @@ SymbolManager::SymbolManager(CommandController& commandController_)
 			if (it == et) break;
 			auto value = *it++; // this could either be the psect or the value column
 			if (auto val = is4DigitHex(value)) {
-				result.symbols.emplace_back(std::string(label), *val);
+				result.symbols.emplace_back(std::string(label), *val, std::nullopt, std::nullopt);
 				continue;
 			}
 
@@ -332,14 +346,14 @@ SymbolManager::SymbolManager(CommandController& commandController_)
 			value = *it++; // try again with 3rd column
 			auto val = is4DigitHex(value);
 			if (!val) break; // if this also doesn't work there's something wrong, skip this line
-			result.symbols.emplace_back(std::string(label), *val);
+			result.symbols.emplace_back(std::string(label), *val, std::nullopt, std::nullopt);
 		}
 	}
 
 	return result;
 }
 
-[[nodiscard]] SymbolFile SymbolManager::loadSymbolFile(const std::string& filename, SymbolFile::Type type)
+[[nodiscard]] SymbolFile SymbolManager::loadSymbolFile(const std::string& filename, SymbolFile::Type type, std::optional<uint8_t> slot)
 {
 	File file(filename);
 	auto buf = file.mmap();
@@ -351,21 +365,31 @@ SymbolManager::SymbolManager(CommandController& commandController_)
 	}
 	assert(type != AUTO_DETECT);
 
-	switch (type) {
-		case ASMSX:
-			return loadASMSX(filename, buffer);
-		case GENERIC:
-			return loadGeneric(filename, buffer);
-		case HTC:
-			return loadHTC(filename, buffer);
-		case LINKMAP:
-			return loadLinkMap(filename, buffer);
-		case NOICE:
-			return loadNoICE(filename, buffer);
-		case VASM:
-			return loadVASM(filename, buffer);
-		default: UNREACHABLE;
+	auto symbolFile = [&]{
+		switch (type) {
+			case ASMSX:
+				return loadASMSX(filename, buffer);
+			case GENERIC:
+				return loadGeneric(filename, buffer);
+			case HTC:
+				return loadHTC(filename, buffer);
+			case LINKMAP:
+				return loadLinkMap(filename, buffer);
+			case NOICE:
+				return loadNoICE(filename, buffer);
+			case VASM:
+				return loadVASM(filename, buffer);
+			default: UNREACHABLE;
+		}
+	}();
+
+	// Update slot info for the file and each of its symbol
+	symbolFile.slot = slot;
+	for (auto& symbol: symbolFile.getSymbols()) {
+		symbol.slot = slot;
 	}
+
+	return symbolFile;
 }
 
 void SymbolManager::refresh()
@@ -386,9 +410,9 @@ void SymbolManager::refresh()
 	if (observer) observer->notifySymbolsChanged();
 }
 
-bool SymbolManager::reloadFile(const std::string& filename, LoadEmpty loadEmpty, SymbolFile::Type type)
+bool SymbolManager::reloadFile(const std::string& filename, LoadEmpty loadEmpty, SymbolFile::Type type, std::optional<uint8_t> slot)
 {
-	auto file = loadSymbolFile(filename, type); // might throw
+	auto file = loadSymbolFile(filename, type, slot); // might throw
 	if (file.symbols.empty() && loadEmpty == LoadEmpty::NOT_ALLOWED) return false;
 
 	if (auto it = ranges::find(files, filename, &SymbolFile::filename);
@@ -434,7 +458,7 @@ std::optional<uint16_t> SymbolManager::parseSymbolOrValue(std::string_view str) 
 		}
 	}
 	// also not found, then try to parse as a numerical value
-	return parseValue(str);
+	return parseValue<uint16_t>(str);
 }
 
 std::span<Symbol const * const> SymbolManager::lookupValue(uint16_t value)
@@ -451,6 +475,15 @@ std::span<Symbol const * const> SymbolManager::lookupValue(uint16_t value)
 		return *sym;
 	}
 	return {};
+}
+
+SymbolFile* SymbolManager::findFile(std::string filename)
+{
+	if (auto it = ranges::find(files, filename, &SymbolFile::filename); it == files.end()) {
+		return nullptr;
+	} else {
+		return &(*it);
+	}
 }
 
 std::string SymbolManager::getFileFilters()

--- a/src/debugger/SymbolManager.hh
+++ b/src/debugger/SymbolManager.hh
@@ -19,11 +19,13 @@ class CommandController;
 
 struct Symbol
 {
-	Symbol(std::string n, uint16_t v)
-		: name(std::move(n)), value(v) {} // clang-15 workaround
+	Symbol(std::string n, uint16_t v, std::optional<uint8_t> s1, std::optional<uint16_t> s2)
+		: name(std::move(n)), value(v), slot(s1), segment(s2) {} // clang-15 workaround
 
 	std::string name;
 	uint16_t value;
+	std::optional<uint8_t> slot;
+	std::optional<uint16_t> segment;
 
 	auto operator<=>(const Symbol&) const = default;
 };
@@ -44,7 +46,9 @@ struct SymbolFile
 	};
 	[[nodiscard]] static zstring_view toString(Type type);
 	[[nodiscard]] static std::optional<Type> parseType(std::string_view str);
+	[[nodiscard]] auto& getSymbols() { return symbols; }
 
+	std::optional<uint8_t> slot;
 	std::string filename;
 	std::vector<Symbol> symbols;
 	Type type;
@@ -72,12 +76,13 @@ public:
 	//   existing file is not replaced and this method returns 'false'.
 	//   Otherwise it return 'true'.
 	enum class LoadEmpty { ALLOWED, NOT_ALLOWED };
-	bool reloadFile(const std::string& filename, LoadEmpty loadEmpty, SymbolFile::Type type);
+	bool reloadFile(const std::string& filename, LoadEmpty loadEmpty, SymbolFile::Type type, std::optional<uint8_t> slot = {});
 
 	void removeFile(std::string_view filename);
 	void removeAllFiles();
 
 	[[nodiscard]] const auto& getFiles() const { return files; }
+	[[nodiscard]] SymbolFile* findFile(std::string filename);
 	[[nodiscard]] std::span<Symbol const * const> lookupValue(uint16_t value);
 	[[nodiscard]] std::optional<uint16_t> parseSymbolOrValue(std::string_view s) const;
 
@@ -88,9 +93,11 @@ public:
 	// These should not be called directly, except by the unittest
 	[[nodiscard]] static std::optional<unsigned> isHexDigit(char c);
 	[[nodiscard]] static std::optional<uint16_t> is4DigitHex(std::string_view s);
-	[[nodiscard]] static std::optional<uint16_t> parseValue(std::string_view str);
-	[[nodiscard]] static std::optional<Symbol> checkLabel(std::string_view label, uint16_t value);
+	template <typename T>
+	[[nodiscard]] static std::optional<T> parseValue(std::string_view str);
+	[[nodiscard]] static std::optional<Symbol> checkLabel(std::string_view label, uint32_t value);
 	[[nodiscard]] static std::optional<Symbol> checkLabelAndValue(std::string_view label, std::string_view value);
+	[[nodiscard]] static std::optional<Symbol> checkLabelSegmentAndValue(std::string_view label, std::string_view value);
 	[[nodiscard]] static SymbolFile::Type detectType(std::string_view filename, std::string_view buffer);
 	[[nodiscard]] static SymbolFile loadLines(
 		std::string_view filename, std::string_view buffer, SymbolFile::Type type,
@@ -101,7 +108,7 @@ public:
 	[[nodiscard]] static SymbolFile loadVASM(std::string_view filename, std::string_view buffer);
 	[[nodiscard]] static SymbolFile loadASMSX(std::string_view filename, std::string_view buffer);
 	[[nodiscard]] static SymbolFile loadLinkMap(std::string_view filename, std::string_view buffer);
-	[[nodiscard]] static SymbolFile loadSymbolFile(const std::string& filename, SymbolFile::Type type);
+	[[nodiscard]] static SymbolFile loadSymbolFile(const std::string& filename, SymbolFile::Type type, std::optional<uint8_t> slot = {});
 
 private:
 	void refresh();

--- a/src/imgui/ImGuiSymbols.cc
+++ b/src/imgui/ImGuiSymbols.cc
@@ -169,7 +169,7 @@ static void checkSort(const SymbolManager& manager, std::vector<SymbolRef>& symb
 
 void ImGuiSymbols::drawContext(MSXMotherBoard* motherBoard, const SymbolRef& sym)
 {
-	if (ImGui::MenuItem("Set breakpoint")) {
+	if (ImGui::MenuItem("Set breakpoint", nullptr, nullptr, motherBoard != nullptr)) {
 		std::string cond;
 		if (auto slot = sym.slot(symbolManager)) {
 			strAppend(cond, "[pc_in_slot ", *slot & 3, ' ', (*slot >> 2) & 3);
@@ -201,8 +201,8 @@ void ImGuiSymbols::drawTable(MSXMotherBoard* motherBoard, const std::string& fil
 	            (FILTER_FILE ? ImGuiTableFlags_ScrollY : 0);
 	im::Table(file.c_str(), (FILTER_FILE ? 4 : 5), flags, {0, 100}, [&]{
 		ImGui::TableSetupScrollFreeze(0, 1); // Make top row always visible
-		ImGui::TableSetupColumn("name");
-		ImGui::TableSetupColumn("value", ImGuiTableColumnFlags_DefaultSort | ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("name", ImGuiTableColumnFlags_NoHide);
+		ImGui::TableSetupColumn("value", ImGuiTableColumnFlags_NoHide | ImGuiTableColumnFlags_DefaultSort | ImGuiTableColumnFlags_WidthFixed);
 		ImGui::TableSetupColumn("slot", ImGuiTableColumnFlags_DefaultHide);
 		ImGui::TableSetupColumn("segment", ImGuiTableColumnFlags_DefaultHide);
 		if (!FILTER_FILE) {

--- a/src/imgui/ImGuiSymbols.cc
+++ b/src/imgui/ImGuiSymbols.cc
@@ -3,6 +3,7 @@
 #include "ImGuiBreakPoints.hh"
 #include "ImGuiCpp.hh"
 #include "ImGuiManager.hh"
+#include "ImGuiDebugger.hh"
 #include "ImGuiOpenFile.hh"
 #include "ImGuiUtils.hh"
 #include "ImGuiWatchExpr.hh"
@@ -10,7 +11,10 @@
 #include "CliComm.hh"
 #include "File.hh"
 #include "Interpreter.hh"
+#include "MSXCliComm.hh"
 #include "MSXException.hh"
+#include "MSXMotherBoard.hh"
+#include "MSXCPUInterface.hh"
 #include "Reactor.hh"
 
 #include "enumerate.hh"
@@ -45,10 +49,16 @@ void ImGuiSymbols::save(ImGuiTextBuffer& buf)
 	for (const auto& file : symbolManager.getFiles()) {
 		buf.appendf("symbolfile=%s\n", file.filename.c_str());
 		buf.appendf("symbolfiletype=%s\n", SymbolFile::toString(file.type).c_str());
+		if (file.slot) {
+			buf.appendf("slotsubslot=%d\n", *file.slot);
+		}
 	}
-	for (const auto& [file, error, type] : fileError) {
+	for (const auto& [file, error, type, slot] : fileError) {
 		buf.appendf("symbolfile=%s\n", file.c_str());
 		buf.appendf("symbolfiletype=%s\n", SymbolFile::toString(type).c_str());
+		if (slot) {
+			buf.appendf("slotsubslot=%d\n", *slot);
+		}
 	}
 }
 
@@ -65,11 +75,18 @@ void ImGuiSymbols::loadLine(std::string_view name, zstring_view value)
 	} else if (name == "symbolfile") {
 		fileError.emplace_back(std::string{value}, // filename
 		                       std::string{}, // error
-		                       SymbolFile::Type::AUTO_DETECT); // type
+		                       SymbolFile::Type::AUTO_DETECT, // type
+				       std::nullopt); // slot-subslot
 	} else if (name == "symbolfiletype") {
 		if (!fileError.empty()) {
 			fileError.back().type =
 				SymbolFile::parseType(value).value_or(SymbolFile::Type::AUTO_DETECT);
+		}
+	} else if (name == "slotsubslot") {
+		if (!fileError.empty()) {
+			if (auto slot = StringOp::stringTo<int>(value)) {
+				fileError.back().slot = slot;
+			}
 		}
 	}
 }
@@ -79,16 +96,16 @@ void ImGuiSymbols::loadEnd()
 	std::vector<FileInfo> tmp;
 	std::swap(tmp, fileError);
 	for (const auto& info : tmp) {
-		loadFile(info.filename, SymbolManager::LoadEmpty::ALLOWED, info.type);
+		loadFile(info.filename, SymbolManager::LoadEmpty::ALLOWED, info.type, info.slot);
 	}
 }
 
-void ImGuiSymbols::loadFile(const std::string& filename, SymbolManager::LoadEmpty loadEmpty, SymbolFile::Type type)
+void ImGuiSymbols::loadFile(const std::string& filename, SymbolManager::LoadEmpty loadEmpty, SymbolFile::Type type, std::optional<uint8_t> slot)
 {
 	auto& cliComm = manager.getCliComm();
 	auto it = ranges::find(fileError, filename, &FileInfo::filename);
 	try {
-		if (!symbolManager.reloadFile(filename, loadEmpty, type)) {
+		if (!symbolManager.reloadFile(filename, loadEmpty, type, slot)) {
 			cliComm.printWarning("Symbol file \"", filename,
 			                     "\" doesn't contain any symbols");
 		}
@@ -100,9 +117,23 @@ void ImGuiSymbols::loadFile(const std::string& filename, SymbolManager::LoadEmpt
 			it->error = e.getMessage(); // overwrite previous error
 			it->type = type;
 		} else {
-			fileError.emplace_back(filename, e.getMessage(), type); // set error
+			fileError.emplace_back(filename, e.getMessage(), type, it->slot); // set error
 		}
 	}
+}
+
+static bool isSlotExpanded(MSXMotherBoard* motherBoard, int ps)
+{
+	return motherBoard != nullptr ? motherBoard->getCPUInterface().isExpanded(ps) : true;
+}
+
+static std::string formatSlot(std::optional<uint8_t> slot, MSXMotherBoard* motherBoard = nullptr)
+{
+	if (!slot) return "-";
+	int ps = (*slot >> 0) & 3;
+	int ss = (*slot >> 2) & 3;
+	return isSlotExpanded(motherBoard, ps) ? strCat(ps, '-', ss)
+	                                       : strCat(ps);
 }
 
 static void checkSort(const SymbolManager& manager, std::vector<SymbolRef>& symbols)
@@ -122,15 +153,39 @@ static void checkSort(const SymbolManager& manager, std::vector<SymbolRef>& symb
 	case 1: // value
 		sortUpDown_T(symbols, sortSpecs, [&](const auto& sym) { return sym.value(manager); });
 		break;
-	case 2: // file
+	case 2: // slot
+		sortUpDown_String(symbols, sortSpecs, [&](const auto& sym) { return formatSlot(sym.slot(manager)); });
+		break;
+	case 3: // segment
+		sortUpDown_T(symbols, sortSpecs, [&](const auto& sym) { return sym.segment(manager); });
+		break;
+	case 4: // file (all symbols)
 		sortUpDown_String(symbols, sortSpecs, [&](const auto& sym) { return sym.file(manager); });
 		break;
 	default:
 		UNREACHABLE;
 	}
 }
+
+void ImGuiSymbols::drawContext(MSXMotherBoard* motherBoard, const SymbolRef& sym)
+{
+	if (ImGui::MenuItem("Set breakpoint")) {
+		std::string cond;
+		if (auto slot = sym.slot(symbolManager)) {
+			strAppend(cond, "[pc_in_slot ", *slot & 3, ' ', (*slot >> 2) & 3);
+			if (auto segment = sym.segment(symbolManager)) {
+				strAppend(cond, ' ', *segment);
+			}
+			strAppend(cond, ']');
+		}
+		BreakPoint newBp(sym.value(symbolManager), TclObject("debug break"), TclObject(cond), false);
+		auto& cpuInterface = motherBoard->getCPUInterface();
+		cpuInterface.insertBreakPoint(std::move(newBp));
+	}
+}
+
 template<bool FILTER_FILE>
-static void drawTable(ImGuiManager& manager, const SymbolManager& symbolManager, std::vector<SymbolRef>& symbols, const std::string& file = {})
+void ImGuiSymbols::drawTable(MSXMotherBoard* motherBoard, const std::string& file)
 {
 	assert(FILTER_FILE == !file.empty());
 
@@ -141,12 +196,15 @@ static void drawTable(ImGuiManager& manager, const SymbolManager& symbolManager,
 	            ImGuiTableFlags_Resizable |
 	            ImGuiTableFlags_Reorderable |
 	            ImGuiTableFlags_Sortable |
+	            ImGuiTableFlags_Hideable |
 	            ImGuiTableFlags_SizingStretchProp |
 	            (FILTER_FILE ? ImGuiTableFlags_ScrollY : 0);
-	im::Table(file.c_str(), FILTER_FILE ? 2 : 3, flags, {0, 100}, [&]{
+	im::Table(file.c_str(), (FILTER_FILE ? 4 : 5), flags, {0, 100}, [&]{
 		ImGui::TableSetupScrollFreeze(0, 1); // Make top row always visible
 		ImGui::TableSetupColumn("name");
 		ImGui::TableSetupColumn("value", ImGuiTableColumnFlags_DefaultSort | ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("slot", ImGuiTableColumnFlags_DefaultHide);
+		ImGui::TableSetupColumn("segment", ImGuiTableColumnFlags_DefaultHide);
 		if (!FILTER_FILE) {
 			ImGui::TableSetupColumn("file");
 		}
@@ -159,10 +217,23 @@ static void drawTable(ImGuiManager& manager, const SymbolManager& symbolManager,
 			if (ImGui::TableNextColumn()) { // name
 				im::ScopedFont sf(manager.fontMono);
 				ImGui::TextUnformatted(sym.name(symbolManager));
+				auto symNameMenu = tmpStrCat("symbol-manager##", sym.name(symbolManager)).data();
+				if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
+					ImGui::OpenPopup(symNameMenu);
+				}
+				im::Popup(symNameMenu, [&]{ drawContext(motherBoard, sym); });
 			}
 			if (ImGui::TableNextColumn()) { // value
 				im::ScopedFont sf(manager.fontMono);
 				ImGui::StrCat(hex_string<4>(sym.value(symbolManager)));
+			}
+			if (ImGui::TableNextColumn()) { // slot
+				im::ScopedFont sf(manager.fontMono);
+				ImGui::TextUnformatted(formatSlot(sym.slot(symbolManager), motherBoard));
+			}
+			if (ImGui::TableNextColumn()) { // segment
+				im::ScopedFont sf(manager.fontMono);
+				ImGui::TextUnformatted(sym.segment(symbolManager) ? tmpStrCat(*sym.segment(symbolManager)).c_str() : "-");
 			}
 			if (!FILTER_FILE && ImGui::TableNextColumn()) { // file
 				ImGui::TextUnformatted(sym.file(symbolManager));
@@ -171,10 +242,11 @@ static void drawTable(ImGuiManager& manager, const SymbolManager& symbolManager,
 	});
 }
 
-void ImGuiSymbols::paint(MSXMotherBoard* /*motherBoard*/)
+void ImGuiSymbols::paint(MSXMotherBoard* motherBoard)
 {
 	if (!show) return;
 
+	const auto& style = ImGui::GetStyle();
 	ImGui::SetNextWindowSize(gl::vec2{24, 18} * ImGui::GetFontSize(), ImGuiCond_FirstUseEver);
 	im::Window("Symbol Manager", &show, [&]{
 		if (ImGui::Button("Load symbol file...")) {
@@ -189,6 +261,7 @@ void ImGuiSymbols::paint(MSXMotherBoard* /*motherBoard*/)
 
 		im::TreeNode("Symbols per file", ImGuiTreeNodeFlags_DefaultOpen, [&]{
 			auto drawFile = [&](const FileInfo& info) {
+				auto* file = symbolManager.findFile(info.filename);
 				im::StyleColor(!info.error.empty(), ImGuiCol_Text, getColor(imColor::ERROR), [&]{
 					auto title = strCat("File: ", info.filename);
 					im::TreeNode(title.c_str(), [&]{
@@ -196,8 +269,45 @@ void ImGuiSymbols::paint(MSXMotherBoard* /*motherBoard*/)
 							ImGui::TextUnformatted(info.error);
 						}
 						im::StyleColor(ImGuiCol_Text, getColor(imColor::TEXT), [&]{
+							auto arrowSize = ImGui::GetFrameHeight();
+							auto extra = arrowSize + 2.0f * style.FramePadding.x;
+							ImGui::SetNextItemWidth(ImGui::CalcTextSize("3-3").x + extra);
+						        ImGui::AlignTextToFramePadding();
+
+							auto preview = formatSlot(file->slot, motherBoard);
+				                        im::Combo(tmpStrCat("Slot##", info.filename).data(), preview.c_str(), [&]{
+								// Set slot and all the symbols in it
+								auto setSlot = [&](std::optional<uint8_t> newSlot) {
+ 									file->slot = newSlot;
+									for (auto& symbol : file->getSymbols()) {
+										symbol.slot = newSlot;
+									}
+								};
+								// initial state
+								if (ImGui::Selectable("-", !file->slot)) {
+									setSlot({});
+								}
+
+								for (uint8_t ps = 0; ps < 4; ++ps) {
+									if (isSlotExpanded(motherBoard, ps)) {
+										for (uint8_t ss = 0; ss < 4; ++ss) {
+											auto slotInfo = tmpStrCat(ps, "-", ss);
+											int psSs = (ss << 2) + ps;
+											if (ImGui::Selectable(slotInfo.c_str(), psSs == file->slot)) {
+												setSlot(psSs);
+											}
+										}
+									} else {
+										if (ImGui::Selectable(tmpStrCat(ps).c_str(), file->slot && ps == file->slot)) {
+											setSlot(ps);
+										}
+									}
+								}
+							});
+							ImGui::SameLine();
+
 							if (ImGui::Button("Reload")) {
-								loadFile(info.filename, SymbolManager::LoadEmpty::NOT_ALLOWED, info.type);
+								loadFile(info.filename, SymbolManager::LoadEmpty::NOT_ALLOWED, info.type, info.slot);
 							}
 							ImGui::SameLine();
 							if (ImGui::Button("Remove")) {
@@ -207,15 +317,14 @@ void ImGuiSymbols::paint(MSXMotherBoard* /*motherBoard*/)
 									fileError.erase(it);
 								}
 							}
-							drawTable<true>(manager, symbolManager, symbols, info.filename);
+							drawTable<true>(motherBoard, info.filename);
 						});
 					});
 				});
 			};
-
 			// make copy because cache may get dropped
-			auto infos = to_vector(view::transform(symbolManager.getFiles(), [](const auto& file) {
-				return FileInfo{file.filename, std::string{}, file.type};
+			auto infos = to_vector(view::transform(symbolManager.getFiles(), [&](const auto& file) {
+				return FileInfo{file.filename, std::string{}, file.type, file.slot};
 			}));
 			append(infos, fileError);
 			for (const auto& info : infos) {
@@ -225,13 +334,13 @@ void ImGuiSymbols::paint(MSXMotherBoard* /*motherBoard*/)
 		});
 		im::TreeNode("All symbols", [&]{
 			if (ImGui::Button("Reload all")) {
-				auto tmp = to_vector(view::transform(symbolManager.getFiles(), [](const auto& file) {
-					return FileInfo{file.filename, std::string{}, file.type};
+				auto tmp = to_vector(view::transform(symbolManager.getFiles(), [&](const auto& file) {
+					return FileInfo{file.filename, std::string{}, file.type, file.slot};
 				}));
 				append(tmp, std::move(fileError));
 				fileError.clear();
 				for (const auto& info : tmp) {
-					loadFile(info.filename, SymbolManager::LoadEmpty::NOT_ALLOWED, info.type);
+					loadFile(info.filename, SymbolManager::LoadEmpty::NOT_ALLOWED, info.type, info.slot);
 				}
 			}
 			ImGui::SameLine();
@@ -239,7 +348,7 @@ void ImGuiSymbols::paint(MSXMotherBoard* /*motherBoard*/)
 				symbolManager.removeAllFiles();
 				fileError.clear();
 			}
-			drawTable<false>(manager, symbolManager, symbols);
+			drawTable<false>(motherBoard);
 		});
 	});
 }

--- a/src/imgui/ImGuiSymbols.cc
+++ b/src/imgui/ImGuiSymbols.cc
@@ -216,8 +216,9 @@ void ImGuiSymbols::drawTable(MSXMotherBoard* motherBoard, const std::string& fil
 
 			if (ImGui::TableNextColumn()) { // name
 				im::ScopedFont sf(manager.fontMono);
-				ImGui::TextUnformatted(sym.name(symbolManager));
-				auto symNameMenu = tmpStrCat("symbol-manager##", sym.name(symbolManager)).data();
+				auto symName = sym.name(symbolManager);
+				ImGui::Selectable(symName.data(), false, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowOverlap);
+				auto symNameMenu = tmpStrCat("symbol-manager##", symName).data();
 				if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
 					ImGui::OpenPopup(symNameMenu);
 				}

--- a/src/unittest/SymbolManager_test.cc
+++ b/src/unittest/SymbolManager_test.cc
@@ -36,48 +36,48 @@ TEST_CASE("SymbolManager: parseValue")
 {
 	SECTION("ok") {
 		// hex
-		CHECK(SymbolManager::parseValue("0xa1") == 0xa1);
-		CHECK(SymbolManager::parseValue("0x1234") == 0x1234);
-		CHECK(SymbolManager::parseValue("0XABCD") == 0xabcd);
-		CHECK(SymbolManager::parseValue("0x00002345") == 0x2345);
-		CHECK(SymbolManager::parseValue("$fedc") == 0xfedc);
-		CHECK(SymbolManager::parseValue("#11aA") == 0x11aa);
-		CHECK(SymbolManager::parseValue("bbffh") == 0xbbff);
-		CHECK(SymbolManager::parseValue("3210H") == 0x3210);
-		CHECK(SymbolManager::parseValue("01234h") == 0x1234);
+		CHECK(SymbolManager::parseValue<uint16_t>("0xa1") == 0xa1);
+		CHECK(SymbolManager::parseValue<uint16_t>("0x1234") == 0x1234);
+		CHECK(SymbolManager::parseValue<uint16_t>("0XABCD") == 0xabcd);
+		CHECK(SymbolManager::parseValue<uint16_t>("0x00002345") == 0x2345);
+		CHECK(SymbolManager::parseValue<uint16_t>("$fedc") == 0xfedc);
+		CHECK(SymbolManager::parseValue<uint16_t>("#11aA") == 0x11aa);
+		CHECK(SymbolManager::parseValue<uint16_t>("bbffh") == 0xbbff);
+		CHECK(SymbolManager::parseValue<uint16_t>("3210H") == 0x3210);
+		CHECK(SymbolManager::parseValue<uint16_t>("01234h") == 0x1234);
 		// dec
-		CHECK(SymbolManager::parseValue("123") == 0x007b);
-		CHECK(SymbolManager::parseValue("65535") == 0xffff);
-		CHECK(SymbolManager::parseValue("0020") == 0x0014); // NOT interpreted as octal
+		CHECK(SymbolManager::parseValue<uint16_t>("123") == 0x007b);
+		CHECK(SymbolManager::parseValue<uint16_t>("65535") == 0xffff);
+		CHECK(SymbolManager::parseValue<uint16_t>("0020") == 0x0014); // NOT interpreted as octal
 		// bin
-		CHECK(SymbolManager::parseValue("%1100") == 0x000c);
-		CHECK(SymbolManager::parseValue("0b000100100011") == 0x0123);
-		CHECK(SymbolManager::parseValue("0B1111000001011000") == 0xf058);
+		CHECK(SymbolManager::parseValue<uint16_t>("%1100") == 0x000c);
+		CHECK(SymbolManager::parseValue<uint16_t>("0b000100100011") == 0x0123);
+		CHECK(SymbolManager::parseValue<uint16_t>("0B1111000001011000") == 0xf058);
 	}
 	SECTION("error") {
 		// wrong format
-		CHECK(SymbolManager::parseValue("0xFEDX") == std::nullopt);
-		CHECK(SymbolManager::parseValue("1234a") == std::nullopt);
-		CHECK(SymbolManager::parseValue("-3") == std::nullopt);
-		CHECK(SymbolManager::parseValue("0b00112110") == std::nullopt);
+		CHECK(SymbolManager::parseValue<uint16_t>("0xFEDX") == std::nullopt);
+		CHECK(SymbolManager::parseValue<uint16_t>("1234a") == std::nullopt);
+		CHECK(SymbolManager::parseValue<uint16_t>("-3") == std::nullopt);
+		CHECK(SymbolManager::parseValue<uint16_t>("0b00112110") == std::nullopt);
 		// overflow
-		CHECK(SymbolManager::parseValue("0x10000") == std::nullopt);
-		CHECK(SymbolManager::parseValue("65536") == std::nullopt);
-		CHECK(SymbolManager::parseValue("%11110000111100001") == std::nullopt);
+		CHECK(SymbolManager::parseValue<uint16_t>("0x10000") == std::nullopt);
+		CHECK(SymbolManager::parseValue<uint16_t>("65536") == std::nullopt);
+		CHECK(SymbolManager::parseValue<uint16_t>("%11110000111100001") == std::nullopt);
 	}
 }
 
 TEST_CASE("SymbolManager: checkLabel")
 {
-	CHECK(SymbolManager::checkLabel("foo", 123) == Symbol("foo", 123));
-	CHECK(SymbolManager::checkLabel("bar:", 234) == Symbol("bar", 234));
+	CHECK(SymbolManager::checkLabel("foo", 123) == Symbol("foo", 123, 0));
+	CHECK(SymbolManager::checkLabel("bar:", 234) == Symbol("bar", 234, 0));
 	CHECK(SymbolManager::checkLabel("", 345) == std::nullopt);
 	CHECK(SymbolManager::checkLabel(":", 456) == std::nullopt);
 }
 
 TEST_CASE("SymbolManager: checkLabelAndValue")
 {
-	CHECK(SymbolManager::checkLabelAndValue("foo", "123") == Symbol("foo", 123));
+	CHECK(SymbolManager::checkLabelAndValue("foo", "123") == Symbol("foo", 123, 0));
 	CHECK(SymbolManager::checkLabelAndValue("", "123") == std::nullopt);
 	CHECK(SymbolManager::checkLabelAndValue("foo", "bla") == std::nullopt);
 }
@@ -107,7 +107,7 @@ TEST_CASE("SymbolManager: detectType")
 TEST_CASE("SymbolManager: loadLines")
 {
 	auto dummyParser = [](std::span<std::string_view> tokens) -> std::optional<Symbol> {
-		if (tokens.size() == 1) return Symbol{std::string(tokens[0]), 123};
+		if (tokens.size() == 1) return Symbol{std::string(tokens[0]), 123, 0};
 		return {};
 	};
 


### PR DESCRIPTION
* [x] display slot and subslot in symbol manager;
![sample image](https://github.com/openMSX/openMSX/assets/7815819/451503ce-8964-4957-9ffa-adbfc96dd794)
 * [ ] ~change slot and subslot in a popup dialog;~
 * idea: after clicking with right mouse button on slots field?
![image](https://github.com/openMSX/openMSX/assets/7815819/960a6e87-fa90-4e75-b056-66562c25d73b)
* [ ] ~save session (omds file);~
* [ ] ~load session (omds file);~
