### PR TITLE
Make opengl scalers work with both 320 and 640 width screens

### DIFF
--- a/src/video/scalers/GLHQLiteScaler.cc
+++ b/src/video/scalers/GLHQLiteScaler.cc
@@ -28,7 +28,7 @@ GLHQLiteScaler::GLHQLiteScaler(GLScaler& fallback_)
 
 	// GL_LUMINANCE_ALPHA is no longer supported in newer openGL versions
 	auto format = (OPENGL_VERSION >= OPENGL_3_3) ? GL_RG : GL_LUMINANCE_ALPHA;
-	edgeTexture.bind();
+	edgeTexture320.bind();
 	glTexImage2D(GL_TEXTURE_2D,    // target
 	             0,                // level
 	             format,           // internal format
@@ -38,11 +38,22 @@ GLHQLiteScaler::GLHQLiteScaler(GLScaler& fallback_)
 	             format,           // format
 	             GL_UNSIGNED_BYTE, // type
 	             nullptr);         // data
+	edgeTexture640.bind();
+	glTexImage2D(GL_TEXTURE_2D,    // target
+	             0,                // level
+	             format,           // internal format
+	             640,              // width
+	             240,              // height
+	             0,                // border
+	             format,           // format
+	             GL_UNSIGNED_BYTE, // type
+	             nullptr);         // data
 #if OPENGL_VERSION >= OPENGL_3_3
 	GLint swizzleMask1[] = {GL_RED, GL_RED, GL_RED, GL_GREEN};
 	glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMask1);
 #endif
-	edgeBuffer.setImage(320, 240);
+	edgeBuffer320.setImage(320, 240);
+	edgeBuffer640.setImage(640, 240);
 
 	const auto& context = systemFileContext();
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
@@ -75,16 +86,16 @@ void GLHQLiteScaler::scaleImage(
 	unsigned dstStartY, unsigned dstEndY, unsigned dstWidth,
 	unsigned logSrcHeight)
 {
-	unsigned factorX = dstWidth / srcWidth; // 1 - 4
+	unsigned factorX = ((srcWidth / 320) * dstWidth) / srcWidth; // 1 - 4
 	unsigned factorY = (dstEndY - dstStartY) / (srcEndY - srcStartY);
 
-	if ((srcWidth == 320) && (factorX > 1) && (factorX == factorY)) {
+	if ((srcWidth % 320 == 0) && (factorX > 1) && (factorX == factorY)) {
 		setup(superImpose != nullptr);
 		src.setInterpolation(true);
 		glActiveTexture(GL_TEXTURE3);
 		offsetTexture[factorX - 2].bind();
 		glActiveTexture(GL_TEXTURE2);
-		edgeTexture.bind();
+		if (srcWidth == 320) edgeTexture320.bind(); else edgeTexture640.bind();
 		glActiveTexture(GL_TEXTURE0);
 		execute(src, superImpose,
 		        srcStartY, srcEndY, srcWidth,
@@ -104,9 +115,12 @@ void GLHQLiteScaler::uploadBlock(
 	unsigned srcStartY, unsigned srcEndY, unsigned lineWidth,
 	FrameSource& paintFrame)
 {
-	if ((lineWidth != 320) || (srcEndY > 240)) return;
+	if ((lineWidth % 320 != 0) || (srcEndY > 240)) return;
 
-	std::array<Endian::L32, 320 / 2> tmpBuf2; // 2 x uint16_t
+	std::array<Endian::L32, 320 / 2> tmp320; // 2 x uint16_t
+	std::array<Endian::L32, 640 / 2> tmp640; // 2 x uint16_t
+	std::span<Endian::L32> tmpBuf2;
+	if (lineWidth == 320) tmpBuf2 = tmp320; else tmpBuf2 = tmp640;
 	#ifndef NDEBUG
 	// Avoid UMR. In optimized mode we don't care.
 	ranges::fill(tmpBuf2, 0);
@@ -118,6 +132,7 @@ void GLHQLiteScaler::uploadBlock(
 	auto next = paintFrame.getLine(narrow<int>(srcStartY) + 0, buf2);
 	calcEdgesGL(curr, next, tmpBuf2, EdgeHQLite());
 
+	gl::PixelBuffer<uint16_t> &edgeBuffer = (lineWidth == 320) ? edgeBuffer320 : edgeBuffer640;
 	edgeBuffer.bind();
 	if (auto* mapped = edgeBuffer.mapWrite()) {
 		for (auto y : xrange(srcStartY, srcEndY)) {
@@ -125,12 +140,12 @@ void GLHQLiteScaler::uploadBlock(
 			std::swap(buf1, buf2);
 			next = paintFrame.getLine(narrow<int>(y + 1), buf2);
 			calcEdgesGL(curr, next, tmpBuf2, EdgeHQLite());
-			memcpy(mapped + 320 * size_t(y), tmpBuf2.data(), 320 * sizeof(uint16_t));
+			memcpy(mapped + lineWidth * size_t(y), tmpBuf2.data(), lineWidth * sizeof(uint16_t));
 		}
 		edgeBuffer.unmap();
 
 		auto format = (OPENGL_VERSION >= OPENGL_3_3) ? GL_RG : GL_LUMINANCE_ALPHA;
-		edgeTexture.bind();
+		if (lineWidth == 320) edgeTexture320.bind(); else edgeTexture640.bind();
 		glTexSubImage2D(GL_TEXTURE_2D,                      // target
 		                0,                                  // level
 		                0,                                  // offset x

--- a/src/video/scalers/GLHQLiteScaler.hh
+++ b/src/video/scalers/GLHQLiteScaler.hh
@@ -25,9 +25,9 @@ public:
 
 private:
 	GLScaler& fallback;
-	gl::Texture edgeTexture;
+	gl::Texture edgeTexture320, edgeTexture640;
 	std::array<gl::Texture, 3> offsetTexture;
-	gl::PixelBuffer<uint16_t> edgeBuffer;
+	gl::PixelBuffer<uint16_t> edgeBuffer320, edgeBuffer640;
 };
 
 } // namespace openmsx

--- a/src/video/scalers/GLHQScaler.cc
+++ b/src/video/scalers/GLHQScaler.cc
@@ -11,6 +11,7 @@
 #include "vla.hh"
 
 #include <array>
+#include <span>
 #include <cstring>
 #include <utility>
 
@@ -29,7 +30,7 @@ GLHQScaler::GLHQScaler(GLScaler& fallback_)
 
 	// GL_LUMINANCE_ALPHA is no longer supported in newer openGL versions
 	auto format = (OPENGL_VERSION >= OPENGL_3_3) ? GL_RG : GL_LUMINANCE_ALPHA;
-	edgeTexture.bind();
+	edgeTexture320.bind();
 	glTexImage2D(GL_TEXTURE_2D,    // target
 	             0,                // level
 	             format,           // internal format
@@ -39,11 +40,22 @@ GLHQScaler::GLHQScaler(GLScaler& fallback_)
 	             format,           // format
 	             GL_UNSIGNED_BYTE, // type
 	             nullptr);         // data
+	edgeTexture640.bind();
+	glTexImage2D(GL_TEXTURE_2D,    // target
+	             0,                // level
+	             format,           // internal format
+	             640,              // width
+	             240,              // height
+	             0,                // border
+	             format,           // format
+	             GL_UNSIGNED_BYTE, // type
+	             nullptr);         // data
 #if OPENGL_VERSION >= OPENGL_3_3
 	GLint swizzleMask[] = {GL_RED, GL_RED, GL_RED, GL_ONE};
 	glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMask);
 #endif
-	edgeBuffer.setImage(320, 240);
+	edgeBuffer320.setImage(320, 240);
+	edgeBuffer640.setImage(640, 240);
 
 	const auto& context = systemFileContext();
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
@@ -86,10 +98,10 @@ void GLHQScaler::scaleImage(
 	unsigned dstStartY, unsigned dstEndY, unsigned dstWidth,
 	unsigned logSrcHeight)
 {
-	unsigned factorX = dstWidth / srcWidth; // 1 - 4
+	unsigned factorX = ((srcWidth / 320) * dstWidth) / srcWidth; // 1 - 4
 	unsigned factorY = (dstEndY - dstStartY) / (srcEndY - srcStartY);
 
-	if ((srcWidth == 320) && (factorX > 1) && (factorX == factorY)) {
+	if ((srcWidth % 320 == 0) && (factorX > 1) && (factorX == factorY)) {
 		assert(src.getHeight() == 2 * 240);
 		setup(superImpose != nullptr);
 		glActiveTexture(GL_TEXTURE4);
@@ -97,7 +109,7 @@ void GLHQScaler::scaleImage(
 		glActiveTexture(GL_TEXTURE3);
 		offsetTexture[factorX - 2].bind();
 		glActiveTexture(GL_TEXTURE2);
-		edgeTexture.bind();
+		if (srcWidth == 320) edgeTexture320.bind(); else edgeTexture640.bind();
 		glActiveTexture(GL_TEXTURE0);
 		execute(src, superImpose,
 		        srcStartY, srcEndY, srcWidth,
@@ -116,9 +128,12 @@ void GLHQScaler::uploadBlock(
 	unsigned srcStartY, unsigned srcEndY, unsigned lineWidth,
 	FrameSource& paintFrame)
 {
-	if ((lineWidth != 320) || (srcEndY > 240)) return;
+	if ((lineWidth % 320 != 0) || (srcEndY > 240)) return;
 
-	std::array<Endian::L32, 320 / 2> tmpBuf2; // 2 x uint16_t
+	std::array<Endian::L32, 320 / 2> tmp320; // 2 x uint16_t
+	std::array<Endian::L32, 640 / 2> tmp640; // 2 x uint16_t
+	std::span<Endian::L32> tmpBuf2;
+	if (lineWidth == 320) tmpBuf2 = tmp320; else tmpBuf2 = tmp640;
 	#ifndef NDEBUG
 	// Avoid UMR. In optimized mode we don't care.
 	ranges::fill(tmpBuf2, 0);
@@ -131,6 +146,7 @@ void GLHQScaler::uploadBlock(
 	EdgeHQ edgeOp(0, 8, 16);
 	calcEdgesGL(curr, next, tmpBuf2, edgeOp);
 
+	gl::PixelBuffer<uint16_t> &edgeBuffer = (lineWidth == 320) ? edgeBuffer320 : edgeBuffer640;
 	edgeBuffer.bind();
 	if (auto* mapped = edgeBuffer.mapWrite()) {
 		for (auto y : xrange(srcStartY, srcEndY)) {
@@ -138,12 +154,12 @@ void GLHQScaler::uploadBlock(
 			std::swap(buf1, buf2);
 			next = paintFrame.getLine(narrow<int>(y + 1), buf2);
 			calcEdgesGL(curr, next, tmpBuf2, edgeOp);
-			memcpy(mapped + 320 * size_t(y), tmpBuf2.data(), 320 * sizeof(uint16_t));
+			memcpy(mapped + lineWidth * size_t(y), tmpBuf2.data(), lineWidth * sizeof(uint16_t));
 		}
 		edgeBuffer.unmap();
 
 		auto format = (OPENGL_VERSION >= OPENGL_3_3) ? GL_RG : GL_LUMINANCE_ALPHA;
-		edgeTexture.bind();
+		if (lineWidth == 320) edgeTexture320.bind(); else edgeTexture640.bind();
 		glTexSubImage2D(GL_TEXTURE_2D,                      // target
 		                0,                                  // level
 		                0,                                  // offset x

--- a/src/video/scalers/GLHQScaler.hh
+++ b/src/video/scalers/GLHQScaler.hh
@@ -24,10 +24,10 @@ public:
 
 private:
 	GLScaler& fallback;
-	gl::Texture edgeTexture;
+	gl::Texture edgeTexture320, edgeTexture640;
 	std::array<gl::Texture, 3> offsetTexture;
 	std::array<gl::Texture, 3> weightTexture;
-	gl::PixelBuffer<uint16_t> edgeBuffer;
+	gl::PixelBuffer<uint16_t> edgeBuffer320, edgeBuffer640;
 };
 
 } // namespace openmsx

--- a/src/video/scalers/GLRGBScaler.cc
+++ b/src/video/scalers/GLRGBScaler.cc
@@ -40,7 +40,7 @@ void GLRGBScaler::scaleImage(
 			src.setInterpolation(true);
 		} else {
 			// treat border as 256-pixel wide display area
-			srcWidth = 320;
+			srcWidth = 640;
 		}
 		auto yScaleF = narrow<float>(yScale);
 		GLfloat a = (yScale & 1) ? 0.5f : ((yScaleF + 1.0f) / (2.0f * yScaleF));

--- a/src/video/scalers/GLScaleNxScaler.cc
+++ b/src/video/scalers/GLScaleNxScaler.cc
@@ -14,7 +14,7 @@ void GLScaleNxScaler::scaleImage(
 	unsigned dstStartY, unsigned dstEndY, unsigned dstWidth,
 	unsigned logSrcHeight)
 {
-	if (srcWidth == 320) {
+	if (srcWidth % 320 == 0) {
 		setup(superImpose != nullptr);
 		execute(src, superImpose,
 		        srcStartY, srcEndY, srcWidth,

--- a/src/video/scalers/HQCommon.hh
+++ b/src/video/scalers/HQCommon.hh
@@ -63,9 +63,9 @@ template<typename EdgeOp>
 void calcEdgesGL(std::span<const uint32_t> curr, std::span<const uint32_t> next,
                  std::span<Endian::L32> edges2, EdgeOp edgeOp)
 {
-	assert(curr.size() == 320);
-	assert(next.size() == 320);
-	assert(edges2.size() == 320 / 2);
+	assert(curr.size() % 320 == 0);
+	assert(next.size() % 320 == 0);
+	assert(edges2.size() % (320 / 2) == 0);
 	// Consider a grid of 3x3 pixels, numbered like this:
 	//    1 | 2 | 3
 	//   ---A---B---
@@ -112,7 +112,7 @@ void calcEdgesGL(std::span<const uint32_t> curr, std::span<const uint32_t> next,
 	Pixel c8 = next[0];
 	if (edgeOp(c5, c8)) pattern |= 0x1800'0000; // edges: 9,D (right pixel)
 
-	for (auto xx : xrange((320 - 2) / 2)) {
+	for (auto xx : xrange((edges2.size() * 2 - 2) / 2)) {
 		pattern = (pattern >> (16 + 9)) & 0x001C;   // edges: 6,D,9 -> 4,7,C        (left pixel)
 		pattern |= (edges2[xx] << 3) & 0xC460'C460; // edges C,8,D,7,9 -> 1,2,3,A,B (left and right)
 


### PR DESCRIPTION
This patch wants to solve https://github.com/openMSX/openMSX/issues/747 ...
It works for me in WSL, not tried on Windows (where I would like to see it fixed mainly).
I don't have much experience with C++ and even less with scalers, so the code may be less than optimal, and perhaps not even entirely correct (functionally and/or in terms of memory handling).

Please review.
I have tried to fix all scalers that needed fixing, not only the HQ and HQ Lite scalers.
I have not fixed any existing bugs, other than making sure that the scalers also run in 640 width modes.
Hence, the TV scaler still has problems with its first and last line, the RGB scaler only works fine in 3x mode and the ScaleNX scaler still looks a bit weird in 4x mode.
