### PR TITLE
When both laserdisc and cassette are present, autorun the cassette

### DIFF
--- a/src/laserdisc/LaserdiscPlayer.cc
+++ b/src/laserdisc/LaserdiscPlayer.cc
@@ -7,6 +7,7 @@
 #include "HardwareConfig.hh"
 #include "XMLElement.hh"
 #include "CassettePort.hh"
+#include "CassettePlayer.hh"
 #include "MSXCliComm.hh"
 #include "Display.hh"
 #include "GlobalSettings.hh"
@@ -676,6 +677,16 @@ void LaserdiscPlayer::autoRun()
 	if (!autoRunSetting.getBoolean()) return;
 	if (motherBoard.getReverseManager().isReplaying()) {
 		// See comments in CassettePlayer::autoRun()
+		return;
+	}
+
+	auto *player = motherBoard.getCassettePort().getCassettePlayer();
+
+	if (player->getTapeLength(EmuTime::dummy()) > 0) {
+		// Murder Mystery laserdisc has no program encoded on the
+		// right audio channel, but provides a seperate cassette.
+		// So if a cassette and laserdisc is present, do not autoload
+		// the laserdisc but autoload the laserdisc instead.
 		return;
 	}
 

--- a/src/laserdisc/LaserdiscPlayer.cc
+++ b/src/laserdisc/LaserdiscPlayer.cc
@@ -682,7 +682,7 @@ void LaserdiscPlayer::autoRun()
 
 	auto *player = motherBoard.getCassettePort().getCassettePlayer();
 
-	if (player->getTapeLength(EmuTime::dummy()) > 0) {
+	if (player && player->getTapeLength(EmuTime::dummy()) > 0) {
 		// Murder Mystery laserdisc has no program encoded on the
 		// right audio channel, but provides a seperate cassette.
 		// So if a cassette and laserdisc is present, do not autoload


### PR DESCRIPTION
The MysteryDisc has both cassette and laserdisc. This means there is no program encoded on the right auto channel of the laserdisc and so CALLLD will not work.