### PR TITLE
focus problem when SetCursorPos called without mnemonic labels

### DIFF
--- a/src/imgui/ImGuiDisassembly.cc
+++ b/src/imgui/ImGuiDisassembly.cc
@@ -479,16 +479,11 @@ void ImGuiDisassembly::paint(MSXMotherBoard* motherBoard)
 								ImGui::TextUnformatted(mnemonic);
 							});
 							if (mnemonicAddr) {
-								ImGui::SetCursorPos(pos);
-								if (ImGui::InvisibleButton("##mnemonicButton", {-FLT_MIN, textSize})) {
-									if (!mnemonicLabels.empty()) {
+								if (!mnemonicLabels.empty()) {
+									ImGui::SetCursorPos(pos);
+									if (ImGui::InvisibleButton("##mnemonicButton", {-FLT_MIN, textSize})) {
 										++cycleLabelsCounter;
 									}
-								}
-								if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
-									nextGotoTarget = *mnemonicAddr;
-								}
-								if (!mnemonicLabels.empty()) {
 									simpleToolTip([&]{
 										auto tip = strCat('#', hex_string<4>(*mnemonicAddr));
 										if (mnemonicLabels.size() > 1) {
@@ -497,6 +492,9 @@ void ImGuiDisassembly::paint(MSXMotherBoard* motherBoard)
 										}
 										return tip;
 									});
+								}
+								if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
+									nextGotoTarget = *mnemonicAddr;
 								}
 							}
 						}


### PR DESCRIPTION
The Mnemonic column normally loses focus on hover where a popup should appear ("multiple possibilites, click to cycle..."), but if there are no mnemonic labels, there is no popup, so the column loses focus (SetCursorPos is called) for nothing.