### PR TITLE
Panasonic FS-JH1 Joy Handle emulation

### DIFF
--- a/build/msvc/openmsx.vcxproj
+++ b/build/msvc/openmsx.vcxproj
@@ -510,6 +510,7 @@
     <ClCompile Include="$(OpenMSXSrcDir)\input\JoystickPort.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\input\JoyTap.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\input\JoyMega.cc" />
+    <ClCompile Include="$(OpenMSXSrcDir)\input\JoyHandle.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\input\Keyboard.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\input\KeyboardSettings.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\input\MSXJoystick.cc" />

--- a/build/msvc/openmsx.vcxproj.filters
+++ b/build/msvc/openmsx.vcxproj.filters
@@ -1462,6 +1462,7 @@
     <ClCompile Include="$(OpenMSXSrcDir)\fdc\RawTrack.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\fdc\DMKDiskImage.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\input\JoyMega.cc" />
+    <ClCompile Include="$(OpenMSXSrcDir)\input\JoyHandle.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\memory\RomDooly.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\sound\ResampledSoundDevice.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\video\scalers\GLHQLiteScaler.cc" />

--- a/src/PluggableFactory.cc
+++ b/src/PluggableFactory.cc
@@ -4,6 +4,7 @@
 #include "MSXMotherBoard.hh"
 #include "Reactor.hh"
 #include "JoyMega.hh"
+#include "JoyHandle.hh"
 #include "ArkanoidPad.hh"
 #include "InputEventGenerator.hh"
 #include "JoyTap.hh"
@@ -82,6 +83,12 @@ void PluggableFactory::createAll(PluggingController& controller,
 	controller.registerPluggable(std::make_unique<JoyMega>(
 		commandController, msxEventDistributor,
 		stateChangeDistributor, joystickManager, 2)); // joymega2
+	controller.registerPluggable(std::make_unique<JoyHandle>(
+		commandController, msxEventDistributor,
+		stateChangeDistributor, joystickManager, 1)); // joyhandle1
+	controller.registerPluggable(std::make_unique<JoyHandle>(
+		commandController, msxEventDistributor,
+		stateChangeDistributor, joystickManager, 2)); // joyhandle2
 
 	// Dongles
 	controller.registerPluggable(std::make_unique<SETetrisDongle>());

--- a/src/imgui/ImGuiConnector.cc
+++ b/src/imgui/ImGuiConnector.cc
@@ -19,6 +19,8 @@ namespace openmsx {
 	if (pluggable == "msxjoystick2")       return "MSX joystick 2";
 	if (pluggable == "joymega1")           return "JoyMega controller 1";
 	if (pluggable == "joymega2")           return "JoyMega controller 2";
+	if (pluggable == "joyhandle1")         return "Panasonic FS-JH1 Joy Handle 1";
+	if (pluggable == "joyhandle2")         return "Panasonic FS-JH1 Joy Handle 2";
 	if (pluggable == "arkanoidpad")        return "Arkanoid Vaus paddle";
 	if (pluggable == "ninjatap")           return "Ninja Tap";
 	if (pluggable == "cassetteplayer")     return "Tape deck";

--- a/src/imgui/ImGuiSettings.cc
+++ b/src/imgui/ImGuiSettings.cc
@@ -21,6 +21,7 @@
 #include "InputEventGenerator.hh"
 #include "IntegerSetting.hh"
 #include "JoyMega.hh"
+#include "JoyHandle.hh"
 #include "KeyCodeSetting.hh"
 #include "KeyboardSettings.hh"
 #include "Mixer.hh"
@@ -464,14 +465,16 @@ void ImGuiSettings::showMenu(MSXMotherBoard* motherBoard)
 [[nodiscard]] static std::string settingName(unsigned joystick)
 {
 	return (joystick < 2) ? strCat("msxjoystick", joystick + 1, "_config")
-	                      : strCat("joymega", joystick - 1, "_config");
+	     : (joystick < 4) ? strCat("joymega",     joystick - 1, "_config")
+						  : strCat("joyhandle",   joystick - 3, "_config");
 }
 
 // joystick is 0..3
 [[nodiscard]] static std::string joystickToGuiString(unsigned joystick)
 {
-	return (joystick < 2) ? strCat("MSX joystick ", joystick + 1)
-	                      : strCat("JoyMega controller ", joystick - 1);
+	return (joystick < 2) ? strCat("MSX joystick ",       joystick + 1)
+		 : (joystick < 4) ? strCat("JoyMega controller ", joystick - 1)
+	                      : strCat("Panasonic FS-JH1 ",   joystick - 3);
 }
 
 [[nodiscard]] static std::string toGuiString(const BooleanInput& input, const JoystickManager& joystickManager)
@@ -840,13 +843,79 @@ static void draw(gl::vec2 scrnPos, std::span<uint8_t> hovered, int hoveredRow)
 
 } // namespace joymega
 
+namespace joyhandle {
+
+enum {UP, DOWN, LEFT, RIGHT, TRIG_A, TRIG_B, WHEEL_LEFT, WHEEL_RIGHT, NUM_BUTTONS};
+
+static constexpr std::array<zstring_view, NUM_BUTTONS> buttonNames = {
+	"Up", "Down", "Left", "Right", "A", "B", "Wheel left", "Wheel right" // show in the GUI
+};
+static constexpr std::array<zstring_view, NUM_BUTTONS> keyNames = {
+	"UP", "DOWN", "LEFT", "RIGHT", "A", "B", "WHEEL_LEFT", "WHEEL_RIGHT" // keys in Tcl dict
+};
+
+// TODO just copied from msxjoystick
+// Customize joystick look
+static constexpr auto boundingBox = gl::vec2{300.0f, 100.0f};
+static constexpr auto radius = 20.0f;
+static constexpr auto corner = 10.0f;
+static constexpr auto centerA = gl::vec2{200.0f, 50.0f};
+static constexpr auto centerB = gl::vec2{260.0f, 50.0f};
+static constexpr auto centerDPad = gl::vec2{50.0f, 50.0f};
+static constexpr auto sizeDPad = 30.0f;
+
+[[nodiscard]] static std::vector<uint8_t> buttonsHovered(gl::vec2 mouse)
+{
+	// TODO just copied from msxjoystick
+
+	std::vector<uint8_t> result(NUM_BUTTONS); // false
+	auto mouseDPad = (mouse - centerDPad) * (1.0f / sizeDPad);
+	if (insideRectangle(mouseDPad, Rectangle{{-1, -1}, {1, 1}}) &&
+		(between(mouseDPad.x, -fractionDPad, fractionDPad) ||
+		between(mouseDPad.y, -fractionDPad, fractionDPad))) { // mouse over d-pad
+		bool t1 = mouseDPad.x <  mouseDPad.y;
+		bool t2 = mouseDPad.x < -mouseDPad.y;
+		result[UP]    = !t1 &&  t2;
+		result[DOWN]  =  t1 && !t2;
+		result[LEFT]  =  t1 &&  t2;
+		result[RIGHT] = !t1 && !t2;
+	}
+	result[TRIG_A] = insideCircle(mouse, centerA, radius);
+	result[TRIG_B] = insideCircle(mouse, centerB, radius);
+	result[WHEEL_LEFT] = 0;
+	result[WHEEL_RIGHT] = 0;
+	return result;
+}
+
+static void draw(gl::vec2 scrnPos, std::span<uint8_t> hovered, int hoveredRow)
+{
+	// TODO just copied from msxjoystick
+
+	auto* drawList = ImGui::GetWindowDrawList();
+
+	auto color = getColor(imColor::TEXT);
+	drawList->AddRect(scrnPos, scrnPos + boundingBox, color, corner, 0, thickness);
+
+	drawDPad(scrnPos + centerDPad, sizeDPad, subspan<4>(hovered), hoveredRow);
+
+	auto scrnCenterA = scrnPos + centerA;
+	drawFilledCircle(scrnCenterA, radius, hovered[TRIG_A] || (hoveredRow == TRIG_A));
+	drawLetterA(scrnCenterA);
+
+	auto scrnCenterB = scrnPos + centerB;
+	drawFilledCircle(scrnCenterB, radius, hovered[TRIG_B] || (hoveredRow == TRIG_B));
+	drawLetterB(scrnCenterB);
+}
+
+} // namespace joyhandle
+
 void ImGuiSettings::paintJoystick(MSXMotherBoard& motherBoard)
 {
 	ImGui::SetNextWindowSize(gl::vec2{316, 323}, ImGuiCond_FirstUseEver);
 	im::Window("Configure MSX joysticks", &showConfigureJoystick, [&]{
 		ImGui::SetNextItemWidth(13.0f * ImGui::GetFontSize());
 		im::Combo("Select joystick", joystickToGuiString(joystick).c_str(), [&]{
-			for (const auto& j : xrange(4)) {
+			for (const auto& j : xrange(6)) {
 				if (ImGui::Selectable(joystickToGuiString(j).c_str())) {
 					joystick = j;
 				}
@@ -864,15 +933,18 @@ void ImGuiSettings::paintJoystick(MSXMotherBoard& motherBoard)
 		gl::vec2 mouse = gl::vec2(ImGui::GetIO().MousePos) - scrnPos;
 
 		// Check if buttons are hovered
-		bool msxOrMega = joystick < 2;
-		auto hovered = msxOrMega ? msxjoystick::buttonsHovered(mouse)
-		                         : joymega    ::buttonsHovered(mouse);
+		// bool msxOrMega = joystick < 2;
+		auto hovered = joystick < 2 ? msxjoystick::buttonsHovered(mouse)
+		             : joystick < 4 ? joymega    ::buttonsHovered(mouse)
+									: joyhandle  ::buttonsHovered(mouse);
 		const auto numButtons = hovered.size();
 		using SP = std::span<const zstring_view>;
-		auto keyNames = msxOrMega ? SP{msxjoystick::keyNames}
-		                          : SP{joymega    ::keyNames};
-		auto buttonNames = msxOrMega ? SP{msxjoystick::buttonNames}
-		                             : SP{joymega    ::buttonNames};
+		auto keyNames = joystick < 2 ? SP{msxjoystick::keyNames}
+		              : joystick < 4 ? SP{joymega    ::keyNames}
+		                             : SP{joyhandle  ::keyNames};
+		auto buttonNames = joystick < 2 ? SP{msxjoystick::buttonNames}
+		                 : joystick < 4 ? SP{joymega    ::buttonNames}
+		                                : SP{joyhandle  ::buttonNames};
 
 		// Any joystick button clicked?
 		std::optional<int> addAction;
@@ -883,7 +955,9 @@ void ImGuiSettings::paintJoystick(MSXMotherBoard& motherBoard)
 			}
 		}
 
-		ImGui::Dummy(msxOrMega ? msxjoystick::boundingBox : joymega::boundingBox); // reserve space for joystick drawing
+		ImGui::Dummy(joystick < 2 ? msxjoystick::boundingBox // reserve space for joystick drawing
+		           : joystick < 4 ? joymega    ::boundingBox
+					              : joyhandle  ::boundingBox);
 
 		// Draw table
 		int hoveredRow = -1;
@@ -942,8 +1016,9 @@ void ImGuiSettings::paintJoystick(MSXMotherBoard& motherBoard)
 				}
 			});
 		});
-		msxOrMega ? msxjoystick::draw(scrnPos, hovered, hoveredRow)
-		          : joymega    ::draw(scrnPos, hovered, hoveredRow);
+		  joystick < 2 ? msxjoystick::draw(scrnPos, hovered, hoveredRow)
+		: joystick < 4 ? joymega    ::draw(scrnPos, hovered, hoveredRow)
+		               : joyhandle  ::draw(scrnPos, hovered, hoveredRow);
 
 		if (ImGui::Button("Default bindings...")) {
 			ImGui::OpenPopup("bindings");
@@ -985,9 +1060,9 @@ void ImGuiSettings::paintJoystick(MSXMotherBoard& motherBoard)
 			for (auto joyId : joystickManager.getConnectedJoysticks()) {
 				im::Menu(joystickManager.getDisplayName(joyId).c_str(), [&]{
 					addOrSet([&]{
-						return msxOrMega
-							? MSXJoystick::getDefaultConfig(joyId, joystickManager)
-							: JoyMega::getDefaultConfig(joyId, joystickManager);
+						return joystick < 2 ? MSXJoystick::getDefaultConfig(joyId, joystickManager)
+						     : joystick < 4 ? JoyMega::getDefaultConfig(joyId, joystickManager)
+							                : JoyHandle::getDefaultConfig(joyId, joystickManager);
 					});
 				});
 			}
@@ -1284,10 +1359,11 @@ std::span<const std::string> ImGuiSettings::getAvailableFonts()
 
 bool ImGuiSettings::signalEvent(const Event& event)
 {
-	bool msxOrMega = joystick < 2;
+	// bool msxOrMega = joystick < 2;
 	using SP = std::span<const zstring_view>;
-	auto keyNames = msxOrMega ? SP{msxjoystick::keyNames}
-	                          : SP{joymega    ::keyNames};
+	auto keyNames = joystick < 2 ? SP{msxjoystick::keyNames}
+	              : joystick < 4 ? SP{joymega    ::keyNames}
+				                 : SP{joyhandle  ::keyNames};
 	if (const auto numButtons = keyNames.size(); popupForKey >= numButtons) {
 		deinitListener();
 		return false; // don't block

--- a/src/input/JoyHandle.cc
+++ b/src/input/JoyHandle.cc
@@ -1,5 +1,6 @@
 #include "JoyHandle.hh"
 
+#include "Clock.hh"
 #include "CommandController.hh"
 #include "Event.hh"
 #include "IntegerSetting.hh"

--- a/src/input/JoyHandle.cc
+++ b/src/input/JoyHandle.cc
@@ -1,0 +1,280 @@
+#include "JoyHandle.hh"
+
+#include "CommandController.hh"
+#include "Event.hh"
+#include "IntegerSetting.hh"
+#include "JoystickManager.hh"
+#include "MSXEventDistributor.hh"
+#include "StateChange.hh"
+#include "StateChangeDistributor.hh"
+#include "serialize.hh"
+#include "serialize_meta.hh"
+#include "build-info.hh"
+
+#include "join.hh"
+#include "ranges.hh"
+#include "unreachable.hh"
+#include "xrange.hh"
+
+namespace openmsx {
+
+class JoyHandleState final : public StateChange
+{
+public:
+	JoyHandleState() = default; // for serialize
+	JoyHandleState(EmuTime::param time_, uint8_t id_,
+	               uint8_t press_, uint8_t release_)
+		: StateChange(time_), id(id_)
+		, press(press_), release(release_) {}
+
+	[[nodiscard]] auto getId()      const { return id; }
+	[[nodiscard]] auto getPress()   const { return press; }
+	[[nodiscard]] auto getRelease() const { return release; }
+
+	template<typename Archive> void serialize(Archive& ar, unsigned /*version*/) {
+		ar.template serializeBase<StateChange>(*this);
+		ar.serialize("id",      id,
+		             "press",   press,
+		             "release", release);
+	}
+
+private:
+	uint8_t id, press, release;
+};
+REGISTER_POLYMORPHIC_CLASS(StateChange, JoyHandleState, "JoyHandleState");
+
+TclObject JoyHandle::getDefaultConfig(JoystickId joyId, const JoystickManager& joystickManager)
+{
+	auto buttons = joystickManager.getNumButtons(joyId);
+	if (!buttons) return {};
+
+	TclObject listA, listB;
+	auto joy = joyId.str();
+	for (auto b : xrange(*buttons)) {
+		((b & 1) ? listB : listA).addListElement(tmpStrCat(joy, " button", b));
+	}
+	return TclObject(TclObject::MakeDictTag{},
+		"UP",          makeTclList(tmpStrCat(joy, " hat0 up")),
+		"DOWN",        makeTclList(tmpStrCat(joy, " hat0 down")),
+		"LEFT",        makeTclList(tmpStrCat(joy, " hat0 left")),
+		"RIGHT",       makeTclList(tmpStrCat(joy, " hat0 right")),
+		"A",           listA,
+		"B",           listB,
+		"WHEEL_LEFT",  makeTclList(tmpStrCat(joy, " -axis0")),
+		"WHEEL_RIGHT", makeTclList(tmpStrCat(joy, " +axis0")));
+}
+
+JoyHandle::JoyHandle(CommandController& commandController_,
+                         MSXEventDistributor& eventDistributor_,
+                         StateChangeDistributor& stateChangeDistributor_,
+                         JoystickManager& joystickManager_,
+                         uint8_t id_)
+	: commandController(commandController_)
+	, eventDistributor(eventDistributor_)
+	, stateChangeDistributor(stateChangeDistributor_)
+	, joystickManager(joystickManager_)
+	, configSetting(commandController, tmpStrCat("joyhandle", id_, "_config"),
+		"joyhandle mapping configuration", getDefaultConfig(JoystickId(id_ - 1), joystickManager).getString())
+	, description(strCat("Panasonic FS-JH1 Joy Handle ", id_, ". Mapping is fully configurable."))
+	, id(id_)
+{
+	configSetting.setChecker([this](const TclObject& newValue) {
+		this->checkJoystickConfig(newValue); });
+	// fill in 'bindings'
+	checkJoystickConfig(configSetting.getValue());
+}
+
+JoyHandle::~JoyHandle()
+{
+	if (isPluggedIn()) {
+		JoyHandle::unplugHelper(EmuTime::dummy());
+	}
+}
+
+void JoyHandle::checkJoystickConfig(const TclObject& newValue)
+{
+	std::array<std::vector<BooleanInput>, 8> newBindings;
+
+	auto& interp = commandController.getInterpreter();
+	unsigned n = newValue.getListLength(interp);
+	if (n & 1) {
+		throw CommandException("Need an even number of elements");
+	}
+	for (unsigned i = 0; i < n; i += 2) {
+		static constexpr std::array<std::string_view, 8> keys = {
+			// order is important!
+			"UP", "DOWN", "LEFT", "RIGHT", "A", "B", "WHEEL_LEFT", "WHEEL_RIGHT"
+		};
+		std::string_view key  = newValue.getListIndex(interp, i + 0).getString();
+		auto it = ranges::find(keys, key);
+		if (it == keys.end()) {
+			throw CommandException(
+				"Invalid key: must be one of ", join(keys, ", "));
+		}
+		auto idx = std::distance(keys.begin(), it);
+
+		TclObject value = newValue.getListIndex(interp, i + 1);
+		for (auto j : xrange(value.getListLength(interp))) {
+			std::string_view val = value.getListIndex(interp, j).getString();
+			auto bind = parseBooleanInput(val);
+			if (!bind) {
+				throw CommandException("Invalid binding: ", val);
+			}
+			newBindings[idx].push_back(*bind);
+		}
+	}
+
+	// only change current bindings when parsing was fully successful
+	ranges::copy(newBindings, bindings);
+}
+
+// Pluggable
+std::string_view JoyHandle::getName() const
+{
+	switch (id) {
+		case 1: return "joyhandle1";
+		case 2: return "joyhandle2";
+		default: UNREACHABLE;
+	}
+}
+
+std::string_view JoyHandle::getDescription() const
+{
+	return description;
+}
+
+void JoyHandle::plugHelper(Connector& /*connector*/, EmuTime::param /*time*/)
+{
+	eventDistributor.registerEventListener(*this);
+	stateChangeDistributor.registerListener(*this);
+
+	lastTime = EmuTime::zero();
+	cycle = 0;
+	analogValue = 0;
+}
+
+void JoyHandle::unplugHelper(EmuTime::param /*time*/)
+{
+	stateChangeDistributor.unregisterListener(*this);
+	eventDistributor.unregisterEventListener(*this);
+}
+
+
+// MSXJoystickDevice
+uint8_t JoyHandle::read(EmuTime::param time)
+{
+	checkTime(time);
+	const uint8_t wheelStatus =
+			((analogValue < 0) && ((analogValue == -100) || (cycle == 1))) ? JOY_LEFT
+		  : ((analogValue > 0) && ((analogValue ==  100) || (cycle == 1))) ? JOY_RIGHT
+		  : 0;
+	return status | wheelStatus;
+}
+
+void JoyHandle::write(uint8_t /*value*/, EmuTime::param /*time*/)
+{
+}
+
+void JoyHandle::checkTime(EmuTime::param time)
+{
+	if ((time - lastTime) > EmuDuration::msec(500)) {
+		// longer than 500ms since last read -> change cycle
+		lastTime = time;
+		cycle = 1 - cycle;
+	}
+}
+
+
+// MSXEventListener
+void JoyHandle::signalMSXEvent(const Event& event,
+                               EmuTime::param time) noexcept
+{
+	uint8_t press = 0;
+	uint8_t release = 0;
+
+	auto getJoyDeadZone = [&](JoystickId joyId) {
+		const auto* setting = joystickManager.getJoyDeadZoneSetting(joyId);
+		return setting ? setting->getInt() : 0;
+	};
+	for (int i : xrange(6)) {
+		for (const auto& binding : bindings[i]) {
+			if (auto onOff = match(binding, event, getJoyDeadZone)) {
+				(*onOff ? press : release) |= 1 << i;
+			}
+		}
+	}
+
+	for (int i = 6; i < 8; i++) {
+		for (const auto& binding : bindings[i]) {
+			std::visit(overloaded{
+				[&](const BooleanJoystickAxis& bind, const JoystickAxisMotionEvent& e) {
+					if (bind.getJoystick() != e.getJoystick()) return;
+					if (bind.getAxis() != e.getAxis()) return;
+					int deadZone = getJoyDeadZone(bind.getJoystick()); // percentage 0..100
+					int threshold = (deadZone * 32768) / 100; // 0..32768
+					int halfwayZone = (deadZone + 100) / 2; // percentage 0..100 halfway between deadZone and 100
+					int halfwayThreshold = (halfwayZone * 32768) / 100; // 0..32768
+					if (bind.getDirection() == BooleanJoystickAxis::Direction::POS) {
+						analogValue = e.getValue() > halfwayThreshold ? 100
+									: e.getValue() > threshold        ?  50
+																	  :   0;
+					} else {
+						analogValue = e.getValue() < -halfwayThreshold ? -100
+									: e.getValue() < -threshold        ?  -50
+																	   :    0;
+					}
+				},
+				[](const auto&, const auto&) { /*ignore*/ }
+			}, binding, event);
+		}
+	}
+
+	// TODO send analogValue to JoyHandleState
+
+	if (((status & ~press) | release) != status) {
+		stateChangeDistributor.distributeNew<JoyHandleState>(
+			time, id, press, release);
+	}
+}
+
+// StateChangeListener
+void JoyHandle::signalStateChange(const StateChange& event)
+{
+	const auto* kjs = dynamic_cast<const JoyHandleState*>(&event);
+	if (!kjs) return;
+	if (kjs->getId() != id) return;
+
+	status = (status & ~kjs->getPress()) | kjs->getRelease();
+
+	// TODO receive analogValue from JoyHandleState
+}
+
+void JoyHandle::stopReplay(EmuTime::param time) noexcept
+{
+	uint8_t newStatus = JOY_UP | JOY_DOWN | JOY_LEFT | JOY_RIGHT |
+	                    JOY_BUTTONA | JOY_BUTTONB;
+	if (newStatus != status) {
+		uint8_t release = newStatus & ~status;
+		stateChangeDistributor.distributeNew<JoyHandleState>(
+			time, id, uint8_t(0), release);
+	}
+}
+
+
+template<typename Archive>
+void JoyHandle::serialize(Archive& ar, unsigned /*version*/)
+{
+	ar.serialize("status",      status,
+				 "lastTime",    lastTime,
+				 "cycle",       cycle,
+				 "analogValue", analogValue);
+	if constexpr (Archive::IS_LOADER) {
+		if (isPluggedIn()) {
+			plugHelper(*getConnector(), EmuTime::dummy());
+		}
+	}
+}
+INSTANTIATE_SERIALIZE_METHODS(JoyHandle);
+REGISTER_POLYMORPHIC_INITIALIZER(Pluggable, JoyHandle, "JoyHandle");
+
+} // namespace openmsx

--- a/src/input/JoyHandle.hh
+++ b/src/input/JoyHandle.hh
@@ -54,8 +54,6 @@ private:
 	void signalStateChange(const StateChange& event) override;
 	void stopReplay(EmuTime::param time) noexcept override;
 
-	void checkTime(EmuTime::param time);
-
 private:
 	CommandController& commandController;
 	MSXEventDistributor& eventDistributor;
@@ -70,8 +68,6 @@ private:
 	const uint8_t id;
 	uint8_t status = JOY_UP | JOY_DOWN | JOY_LEFT | JOY_RIGHT |
 	                 JOY_BUTTONA | JOY_BUTTONB;
-	EmuTime lastTime = EmuTime::zero();
-	uint8_t cycle = 0; // 0-1
 	int8_t analogValue = 0;
 };
 

--- a/src/input/JoyHandle.hh
+++ b/src/input/JoyHandle.hh
@@ -75,6 +75,9 @@ private:
 	int8_t analogValue = 0;
 };
 
+[[nodiscard]] std::optional<int8_t> matchAnalog(const BooleanInput& binding, const Event& event,
+												function_ref<int(JoystickId)> getJoyDeadZone);
+
 } // namespace openmsx
 
 #endif

--- a/src/input/JoyHandle.hh
+++ b/src/input/JoyHandle.hh
@@ -1,0 +1,80 @@
+#ifndef JOYHANDLE_HH
+#define JOYHANDLE_HH
+
+#include "JoystickDevice.hh"
+
+#include "BooleanInput.hh"
+#include "MSXEventListener.hh"
+#include "StateChangeListener.hh"
+#include "StringSetting.hh"
+
+#include <array>
+#include <vector>
+
+namespace openmsx {
+
+class CommandController;
+class JoystickManager;
+class MSXEventDistributor;
+class StateChangeDistributor;
+
+class JoyHandle final : public JoystickDevice, private MSXEventListener
+                        , private StateChangeListener
+{
+public:
+	JoyHandle(CommandController& commandController,
+	          MSXEventDistributor& eventDistributor,
+	          StateChangeDistributor& stateChangeDistributor,
+	          JoystickManager& joystickManager,
+	          uint8_t id);
+	~JoyHandle() override;
+
+	[[nodiscard]] static TclObject getDefaultConfig(JoystickId joyId, const JoystickManager& joystickManager);
+
+	template<typename Archive>
+	void serialize(Archive& ar, unsigned version);
+
+private:
+	void checkJoystickConfig(const TclObject& newValue);
+
+	// Pluggable
+	[[nodiscard]] std::string_view getName() const override;
+	[[nodiscard]] std::string_view getDescription() const override;
+	void plugHelper(Connector& connector, EmuTime::param time) override;
+	void unplugHelper(EmuTime::param time) override;
+
+	// MSXJoystickDevice
+	[[nodiscard]] uint8_t read(EmuTime::param time) override;
+	void write(uint8_t value, EmuTime::param time) override;
+
+	// MSXEventListener
+	void signalMSXEvent(const Event& event,
+	                    EmuTime::param time) noexcept override;
+	// StateChangeListener
+	void signalStateChange(const StateChange& event) override;
+	void stopReplay(EmuTime::param time) noexcept override;
+
+	void checkTime(EmuTime::param time);
+
+private:
+	CommandController& commandController;
+	MSXEventDistributor& eventDistributor;
+	StateChangeDistributor& stateChangeDistributor;
+	JoystickManager& joystickManager;
+	StringSetting configSetting;
+
+	// up, down, left, right, a, b, wheel_left, wheel_right (in sync with order in JoystickDevice)
+	std::array<std::vector<BooleanInput>, 8> bindings; // calculated from 'configSetting'
+
+	const std::string description;
+	const uint8_t id;
+	uint8_t status = JOY_UP | JOY_DOWN | JOY_LEFT | JOY_RIGHT |
+	                 JOY_BUTTONA | JOY_BUTTONB;
+	EmuTime lastTime = EmuTime::zero();
+	uint8_t cycle = 0; // 0-1
+	int8_t analogValue = 0;
+};
+
+} // namespace openmsx
+
+#endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -218,6 +218,7 @@ sources = files(
     'input/DummyJoystick.cc',
     'input/EventDelay.cc',
     'input/JoyMega.cc',
+    'input/JoyHandle.cc',
     'input/JoyTap.cc',
     'input/JoystickDevice.cc',
     'input/JoystickPort.cc',


### PR DESCRIPTION
Disclaimer: I am not familiar with C++ development; most of the changes have been done copying from other source codes (such as JoyMega, Paddle, BooleanInput, ...)

An attempt to support Panasonic FS-JH1 Joy Handle emulation. My steps so far:
- Cloned _MSXJoystick_ as _JoyHandle_,
- added it in _PluggableFactory_, _ImGuiConnector_ and _ImGuiSettings_,
- added handling of _BooleanJoystickAxis_ + _JoystickAxisMotionEvent_ in _signalMSXEvent()_ to update _analogValue_, and
- used the _analogValue_ in _read()_.

Code is compiling, Joy Handle can be plugged in its inputs can be mapped, ~~but it seems that the _analogValue_ is never updated~~.
_[Edit: fixed in a260b848eb48734950f1977d52ebaa9dd01a40d2]_

Other things in the _to do_ list:
- _analogValue_ in _JoyHandleState_.
- _analogValue_ serialization.
- Proper input mapping window (right now it is just a clone of MSX Joystick).
