### PR TITLE
Add context menu with 'Show in Disassembly' entry to addresses in breakpoints window

### DIFF
--- a/src/imgui/ImGuiBreakPoints.cc
+++ b/src/imgui/ImGuiBreakPoints.cc
@@ -1,6 +1,7 @@
 #include "ImGuiBreakPoints.hh"
 
 #include "ImGuiCpp.hh"
+#include "ImGuiDebugger.hh"
 #include "ImGuiManager.hh"
 #include "ImGuiUtils.hh"
 
@@ -724,6 +725,13 @@ void ImGuiBreakPoints::drawRow(MSXCPUInterface& cpuInterface, Debugger& debugger
 			im::Font(manager.fontMono, [&]{
 				addrChanged |= ImGui::InputText("##addr", &addr);
 			});
+
+			auto breakpointsNameMenu = strCat("breakpoint-manager##", item.addr.value_or(0));
+			if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
+				ImGui::OpenPopup(breakpointsNameMenu.c_str());
+			}
+			im::Popup(breakpointsNameMenu.c_str(), [&] { drawBreakpointContext(item); });
+
 			addrToolTip();
 			if (ImGui::IsItemActive()) selectedRow = row;
 		}
@@ -770,6 +778,12 @@ void ImGuiBreakPoints::drawRow(MSXCPUInterface& cpuInterface, Debugger& debugger
 	}
 	if (needSync) {
 		syncToOpenMsx<Item>(cpuInterface, debugger, interp, item);
+	}
+}
+void ImGuiBreakPoints::drawBreakpointContext(const GuiItem &item)
+{
+	if (ImGui::MenuItem("Show in Dissassembly", nullptr, nullptr, item.addr.has_value())) {
+		manager.debugger->setGotoTarget(item.addr.value());
 	}
 }
 

--- a/src/imgui/ImGuiBreakPoints.hh
+++ b/src/imgui/ImGuiBreakPoints.hh
@@ -75,6 +75,7 @@ private:
 	template<typename Item> void drawRow(MSXCPUInterface& cpuInterface, Debugger& debugger, int row, GuiItem& item);
 	bool editRange(std::string& begin, std::string& end);
 	bool editCondition(ParsedSlotCond& slot);
+	void drawBreakpointContext(const GuiItem &item);
 
 	[[nodiscard]] auto& getItems(BreakPoint*) { return guiBps; }
 	[[nodiscard]] auto& getItems(WatchPoint*) { return guiWps; }


### PR DESCRIPTION
I didn't add a context menu for watchpoints, which should jump to the memory viewer, because I'm not sure which memory viewer to address (there can be multiple, ...), and how to best solve that issue.