### PR TITLE
Allow to reset the MSX also after removal of cartridge/extension.

### DIFF
--- a/src/imgui/ImGuiManager.cc
+++ b/src/imgui/ImGuiManager.cc
@@ -687,7 +687,7 @@ void ImGuiManager::paintImGui()
 			});
 		}
 
-		ImGui::Checkbox("Reset MSX on inserting ROM", &media->resetOnInsertRom);
+		ImGui::Checkbox("Reset MSX on inserting ROM", &media->resetOnCartChanges);
 
 		if (ImGui::Button("Insert ROM")) {
 			auto cmd = makeTclList(selectedMedia, "insert", droppedFile);
@@ -695,7 +695,7 @@ void ImGuiManager::paintImGui()
 				cmd.addListElement("-romtype", RomInfo::romTypeToName(selectedRomType));
 			}
 			insert2(strCat("cartridge slot ", char(selectedMedia.back() - 'a' + 'A')), cmd);
-			if (media->resetOnInsertRom) {
+			if (media->resetOnCartChanges) {
 				executeDelayed(TclObject("reset"));
 			}
 			ImGui::CloseCurrentPopup();

--- a/src/imgui/ImGuiMedia.cc
+++ b/src/imgui/ImGuiMedia.cc
@@ -1266,7 +1266,6 @@ void ImGuiMedia::cartridgeMenu(int cartNum)
 					ImGui::SetNextItemWidth(-(ImGui::CalcTextSize("mapper-type").x + style.ItemInnerSpacing.x));
 					interacted |= selectMapperType("mapper-type", item.romType);
 					interacted |= selectPatches(item, group.patchIndex);
-					interacted |= ImGui::Checkbox("Reset MSX on inserting ROM", &resetOnInsertRom);
 					if (interacted) info.select = IMAGE;
 				});
 			});
@@ -1316,10 +1315,11 @@ void ImGuiMedia::cartridgeMenu(int cartNum)
 			if (!current.empty()) {
 				ImGui::RadioButton("Eject", std::bit_cast<int*>(&info.select), to_underlying(EMPTY));
 			}
+			ImGui::Checkbox("Reset MSX on changes", &resetOnCartChanges);
 		});
 		if (insertMediaButton(info.select == EXTENSION ? extName : cartName,
 		                      info.groups[info.select], &info.show)) {
-			if (resetOnInsertRom && info.select == IMAGE) {
+			if (resetOnCartChanges) {
 				manager.executeDelayed(TclObject("reset"));
 			}
 		}

--- a/src/imgui/ImGuiMedia.hh
+++ b/src/imgui/ImGuiMedia.hh
@@ -109,7 +109,7 @@ public:
 	};
 
 public:
-	bool resetOnInsertRom = true;
+	bool resetOnCartChanges = true;
 
 	static void printDatabase(const RomInfo& romInfo, const char* buf);
 	static bool selectMapperType(const char* label, RomType& item);
@@ -153,7 +153,7 @@ private:
 	std::vector<ExtensionInfo> extensionInfo;
 
 	static constexpr auto persistentElements = std::tuple{
-		PersistentElement{"resetOnInsertRom", &ImGuiMedia::resetOnInsertRom},
+		PersistentElement{"resetOnCartChanges", &ImGuiMedia::resetOnCartChanges},
 		// most media stuff is handled elsewhere
 	};
 };


### PR DESCRIPTION
Note that the reset is also performed when the insertion fails. That was already the case before this patch. Maybe not too important.

The patch renames the also persistent variable for the checkbox. I don't think this is an issue in practice.

Closes #1814.