### PR TITLE
Fix msvc build error

### DIFF
--- a/src/imgui/ImGuiDisassembly.hh
+++ b/src/imgui/ImGuiDisassembly.hh
@@ -15,7 +15,7 @@ class MSXDevice;
 class MSXCPUInterface;
 class MSXRom;
 class RomBlockDebuggableBase;
-class Symbol;
+struct Symbol;
 class SymbolManager;
 
 class ImGuiDisassembly final : public ImGuiPart


### PR DESCRIPTION
"struct Symbol" is used with an incorrect forward declaration. (declared as a class in forward declaration)