### PR TITLE
Toggles breakpoint in selected address

### DIFF
--- a/src/imgui/ImGuiDisassembly.hh
+++ b/src/imgui/ImGuiDisassembly.hh
@@ -55,6 +55,8 @@ private:
 	std::string title;
 	size_t cycleLabelsCounter = 0;
 
+	static ImGuiDisassembly* lastWidget;
+	std::optional<uint16_t> selectedAddr = {};
 	std::string gotoAddr;
 	std::string runToAddr;
 	std::optional<unsigned> gotoTarget;


### PR DESCRIPTION
Allow user to select a row by left-clicking on it in the Disassemblywidget until widget loses focus. The selected address changes with the
arrow keys. Pressing the breakpoint shortcut toggles breakpoints in theselected address OR program counter if no address is selected.

This fixes #1852