### PR TITLE
Allow speed settings smaller than 1 (float value).

### DIFF
--- a/src/SpeedManager.cc
+++ b/src/SpeedManager.cc
@@ -7,11 +7,11 @@ namespace openmsx {
 SpeedManager::SpeedManager(CommandController& commandController)
 	: speedSetting(commandController, "speed",
 	       "controls the emulation speed: higher is faster, 100 is normal",
-	       100, 1, 10000, Setting::Save::NO)
+	       100.0, 0.01, 10000.0, Setting::Save::NO)
 	, fastforwardSpeedSetting(commandController, "fastforwardspeed",
 	       "controls the emulation speed in fastforward mode: "
-		   "higher is faster, 100 is normal",
-	       2000, 1, 10000)
+		   "higher is faster, 100 is normal speed",
+	       2000.0, 0.01, 10000.0)
 	, fastforwardSetting(commandController, "fastforward",
 	       "select emulation speed:\n"
 	       " on -> fastforward speed ('fastforwardspeed' setting)\n"
@@ -33,7 +33,7 @@ SpeedManager::~SpeedManager()
 void SpeedManager::updateSpeed()
 {
 	speed = (fastforwardSetting.getBoolean() ? fastforwardSpeedSetting : speedSetting)
-	        .getInt() * (1.0 / 100.0);
+	        .getFloat() * (1.0 / 100.0);
 	notify();
 }
 

--- a/src/SpeedManager.hh
+++ b/src/SpeedManager.hh
@@ -3,7 +3,7 @@
 
 #include "Subject.hh"
 #include "BooleanSetting.hh"
-#include "IntegerSetting.hh"
+#include "FloatSetting.hh"
 
 namespace openmsx {
 
@@ -36,8 +36,8 @@ private:
 	void update(const Setting& setting) noexcept override;
 
 private:
-	IntegerSetting speedSetting;
-	IntegerSetting fastforwardSpeedSetting;
+	FloatSetting speedSetting;
+	FloatSetting fastforwardSpeedSetting;
 	BooleanSetting fastforwardSetting;
 	double speed = 1.0;
 };

--- a/src/imgui/ImGuiSettings.cc
+++ b/src/imgui/ImGuiSettings.cc
@@ -234,10 +234,10 @@ void ImGuiSettings::showMenu(MSXMotherBoard* motherBoard)
 				}
 				im::Indent([&]{
 					im::Disabled(fastForward != 0, [&]{
-						SliderInt("Speed (%)", speedManager.getSpeedSetting());
+						SliderFloat("Speed (%)", speedManager.getSpeedSetting(), "%.1f", ImGuiSliderFlags_Logarithmic);
 					});
 					im::Disabled(fastForward != 1, [&]{
-						SliderInt("Fast forward speed (%)", speedManager.getFastForwardSpeedSetting());
+						SliderFloat("Fast forward speed (%)", speedManager.getFastForwardSpeedSetting(), "%.1f", ImGuiSliderFlags_Logarithmic);
 					});
 				});
 				Checkbox(hotKey, "Go full speed when loading", globalSettings.getThrottleManager().getFullSpeedLoadingSetting());

--- a/src/settings/FloatSetting.cc
+++ b/src/settings/FloatSetting.cc
@@ -5,9 +5,10 @@ namespace openmsx {
 FloatSetting::FloatSetting(CommandController& commandController_,
                            std::string_view name_, static_string_view description_,
                            double initialValue,
-                           double minValue_, double maxValue_)
+                           double minValue_, double maxValue_,
+                           Save save_)
 	: Setting(commandController_, name_, description_,
-	          TclObject(initialValue), Save::YES)
+	          TclObject(initialValue), save_)
 	, minValue(minValue_)
 	, maxValue(maxValue_)
 {

--- a/src/settings/FloatSetting.hh
+++ b/src/settings/FloatSetting.hh
@@ -12,7 +12,8 @@ class FloatSetting final : public Setting
 public:
 	FloatSetting(CommandController& commandController,
 	             std::string_view name, static_string_view description,
-	             double initialValue, double minValue, double maxValue);
+	             double initialValue, double minValue, double maxValue,
+	             Save save = Save::YES);
 
 	[[nodiscard]] std::string_view getTypeString() const override;
 	void additionalInfo(TclObject& result) const override;


### PR DESCRIPTION
This does break updates from openMSX to the Catapult slider. But that's it, the display value is still correct, and control still works towards openMSX.

Fixes #1742.