### PR TITLE
Fix error passing nonexistent texture to ImGui::Image().

### DIFF
--- a/src/imgui/ImGuiOsdIcons.cc
+++ b/src/imgui/ImGuiOsdIcons.cc
@@ -197,11 +197,13 @@ void ImGuiOsdIcons::paint(MSXMotherBoard* /*motherBoard*/)
 			}();
 
 			const auto& ic = state ? icon.on : icon.off;
-			gl::vec2 cursor = ImGui::GetCursorPos();
-			ImGui::Image(ic.tex.getImGui(), gl::vec2(ic.size),
-			             {0.0f, 0.0f}, {1.0f, 1.0f}, {1.0f, 1.0f, 1.0f, alpha});
+			if (ic.tex.get()) {
+				gl::vec2 cursor = ImGui::GetCursorPos();
+				ImGui::Image(ic.tex.getImGui(), gl::vec2(ic.size),
+				             {0.0f, 0.0f}, {1.0f, 1.0f}, {1.0f, 1.0f, 1.0f, alpha});
+				ImGui::SetCursorPos(cursor);
+			}
 
-			ImGui::SetCursorPos(cursor);
 			auto size = gl::vec2(max(icon.on.size, icon.off.size));
 			(iconsHorizontal ? size.x : size.y) += spacing;
 			ImGui::Dummy(size);

--- a/src/video/GLUtil.hh
+++ b/src/video/GLUtil.hh
@@ -74,7 +74,10 @@ public:
 
 	/** Return as a 'void*' (needed for 'Dear ImGui').
 	  */
-	[[nodiscard]] void* getImGui() const { return std::bit_cast<void*>(uintptr_t(textureId)); }
+	[[nodiscard]] void* getImGui() const {
+		assert(textureId);
+		return std::bit_cast<void*>(uintptr_t(textureId));
+	}
 
 	/** Makes this texture the active GL texture.
 	  * The other methods of this class and its subclasses will implicitly


### PR DESCRIPTION
Caused the following warning to be logged on start-up on M1 Macs:

> UNSUPPORTED (log once): POSSIBLE ISSUE: unit 0 GLD_TEXTURE_INDEX_2D is unloadable and bound to sampler type (Float) - using zero texture because texture unloadable