### PR TITLE
Highlight known symbols in hex memory view

### DIFF
--- a/src/imgui/DebuggableEditor.hh
+++ b/src/imgui/DebuggableEditor.hh
@@ -83,6 +83,7 @@ private:
 	bool showAddress = true;      // display the address bar (e.g. on small views it can make sense to hide this)
 	bool showSearch = false;      // display search functionality
 	bool showDataPreview = false; // display a footer previewing the decimal/binary/hex/float representation of the currently selected bytes.
+	bool showSymbolInfo = false;  // display symbol information and highlight known symbols in hex view
 	bool greyOutZeroes = true;    // display null/zero bytes using the TextDisabled color.
 	std::string addrExpr;
 	std::string searchString;
@@ -101,6 +102,7 @@ private:
 		PersistentElement   {"showAddress",      &DebuggableEditor::showAddress},
 		PersistentElement   {"showSearch",       &DebuggableEditor::showSearch},
 		PersistentElement   {"showDataPreview",  &DebuggableEditor::showDataPreview},
+		PersistentElement   {"showSymbolInfo",   &DebuggableEditor::showSymbolInfo},
 		PersistentElement   {"greyOutZeroes",    &DebuggableEditor::greyOutZeroes},
 		PersistentElement   {"addrExpr",         &DebuggableEditor::addrExpr},
 		PersistentElement   {"searchString",     &DebuggableEditor::searchString},


### PR DESCRIPTION
This patch highlights the known symbols in the memory view. This helped me keeping track of which memory locations I had already taken a look at and which were currently unknown. 
It also shows the symbol name of the current address at the bottom of the window. All behind a toggle in the popup menu.

![memory-symbols](https://github.com/user-attachments/assets/a33d50ad-ab88-433b-8df4-3e32790f0f2d)

The color of the highlight can obviously be changed if necessary, I just picked something with enough contrast.
