### PR TITLE
fix POSITIONAL mode JAPANESE keymap

### DIFF
--- a/src/input/Keyboard.cc
+++ b/src/input/Keyboard.cc
@@ -227,7 +227,8 @@ static constexpr auto getMSXMapping()
 		M{P{0x11}, K{SDLK_9},           S{SDL_SCANCODE_9}},
 		M{P{0x12}, K{SDLK_MINUS},       S{SDL_SCANCODE_MINUS}},
 		M{P{0x13}, K{SDLK_EQUALS},      S{SDL_SCANCODE_EQUALS}},
-		M{P{0x14}, K{SDLK_BACKSLASH},   S{SDL_SCANCODE_BACKSLASH}},
+//		M{P{0x14}, K{SDLK_BACKSLASH},   S{SDL_SCANCODE_BACKSLASH}},
+		M{P{0x14}, K{SDLK_BACKSLASH},   S{SDL_SCANCODE_BACKSLASH, SDL_SCANCODE_INTERNATIONAL3}}, // japanese yen
 		M{P{0x15}, K{SDLK_LEFTBRACKET}, S{SDL_SCANCODE_LEFTBRACKET}},
 		M{P{0x16}, K{SDLK_RIGHTBRACKET},S{SDL_SCANCODE_RIGHTBRACKET}},
 		M{P{0x17}, K{SDLK_SEMICOLON},   S{SDL_SCANCODE_SEMICOLON}},
@@ -237,7 +238,8 @@ static constexpr auto getMSXMapping()
 		M{P{0x22}, K{SDLK_COMMA},       S{SDL_SCANCODE_COMMA}},
 		M{P{0x23}, K{SDLK_PERIOD},      S{SDL_SCANCODE_PERIOD}},
 		M{P{0x24}, K{SDLK_SLASH},       S{SDL_SCANCODE_SLASH}},
-		M{P{0x25}, K{SDLK_RCTRL},       S{SDL_SCANCODE_RCTRL}}, // Acc
+//      M{P{0x25}, K{SDLK_RCTRL},       S{SDL_SCANCODE_RCTRL}}, // Acc
+		M{P{0x25}, K{SDLK_RCTRL},       S{SDL_SCANCODE_RCTRL, SDL_SCANCODE_NONUSBACKSLASH}}, // Acc / japanese backslash
 		M{P{0x26}, K{SDLK_a},           S{SDL_SCANCODE_A}},
 		M{P{0x27}, K{SDLK_b},           S{SDL_SCANCODE_B}},
 
@@ -991,6 +993,11 @@ bool Keyboard::processQueuedEvent(const Event& event, EmuTime::param time)
 		debug("Key released, keyCode: 0x%05x, keyName: %s\n",
 		      keyEvent.getKeyCode(),
 		      key.toString().c_str());
+	}
+
+	// ** for japanese Kanji mode bug. (Multi-character make keydown event without keyrelease messege) **
+	if (keyEvent.getScanCode() == SDL_SCANCODE_UNKNOWN) {
+		return false;
 	}
 
 	// Process dead keys.


### PR DESCRIPTION
for https://github.com/openMSX/openMSX/issues/1465

1. MSX KEYMATRIX 1-4: (￥) = SDL_SCANCODE_INTERNATIONAL3
2. MSX KEYMATRIX 2-5: (ろ_) = SDL_SCANCODE_NONUSBACKSLASH 
3. Fixed the issue where key release does not occur in IME multi-byte character mode.

see.  https://wiki.libsdl.org/SDL2/SDL_Scancode

- I was able to verify only the Japanese keyboard, but NONUSBACKSLASH may also be effective on keyboards outside Japan.

- I have determined that there is no solution to the CHARACTER/KEY mode problem.
  The behavior in POSITIONAL mode was fixable, so I fixed it.