### PR TITLE
[macOS] Raise main window to front on start-up

### DIFF
--- a/src/imgui/ImGuiLayer.cc
+++ b/src/imgui/ImGuiLayer.cc
@@ -32,9 +32,8 @@ void ImGuiLayer::paint(OutputSurface& /*surface*/)
 		ImGuiDockNodeFlags_NoDockingOverCentralNode |
 		ImGuiDockNodeFlags_PassthruCentralNode);
 
-	if (first) {
+	if (ImGui::GetFrameCount() == 1) {
 		// on startup, focus main openMSX window instead of the GUI window
-		first = false;
 		ImGui::SetWindowFocus(nullptr);
 	}
 

--- a/src/imgui/ImGuiLayer.cc
+++ b/src/imgui/ImGuiLayer.cc
@@ -51,6 +51,14 @@ void ImGuiLayer::paint(OutputSurface& /*surface*/)
 		ImGui::UpdatePlatformWindows();
 		ImGui::RenderPlatformWindowsDefault();
 		SDL_GL_MakeCurrent(backup_current_window, backup_current_context);
+
+#ifdef __APPLE__
+		if (ImGui::GetFrameCount() == 1) {
+			// On startup, bring main openMSX window to front, which it doesn't
+			// do it by itself due to creation of platform windows for viewports.
+			SDL_RaiseWindow(SDL_GetWindowFromID(WindowEvent::getMainWindowId()));
+		}
+#endif
 	}
 }
 

--- a/src/imgui/ImGuiLayer.hh
+++ b/src/imgui/ImGuiLayer.hh
@@ -18,7 +18,6 @@ private:
 
 private:
 	ImGuiManager& manager;
-	bool first = true;
 };
 
 } // namespace openmsx


### PR DESCRIPTION
If I launch openMSX with additional windows opened (like the debugger & console), the openMSX window does not receive focus. Only the additional windows show in front, and openMSX window itself goes behind the window that opened it (such as the terminal or VSCode). Also key input is not received by the MSX until I click on the main window to focus it. It works fine as normal when there are no additional windows opened.

These are actually two separate issues:

1. When there are multiple windows open on startup, then by default the main msx window should start with focus, not some other window.
2. When starting openMSX it can happen that the main msx window opens behind some other (non-openmsx) window.