### PR TITLE
[Windows] disable IME on main window (Japanese keyboard fix)

### DIFF
--- a/src/input/Keyboard.cc
+++ b/src/input/Keyboard.cc
@@ -41,6 +41,22 @@
 #include <ranges>
 #include <type_traits>
 
+#if defined(_WIN32)
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>
+#include <imm.h>
+#ifdef _MSC_VER
+#pragma comment(lib, "imm32")
+#endif
+#include "SDL_syswm.h"
+
+#endif // _WIN32
+
+
 namespace openmsx {
 
 // How does the CAPSLOCK key behave?
@@ -709,6 +725,7 @@ Keyboard::Keyboard(MSXMotherBoard& motherBoard,
 	, msxcode2UnicodeCmd(commandController)
 	, unicode2MsxcodeCmd(commandController)
 	, capsLockAligner(eventDistributor, scheduler_)
+	, imeManager(eventDistributor)
 	, keyboardSettings(commandController)
 	, msxKeyEventQueue(scheduler_, commandController.getInterpreter())
 	, keybDebuggable(motherBoard)
@@ -2011,6 +2028,80 @@ void Keyboard::CapsLockAligner::alignCapsLock(EmuTime::param time)
 	}
 }
 
+// class ImeManager
+
+/*  FOR WINDOWS:
+ *  To work around a Japanese keyboard Kanji mode bug. (Multi-character
+ *	input makes a keydown event without keyrelease message.)
+ */
+Keyboard::ImeManager::ImeManager(
+		EventDistributor& eventDistributor_)
+	: eventDistributor(eventDistributor_)
+{
+	for (auto type : { EventType::WINDOW }) {
+		eventDistributor.registerEventListener(type, *this);
+	}
+#if defined(_WIN32)
+	hImc = 0;
+#endif
+}
+
+Keyboard::ImeManager::~ImeManager()
+{
+	for (auto type : { EventType::WINDOW }) {
+		eventDistributor.unregisterEventListener(type, *this);
+	}
+}
+
+/*
+ *  disable IME at msx window.
+ *  -> SDL_WINDOWEVENT_FOCUS_GAINED : IME OFF
+ */
+bool Keyboard::ImeManager::signalEvent(const Event& event)
+{
+#if defined(_WIN32)
+	auto getWindow = [](const WindowEvent& e) -> HWND {
+		SDL_SysWMinfo info;
+		SDL_VERSION(&info.version);
+		auto window = SDL_GetWindowFromID(e.getMainWindowId());
+		if (SDL_GetWindowWMInfo(window, &info)) {
+			return info.info.win.window;
+		}
+		return nullptr;
+	};
+#endif
+
+	std::visit(overloaded{
+		[&](const WindowEvent& e) {
+			if (e.isMainWindow()) {
+				const auto& evt = e.getSdlWindowEvent();
+				if (evt.event == SDL_WINDOWEVENT_FOCUS_GAINED) {
+					auto& keyboard = OUTER(Keyboard, imeManager);
+					if (keyboard.keyboardSettings.getDisableIME()) {
+						// disable IME when focus is gained
+					#if defined(_WIN32)
+						auto hwnd = getWindow(e);
+						if (hwnd) {
+							hImc = ::ImmAssociateContext(hwnd, 0);
+						}
+					#endif
+					}
+				}
+				else if (evt.event == SDL_WINDOWEVENT_FOCUS_LOST) {
+				#if defined(_WIN32)
+					auto hwnd = getWindow(e);
+					if (hwnd && hImc) {
+						hImc = ::ImmAssociateContext(hwnd, hImc);
+					}
+				#endif
+				}
+			}
+		},
+		[](const EventBase&) { UNREACHABLE; }
+	}, event);
+
+	return false;
+}
 
 // class KeybDebuggable
 

--- a/src/input/Keyboard.hh
+++ b/src/input/Keyboard.hh
@@ -20,6 +20,15 @@
 #include <string_view>
 #include <vector>
 
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>
+#include <imm.h>
+#endif // _WIN32
+
 namespace openmsx {
 
 class MSXMotherBoard;
@@ -214,6 +223,24 @@ private:
 			MUST_ALIGN_CAPSLOCK, MUST_DISTRIBUTE_KEY_RELEASE, IDLE
 		} state = IDLE;
 	} capsLockAligner;
+
+	class ImeManager final : private EventListener {
+	public:
+		ImeManager(EventDistributor& eventDistributor);
+		~ImeManager();
+
+	private:
+		// EventListener
+		bool signalEvent(const Event& event) override;
+
+	private:
+		EventDistributor& eventDistributor;
+
+	#if defined(_WIN32)
+		HIMC hImc;
+	#endif
+
+	} imeManager;
 
 	KeyboardSettings keyboardSettings;
 

--- a/src/input/KeyboardSettings.cc
+++ b/src/input/KeyboardSettings.cc
@@ -70,6 +70,10 @@ KeyboardSettings::KeyboardSettings(CommandController& commandController)
 		"kbd_auto_toggle_code_kana_lock",
 		"Automatically toggle the CODE/KANA lock, based on the characters entered on the host keyboard",
 		true)
+	, disableIME(commandController,
+		"kbd_disable_IME",
+		"disable IME, avoid keyboard input problems in Kanji mode",
+		true)
 {
 }
 

--- a/src/input/KeyboardSettings.hh
+++ b/src/input/KeyboardSettings.hh
@@ -42,6 +42,9 @@ public:
 	[[nodiscard]] bool getAutoToggleCodeKanaLock() const {
 		return autoToggleCodeKanaLock.getBoolean();
 	}
+	[[nodiscard]] bool getDisableIME() const {
+		return disableIME.getBoolean();
+	}
 
 private:
 	std::array<EnumSetting<SDL_Keycode>, 3> deadKeyHostKey;
@@ -51,6 +54,7 @@ private:
 	BooleanSetting alwaysEnableKeypad;
 	BooleanSetting traceKeyPresses;
 	BooleanSetting autoToggleCodeKanaLock;
+	BooleanSetting disableIME;
 };
 
 } // namespace openmsx


### PR DESCRIPTION
for issue: https://github.com/openMSX/openMSX/issues/1284

add setting "kbd_disable_IME" (default: true)

Disable IME in main window.
(Subwindows are not suppressed.)

Basically, if the IME is turned on, there will be problems with key input, so the default is kbd_disable_IME=false.

In case you want to use IME in menus etc. in the future, we have added an option to enable IME.