### PR TITLE
Run auto-run on rewind instead of insert tape.

### DIFF
--- a/src/cassette/CassettePlayer.hh
+++ b/src/cassette/CassettePlayer.hh
@@ -1,7 +1,6 @@
 #ifndef CASSETTEPLAYER_HH
 #define CASSETTEPLAYER_HH
 
-#include "EventListener.hh"
 #include "CassetteDevice.hh"
 #include "ResampledSoundDevice.hh"
 #include "MSXMotherBoard.hh"
@@ -26,7 +25,6 @@ class Wav8Writer;
 
 class CassettePlayer final : public CassetteDevice, public ResampledSoundDevice
                            , public MediaInfoProvider
-                           , private EventListener
 {
 public:
 	static constexpr std::string_view TAPE_RECORDING_DIR = "taperecordings";
@@ -125,9 +123,6 @@ private:
 	void fillBuf(size_t length, double x);
 	void flushOutput();
 	void autoRun();
-
-	// EventListener
-	bool signalEvent(const Event& event) override;
 
 	// Schedulable
 	struct SyncEndOfTape final : Schedulable {


### PR DESCRIPTION
This will make sure that at boot the tape is not reinserted. That was a bad idea, because it will make it impossible to reset and continue loading a next item on the tape. A real MSX also doesn't rewind the tape when resetting it.

Fixes #1724.