### PR TITLE
changing order of commands suppresses warning msg

### DIFF
--- a/src/fdc/DirAsDSK.cc
+++ b/src/fdc/DirAsDSK.cc
@@ -238,8 +238,8 @@ static std::array<char, 11> hostToMsxName(string hostName)
 
 	std::array<char, 8 + 3> result;
 	ranges::fill(result, ' ');
+	ranges::copy(subspan( ext, 0, std::min<size_t>(3,  ext.size())), subspan<3>(result, 8));
 	ranges::copy(subspan(file, 0, std::min<size_t>(8, file.size())), subspan<8>(result, 0));
-	ranges::copy(subspan(ext,  0, std::min<size_t>(3, ext .size())), subspan<3>(result, 8));
 	ranges::replace(result, '.', '_');
 	return result;
 }


### PR DESCRIPTION
```
Compiling fdc/DirAsDSK.cc...
In file included from src/fdc/DiskImageUtils.hh:6,
                 from src/fdc/DirAsDSK.hh:4,
                 from src/fdc/DirAsDSK.cc:1:
In function ‘constexpr auto ranges::copy(Input&&, Output&&) [with Input = std::span<const char, 18446744073709551615>; Output = std::span<char, 3>]’,
    inlined from ‘std::array<char, 11> openmsx::hostToMsxName(std::string)’ at src/fdc/DirAsDSK.cc:242:14,
    inlined from ‘openmsx::DirAsDSK::DirIndex openmsx::DirAsDSK::fillMSXDirEntry(const std::string&, const std::string&, unsigned int)’ at src/fdc/DirAsDSK.cc:835:35:
src/utils/ranges.hh:268:22: warning: writing 8 bytes into a region of size 3 [-Wstringop-overflow=]
  268 |                 *o++ = *f++;
      |                 ~~~~~^~~~~~
src/fdc/DirAsDSK.cc: In member function ‘openmsx::DirAsDSK::DirIndex openmsx::DirAsDSK::fillMSXDirEntry(const std::string&, const std::string&, unsigned int)’:
src/fdc/DirAsDSK.cc:239:30: note: at offset [8, 11] into destination object ‘result’ of size 11
  239 |         std::array<char, 11> result;
      |                              ^~~~~~

```