### PR TITLE
Add persistency to open/close status of chips in wave viewer.

### DIFF
--- a/src/imgui/ImGuiWaveViewer.hh
+++ b/src/imgui/ImGuiWaveViewer.hh
@@ -2,6 +2,7 @@
 #define IMGUI_WAVEVIEWER_HH
 
 #include "ImGuiPart.hh"
+#include <set>
 
 namespace openmsx {
 
@@ -12,6 +13,7 @@ public:
 
 	[[nodiscard]] zstring_view iniName() const override { return "wave-viewer"; }
 	void save(ImGuiTextBuffer& buf) override;
+	void loadStart() override;
 	void loadLine(std::string_view name, zstring_view value) override;
 	void paint(MSXMotherBoard* motherBoard) override;
 
@@ -22,6 +24,8 @@ private:
 	static constexpr auto persistentElements = std::tuple{
 		PersistentElement{"show", &ImGuiWaveViewer::show}
 	};
+
+	std::set<std::string> openChips;
 };
 
 } // namespace openmsx


### PR DESCRIPTION
Here's a first attempt. It's a bit odd, as it only adds items with `=1` behind, but this seems to be a simpler solution than storing a list (which may get buggy if commas end up in the name).

Please have  a look at this solution.