### PR TITLE
Fatal error and message if init.tcl is not found

### DIFF
--- a/src/Reactor.cc
+++ b/src/Reactor.cc
@@ -543,8 +543,9 @@ void Reactor::runStartupScripts(const CommandLineParser& parser)
 	try {
 		commandController.source(
 			preferSystemFileContext().resolve("init.tcl"));
-	} catch (FileException&) {
-		// no init.tcl, ignore
+	} catch (FileException& e) {
+		throw FatalError("Couldn't execute \"<openmsx>/share/init.tcl\": ",
+		                 e.getMessage());
 	}
 
 	// execute startup scripts


### PR DESCRIPTION
Display more useful error message instead of just crashing, since OpenMSX is still usable without the Tcl environment.