### PR TITLE
Add support for Circuit Designer RD dongle

### DIFF
--- a/doc/manual/user.html
+++ b/doc/manual/user.html
@@ -983,7 +983,7 @@ Tetris 2 Special Edition from R.A.M., an Italian MSX group needs the dongle in p
     Circuit Designer dongle from The Falcon, needs the dongle in port B too start the program:</p>
 
 <div class="commandline">
-    <a class="external" href="commands.html#plugunplug">plug</a> joyportb circuitdesignerrd-protection
+    <a class="external" href="commands.html#plugunplug">plug</a> joyportb circuit-designer-rd-dongle
 </div>
 
 <h2><a id="video">6. Video</a></h2>

--- a/doc/manual/user.html
+++ b/doc/manual/user.html
@@ -89,6 +89,7 @@
 			<li><a class="internal" href="#ninjatap">5.8 Ninja Tap</a></li>
 			<li><a class="internal" href="#tetris2dongle">5.9 Tetris II Special Edition dongle</a></li>
 			<li><a class="internal" href="#msxpaddle">5.10 MSX Paddle</a></li>
+			<li><a class="internal" href="#circuitdesignerdongle">5.11 Circuit Designer RD dongle</a></li>
 		</ol>
 	</li>
 
@@ -976,6 +977,14 @@ Tetris 2 Special Edition from R.A.M., an Italian MSX group needs the dongle in p
     <a class="external" href="commands.html#plugunplug">plug</a> joyporta paddle
 </div>
 
+<h3><a id="circuitdesignerrddongle">5.9 Circuit Designer dongle</a></h3>
+
+<p>
+    Circuit Designer dongle from The Falcon, needs the dongle in port B too start the program:</p>
+
+<div class="commandline">
+    <a class="external" href="commands.html#plugunplug">plug</a> joyportb circuitdesignerrd-protection
+</div>
 
 <h2><a id="video">6. Video</a></h2>
 

--- a/src/PluggableFactory.cc
+++ b/src/PluggableFactory.cc
@@ -86,7 +86,7 @@ void PluggableFactory::createAll(PluggingController& controller,
 	// Dongles
 	controller.registerPluggable(std::make_unique<SETetrisDongle>());
 	controller.registerPluggable(std::make_unique<MagicKey>());
-     controller.registerPluggable(std::make_unique<CircuitDesignerRDDongle>());
+    controller.registerPluggable(std::make_unique<CircuitDesignerRDDongle>());
 
 	// Logging:
 	controller.registerPluggable(std::make_unique<PrinterPortLogger>(

--- a/src/PluggableFactory.cc
+++ b/src/PluggableFactory.cc
@@ -9,6 +9,7 @@
 #include "JoyTap.hh"
 #include "NinjaTap.hh"
 #include "SETetrisDongle.hh"
+#include "CircuitDesignerRDDongle.hh"
 #include "MagicKey.hh"
 #include "MSXJoystick.hh"
 #include "MidiInReader.hh"
@@ -85,6 +86,7 @@ void PluggableFactory::createAll(PluggingController& controller,
 	// Dongles
 	controller.registerPluggable(std::make_unique<SETetrisDongle>());
 	controller.registerPluggable(std::make_unique<MagicKey>());
+     controller.registerPluggable(std::make_unique<CircuitDesignerRDDongle>());
 
 	// Logging:
 	controller.registerPluggable(std::make_unique<PrinterPortLogger>(

--- a/src/imgui/ImGuiConnector.cc
+++ b/src/imgui/ImGuiConnector.cc
@@ -26,7 +26,7 @@ namespace openmsx {
 	if (pluggable == "msx-printer")        return "MSX printer";
 	if (pluggable == "epson-printer")      return "Epson printer";
 	if (pluggable == "tetris2-protection") return "Tetris II SE dongle";
-	if (pluggable == "circuitdesignerrd-protection") return "Circuit Designer RD dongle";
+	if (pluggable == "circuit-designer-rd-dongle") return "Circuit Designer RD dongle";
 	return std::string(pluggable);
 }
 

--- a/src/imgui/ImGuiConnector.cc
+++ b/src/imgui/ImGuiConnector.cc
@@ -26,6 +26,7 @@ namespace openmsx {
 	if (pluggable == "msx-printer")        return "MSX printer";
 	if (pluggable == "epson-printer")      return "Epson printer";
 	if (pluggable == "tetris2-protection") return "Tetris II SE dongle";
+	if (pluggable == "circuitdesignerrd-protection") return "Circuit Designer RD dongle";
 	return std::string(pluggable);
 }
 

--- a/src/input/CircuitDesignerRDDongle.cc
+++ b/src/input/CircuitDesignerRDDongle.cc
@@ -13,7 +13,7 @@ namespace openmsx {
 // Pluggable
 std::string_view CircuitDesignerRDDongle::getName() const
 {
-	return "circuitdesignerrd-protection";
+	return "circuit-designer-rd-dongle";
 }
 
 std::string_view CircuitDesignerRDDongle::getDescription() const

--- a/src/input/CircuitDesignerRDDongle.cc
+++ b/src/input/CircuitDesignerRDDongle.cc
@@ -1,0 +1,75 @@
+#include "CircuitDesignerRDDongle.hh"
+#include "serialize.hh"
+#include "serialize_meta.hh"
+
+/*
+ The circuit designer RD dongle is a simple dongle that is used to protect the software.
+ It needs to be plugged in Joystick port B, when it's not plugged in the software will
+ add a reset command to the BLOAD hook which will reset the MSX.
+*/
+
+namespace openmsx {
+
+// Pluggable
+std::string_view CircuitDesignerRDDongle::getName() const
+{
+	return "circuitdesignerrd-protection";
+}
+
+std::string_view CircuitDesignerRDDongle::getDescription() const
+{
+	return "Circuit Designer RD dongle";
+}
+
+void CircuitDesignerRDDongle::plugHelper(
+	Connector& /*connector*/, EmuTime::param /*time*/)
+{
+}
+
+void CircuitDesignerRDDongle::unplugHelper(EmuTime::param /*time*/)
+{
+}
+
+
+// JoystickDevice
+uint8_t CircuitDesignerRDDongle::read(EmuTime::param /*time*/)
+{
+	return status;
+}
+
+/*
+     Pin 1 = Up
+     Pin 6 = Button A
+     Pin 7 = Button B
+
+     Output  Input
+     pin|pin|Pin (Up)
+     7 | 6 | 1
+     -----------------
+     0 | 0 | 0
+     0 | 1 | 1
+     1 | 0 | 0
+     1 | 1 | 0
+*/
+void CircuitDesignerRDDongle::write(uint8_t value, EmuTime::param /*time*/)
+{
+     bool pin6 =  value & (1 << 0);
+     bool pin7 = value & (1 << 1);
+
+	if (!pin7 && pin6) {
+		status  |= JOY_UP;
+	} else {
+		status &= ~JOY_UP;
+	}
+}
+
+template<typename Archive>
+void CircuitDesignerRDDongle::serialize(Archive& /*ar*/, unsigned /*version*/)
+{
+	// no need to serialize 'status', port will anyway be re-written
+	// on de-serialize
+}
+INSTANTIATE_SERIALIZE_METHODS(CircuitDesignerRDDongle);
+REGISTER_POLYMORPHIC_INITIALIZER(Pluggable, CircuitDesignerRDDongle, "CircuitDesignerRDDongle");
+
+} // namespace openmsx

--- a/src/input/CircuitDesignerRDDongle.hh
+++ b/src/input/CircuitDesignerRDDongle.hh
@@ -1,0 +1,31 @@
+#ifndef CIRCUITDESIGNERRDDONGLE_HH
+#define CIRCUITDESIGNERRDDONGLE_HH
+
+#include "JoystickDevice.hh"
+
+namespace openmsx {
+
+class CircuitDesignerRDDongle final : public JoystickDevice
+{
+public:
+	// Pluggable
+	[[nodiscard]] std::string_view getName() const override;
+	[[nodiscard]] std::string_view getDescription() const override;
+	void plugHelper(Connector& connector, EmuTime::param time) override;
+	void unplugHelper(EmuTime::param time) override;
+
+	// JoystickDevice
+	[[nodiscard]] uint8_t read(EmuTime::param time) override;
+	void write(uint8_t value, EmuTime::param time) override;
+
+	template<typename Archive>
+	void serialize(Archive& ar, unsigned version);
+
+private:
+	uint8_t status = JOY_UP | JOY_DOWN | JOY_LEFT | JOY_RIGHT |
+	                 JOY_BUTTONA | JOY_BUTTONB;
+};
+
+} // namespace openmsx
+
+#endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -213,6 +213,7 @@ sources = files(
     'ide/SunriseIDE.cc',
     'ide/WD33C93.cc',
     'input/ArkanoidPad.cc',
+    'input/CircuitDesignerRDDongle.cc',
     'input/ColecoJoystickIO.cc',
     'input/DummyJoystick.cc',
     'input/EventDelay.cc',


### PR DESCRIPTION
This PR adds support for a new dongle that is needed to start the Circuit Designer RD software of The Falcon (Rene Derkx). If the dongle is not present it will add a reset command to the BLOAD hook (that will reset the MSX if you try to load something).

Thanks to Tsjakoe and Lars The 18Th for finding the copy protection and info on how it works.

See: https://www.generation-msx.nl/software/the-falcon/circuit-designer-rd/release/8309/
