### PR TITLE
Added support for loading symbol files generated by WLA-DX

### DIFF
--- a/src/debugger/SymbolManager.cc
+++ b/src/debugger/SymbolManager.cc
@@ -23,13 +23,14 @@ zstring_view SymbolFile::toString(Type type)
 {
 	switch (type) {
 		using enum Type;
-		case AUTO_DETECT: return "auto-detect";
-		case ASMSX:       return "asMSX";
-		case GENERIC:     return "generic";
-		case HTC:         return "htc";
-		case LINKMAP:     return "linkmap";
-		case NOICE:       return "NoICE";
-		case VASM:        return "vasm";
+		case AUTO_DETECT:   return "auto-detect";
+		case ASMSX:         return "asMSX";
+		case GENERIC:       return "generic";
+		case HTC:           return "htc";
+		case LINKMAP:       return "linkmap";
+		case NOICE:         return "NoICE";
+		case VASM:          return "vasm";
+		case WLALINK_NOGMB: return "wlalink";
 		default: UNREACHABLE;
 	}
 }
@@ -44,6 +45,7 @@ std::optional<SymbolFile::Type> SymbolFile::parseType(std::string_view str)
 	if (str == "linkmap")     return LINKMAP;
 	if (str == "NoICE")       return NOICE;
 	if (str == "vasm")        return VASM;
+	if (str == "wlalink")     return WLALINK_NOGMB;
 	return {};
 }
 
@@ -76,6 +78,8 @@ SymbolManager::SymbolManager(CommandController& commandController_)
 			return GENERIC;
 		} else if (StringOp::containsCaseInsensitive(line, "Sections:")) {
 			return VASM;
+		} else if (StringOp::containsCaseInsensitive(line, "; this file was created with wlalink")) {
+			return WLALINK_NOGMB;
 		} else {
 			// this is a blunt conclusion but I don't know a way
 			// to detect this file type
@@ -253,6 +257,20 @@ template std::optional<uint32_t> SymbolManager::parseValue<uint32_t>(std::string
 	return result;
 }
 
+[[nodiscard]] SymbolFile SymbolManager::loadNoGmb(std::string_view filename, std::string_view buffer)
+{
+	auto parseLine = [](std::span<std::string_view> tokens) -> std::optional<Symbol> {
+		if (tokens.size() != 2) return {};
+		auto value = tokens[0];
+		auto label = tokens[1];
+		if (!value.starts_with("00:")) return {};
+		std::optional<uint16_t> num = StringOp::stringToBase<16, uint16_t>(value.substr(3));
+		if (!num.has_value()) return {};
+		return checkLabel(label, num.value());
+	};
+	return loadLines(filename, buffer, SymbolFile::Type::WLALINK_NOGMB, parseLine);
+}
+
 [[nodiscard]] SymbolFile SymbolManager::loadASMSX(std::string_view filename, std::string_view buffer)
 {
 	SymbolFile result;
@@ -391,6 +409,8 @@ template std::optional<uint32_t> SymbolManager::parseValue<uint32_t>(std::string
 				return loadNoICE(filename, buffer);
 			case VASM:
 				return loadVASM(filename, buffer);
+			case WLALINK_NOGMB:
+				return loadNoGmb(filename, buffer);
 			default: UNREACHABLE;
 		}
 	}();
@@ -508,7 +528,8 @@ std::string SymbolManager::getFileFilters()
 	       "pasmo symbol files (*.symbol *.publics *.sys){.symbol,.publics,.sys},"
 	       "tniASM 0.x symbol files (*.sym){.sym},"
 	       "tniASM 1.x symbol files (*.sym){.sym},"
-	       "vasm symbol files (*.sym){.sym}";
+	       "vasm symbol files (*.sym){.sym},"
+	       "wlalink no$gmb symbol files (*.sym){.sym}";
 }
 
 SymbolFile::Type SymbolManager::getTypeForFilter(std::string_view filter)
@@ -526,6 +547,8 @@ SymbolFile::Type SymbolManager::getTypeForFilter(std::string_view filter)
 		return NOICE;
 	} else if (filter.starts_with("vasm")) {
 		return VASM;
+	} else if (filter.starts_with("wlalink")) {
+		return WLALINK_NOGMB;
 	} else {
 		return GENERIC;
 	}

--- a/src/debugger/SymbolManager.cc
+++ b/src/debugger/SymbolManager.cc
@@ -78,7 +78,7 @@ SymbolManager::SymbolManager(CommandController& commandController_)
 			return GENERIC;
 		} else if (StringOp::containsCaseInsensitive(line, "Sections:")) {
 			return VASM;
-		} else if (StringOp::containsCaseInsensitive(line, "; this file was created with wlalink")) {
+		} else if (line.starts_with("; this file was created with wlalink")) {
 			return WLALINK_NOGMB;
 		} else {
 			// this is a blunt conclusion but I don't know a way

--- a/src/debugger/SymbolManager.hh
+++ b/src/debugger/SymbolManager.hh
@@ -40,6 +40,7 @@ struct SymbolFile
 		LINKMAP,
 		NOICE,
 		VASM,
+		WLALINK_NOGMB,
 
 		FIRST = AUTO_DETECT,
 		LAST = VASM + 1,
@@ -106,6 +107,7 @@ public:
 	[[nodiscard]] static SymbolFile loadNoICE(std::string_view filename, std::string_view buffer);
 	[[nodiscard]] static SymbolFile loadHTC(std::string_view filename, std::string_view buffer);
 	[[nodiscard]] static SymbolFile loadVASM(std::string_view filename, std::string_view buffer);
+	[[nodiscard]] static SymbolFile loadNoGmb(std::string_view filename, std::string_view buffer);
 	[[nodiscard]] static SymbolFile loadASMSX(std::string_view filename, std::string_view buffer);
 	[[nodiscard]] static SymbolFile loadLinkMap(std::string_view filename, std::string_view buffer);
 	[[nodiscard]] static SymbolFile loadSymbolFile(const std::string& filename, SymbolFile::Type type, std::optional<uint8_t> slot = {});

--- a/src/unittest/SymbolManager_test.cc
+++ b/src/unittest/SymbolManager_test.cc
@@ -287,7 +287,7 @@ TEST_CASE("SymbolManager: loadNoGmb")
 		"00:402d main@main_loop\n"
 		"00:404f Game_Initialize\n"
 		"00:404e Game_Update\n";
-	auto file = SymbolManager::loadGeneric("myfile.sym", buffer);
+	auto file = SymbolManager::loadNoGmb("myfile.sym", buffer);
 	CHECK(file.filename == "myfile.sym");
 	CHECK(file.type == SymbolFile::Type::WLALINK_NOGMB);
 	REQUIRE(file.symbols.size() == 4);


### PR DESCRIPTION
This PR adds support for loading `no$gmb` symbol files generated by WLA-DX.
The `no$gmb` symbol format is used by other assembly tools, so the `loadNoGmb` should be reusable.
However, the auto-detect feature will only work for files generated by WLA-DX right now.

Note that WLA-DX can also generate symbol files in its own format, but this custom format is not supported by this PR.