### PR TITLE
Issue#1780: Toolbar buttons have inconsistent sizes and shapes

### DIFF
--- a/src/imgui/ImGuiDebugger.cc
+++ b/src/imgui/ImGuiDebugger.cc
@@ -11,6 +11,7 @@
 #include "ImGuiUtils.hh"
 #include "ImGuiVdpRegs.hh"
 #include "ImGuiWatchExpr.hh"
+#include "imgui_internal.h"
 
 #include "CPURegs.hh"
 #include "Dasm.hh"
@@ -283,10 +284,16 @@ void ImGuiDebugger::drawControl(MSXCPUInterface& cpuInterface, MSXMotherBoard& m
 			const auto* g = font->FindGlyph(c);
 			buttonSize = max(buttonSize, gl::vec2{g->X1 - g->X0, g->Y1 - g->Y0});
 		}
+		// Create a reasonable minimum square button size.
+		buttonSize = max(buttonSize, gl::vec2(28, 28));
 
 		auto ButtonGlyph = [&](const char* id, ImWchar c, Shortcuts::ID sid) {
-			const auto* g = font->FindGlyph(c);
-			bool result = ImGui::ImageButton(id, texId, buttonSize, {g->U0, g->V0}, {g->U1, g->V1});
+			char glyphString[5];
+			ImTextCharToUtf8(glyphString, c);
+			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 8));
+			ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.5f, 0.5f));
+			bool result = ImGui::Button(glyphString, buttonSize);
+			ImGui::PopStyleVar(2);
 			simpleToolTip([&]() -> std::string {
 				const auto& shortcuts = manager.getShortcuts();
 				const auto& shortcut = shortcuts.getShortcut(sid);


### PR DESCRIPTION
The suggestion in this commit is to change the ImageButton to a Button and convert the glyph symbol to a null terminated character. This makes it easier to align and center the symbol in the button without undesired scaling. As an extra, the buttons have now a bit of margin and the symbols don't look crammed in the button. It takes now a 28x28 pixel size or the largest glyph size, if the default is too small.

See issue #1780, commit 459f221f56328ba0bbd97bd988edef6d825dffd5

I'm not sure if this is a better way, or if you want to keep the buttons as ImageButton type.

The buttons look now like in the screenshot. 
<img width="384" alt="Screenshot 2024-10-12 at 23 27 15" src="https://github.com/user-attachments/assets/6bb180de-e0c0-4f1b-98ae-5cdab28d1c76">
