### PR TITLE
Implemented a programmable device

### DIFF
--- a/doc/manual/user.html
+++ b/doc/manual/user.html
@@ -130,6 +130,12 @@
 					<li><a class="internal" href="#debugdevicemode2">9.4.4 Multi Byte Mode</a></li>
 				</ol>
 			</li>
+			<li><a class="internal" href="#programmabledevice">9.5 Programmable Device</a>
+				<ol class="toc">
+					<li><a class="internal" href="#programmabledeviceenable">9.5.1 Enabling the Programmable Device</a></li>
+					<li><a class="internal" href="#programmabledeviceports">9.5.2 Device Ports and callbacks</a></li>
+				</ol>
+			</li>
 		</ol>
 	</li>
 	<li><a class="internal" href="#contact">10. Contact Info</a></li>
@@ -2489,6 +2495,84 @@ output, all we need to do is change <code>xx</code> for <code>$23</code>:
 In this special case, the space in between the data is left out. Any special
 character like carriage return, linefeed, beep or tab will be printed as you
 would expect.
+</p>
+
+<h3><a id="programmabledevice">9.5 Programmable Device</a></h3>
+
+<p>
+This chapter describes briefly the built-in programmable device, a resource that could prove useful for driver or hardware developers writing and debugging software on openMSX instead of a real MSX. The programmable device is a virtual MSX device that can be connected on the fly to a user-defined list of I/O ports. It can be used to create a two-way communication between the virtual computer and the host operating system by using the high-level Tcl language that openMSX provides. It goes without saying that you must know how to use the Tcl language to use this feature.
+</p>
+<p>
+Note that this is not intended to be used as a drop-in replacement for resource-intensive hardware like VDPs. Tcl is overall a very slow language, but a programmable device opens up possibilities for using openMSX as a development tool that were not possible before.
+</p>
+
+<h4><a id="programmabledeviceenable">9.5.1 Enabling the Programmable Device</a></h4>
+
+<p>
+To enable the programmable device, insert the <code>programmabledevice</code>
+extension. To do this when starting openMSX, simply add
+<code>-ext programmabledevice</code> to the openMSX command line. If openMSX is
+already running, you can use the
+<code><a class="external" href="commands.html#ext">ext</a></code> console command.
+</p>
+
+<h4><a id="programmabledeviceports">9.5.2 Device Ports and callbacks</a></h4>
+
+<p>
+Device ports are a list of I/O ports connected between the guest computer and the
+Tcl environment. This means that anything a Z80 assembly program sends through
+one of these I/O ports using an OUT instruction automatically calls an "output
+callback" (a Tcl procedure) to receive the data on the Tcl side. You must declare
+your own output callback, otherwise the programmable device will do nothing when
+it receives a byte. Your callback must receive two 8-bit parameters (port and
+value) and it shouldn't return anything.
+</p>
+<p>
+Alternatively, anything a Z80 assembly program reads from one of these I/O ports
+using an IN instruction automatically calls an "input callback" on the Tcl side
+to send the data that will be consumed. You also must declare your own input
+callback, otherwise the programmable device will send 0xFF automatically instead
+of something useful. An input callback receives only a port number as parameter,
+but it must return an 8-bit value back.
+</p>
+<p>
+The third kind of callback you can create is the "reset callback". This one
+receives and returns nothing, but it can be useful for setting back an initial
+state when the MSX reboots.
+</p>
+<p>
+You can check the four environment variables that Programmable Device uses with
+the <a class="external" href="commands.html#help">help</a> command, but briefly:
+</p>
+<div class="commandline">
+    <a class="external" href="commands.html#set">set</a> {Programmable Device
+ports} {6 7}
+</div>
+<p>
+tracks I/O ports 6 e 7.
+</p>
+<div class="commandline">
+    <a class="external" href="commands.html#set">set</a> {Programmable Device
+reset callback} "my_reset_proc"
+</div>
+<p>
+connects the reset event with your previously declared "my_reset_proc" callback.
+</p>
+<div class="commandline">
+    <a class="external" href="commands.html#set">set</a> {Programmable Device
+output callback} "my_output_proc"
+</div>
+<p>
+connects the "OUT instruction" event with your previously declared
+"my_output_proc" callback.
+</p>
+<div class="commandline">
+    <a class="external" href="commands.html#set">set</a> {Programmable Device
+input callback} "my_input_proc"
+</div>
+<p>
+connects the "IN instruction" event with your previously declared
+"my_input_proc" callback.
 </p>
 
 <h2><a id="contact">10. Contact Info</a></h2>

--- a/share/extensions/programmabledevice.xml
+++ b/share/extensions/programmabledevice.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<!DOCTYPE msxconfig SYSTEM 'msxconfig2.dtd'>
+<msxconfig>
+  <info>
+    <name>Programmable Device</name>
+    <manufacturer>PVM</manufacturer>
+    <code/>
+    <release_year>2025</release_year>
+    <description>Virtual device to read and write to specific hardware ports.</description>
+    <type>debug tool</type>
+  </info>
+  <devices>
+    <ProgrammableDevice id="Programmable Device">
+    </ProgrammableDevice>
+  </devices>
+</msxconfig>

--- a/src/DeviceFactory.cc
+++ b/src/DeviceFactory.cc
@@ -43,6 +43,7 @@
 #include "PanasonicRam.hh"
 #include "MSXRTC.hh"
 #include "PasswordCart.hh"
+#include "ProgrammableDevice.hh"
 #include "RomFactory.hh"
 #include "MSXPrinterPort.hh"
 #include "SVIPrinterPort.hh"
@@ -279,6 +280,8 @@ std::unique_ptr<MSXDevice> DeviceFactory::create(DeviceConfig& conf)
 		result = make_unique<MSXPac>(conf);
 	} else if (type == "HBI55") {
 		result = make_unique<MSXHBI55>(conf);
+	} else if (type == "ProgrammableDevice") {
+		result = make_unique<ProgrammableDevice>(conf);
 	} else if (type == "DebugDevice") {
 		result = make_unique<DebugDevice>(conf);
 	} else if (type == "V9990") {

--- a/src/MSXDevice.cc
+++ b/src/MSXDevice.cc
@@ -335,6 +335,11 @@ void MSXDevice::registerPorts()
 		}
 	}
 	// .. and only then register the ports. This filters possible overlaps.
+	doRegisterPorts();
+}
+
+void MSXDevice::doRegisterPorts()
+{
 	inPorts.foreachSetBit([&](auto port) {
 		getCPUInterface().register_IO_In(narrow_cast<byte>(port), this);
 	});

--- a/src/MSXDevice.hh
+++ b/src/MSXDevice.hh
@@ -332,10 +332,11 @@ private:
 	void registerSlots();
 	void unregisterSlots();
 
+protected:
 	void registerPorts();
+	void doRegisterPorts();
 	void unregisterPorts();
 
-protected:
 	mutable std::string deviceName; // MSXMultiXxxDevice has a dynamic (lazy) name
 
 	[[nodiscard]] byte getPrimarySlot() const {
@@ -343,6 +344,9 @@ protected:
 		assert((0 <= ps) && (ps <= 3));
 		return narrow_cast<byte>(ps);
 	}
+
+	IterableBitSet<256> inPorts;
+	IterableBitSet<256> outPorts;
 
 private:
 	struct BaseSize {
@@ -352,8 +356,6 @@ private:
 	};
 	using MemRegions = std::vector<BaseSize>;
 	MemRegions memRegions;
-	IterableBitSet<256> inPorts;
-	IterableBitSet<256> outPorts;
 
 	DeviceConfig deviceConfig;
 

--- a/src/ProgrammableDevice.cc
+++ b/src/ProgrammableDevice.cc
@@ -1,0 +1,109 @@
+#include "ProgrammableDevice.hh"
+
+#include "CommandController.hh"
+#include "MSXCliComm.hh"
+#include "MSXCPUInterface.hh"
+#include "MSXException.hh"
+#include "StringSetting.hh"
+#include "serialize.hh"
+
+#include "narrow.hh"
+
+namespace openmsx {
+
+static IterableBitSet<256> parseAllPorts(const Setting& setting);
+
+ProgrammableDevice::ProgrammableDevice(const DeviceConfig& config)
+	: MSXDevice(config)
+	, portListSetting(
+		getCommandController(), tmpStrCat(getName(), " ports"),
+		"List of ports that are added to the pool of I/O ports this extension scans for", "")
+	, resetCallback(getCommandController(),
+		getName() + " reset callback",
+		"Tcl proc to call when reset was detected, no parameters and return values are "
+		"used", "", Setting::Save::NO)
+	, inCallback(getCommandController(),
+		tmpStrCat(getName(), " input callback"),
+		"Defines a Tcl proc that receives a port number (byte) and returns a byte when "
+		"the MSX is reading from a port of the device", "", Setting::Save::NO)
+	, outCallback(getCommandController(),
+		tmpStrCat(getName(), " output callback"),
+		"Defines a Tcl proc that receives a port number (byte) and a byte when the "
+		"MSX is writing to a port from the device", "", Setting::Save::NO)
+{
+	portListSetting.attach(*this);
+	try {
+		outPorts = inPorts = parseAllPorts(portListSetting);
+	} catch (MSXException&) {
+		// silently ignore error in settings.xml
+		portListSetting.setString("");
+	}
+}
+
+ProgrammableDevice::~ProgrammableDevice()
+{
+	portListSetting.detach(*this);
+}
+
+static IterableBitSet<256> parseAllPorts(const Setting& setting)
+{
+	Interpreter& interp = setting.getInterpreter();
+	TclObject portList = setting.getValue();
+	IterableBitSet<256> ports;
+
+	for (unsigned n = 0; n < portList.getListLength(interp); n++) {
+		int tmp = portList.getListIndex(interp, n).getInt(interp);
+		if ((tmp < 0) || (tmp > 255)) {
+		        throw MSXException("outside range 0..255");
+		}
+		ports.set(narrow_cast<byte>(tmp));
+	}
+	return ports;
+}
+
+void ProgrammableDevice::update(const Setting& setting) noexcept
+{
+	try {
+		IterableBitSet<256> tmpPorts = parseAllPorts(setting);
+		unregisterPorts();
+		inPorts = tmpPorts;
+		outPorts = tmpPorts;
+		doRegisterPorts();
+	} catch (MSXException& e) {
+		getCliComm().printWarning(
+			"Parse error in \"",
+			portListSetting.getFullName(), "\": ", e.getMessage());
+	}
+}
+
+void ProgrammableDevice::writeIO(word port, byte value, EmuTime::param /*time*/)
+{
+	outCallback.execute(port, value);
+}
+
+byte ProgrammableDevice::readIO(word port, EmuTime::param /* time */)
+{
+	try {
+		auto obj = inCallback.execute(port);
+		int tmp = obj.getInt(getCommandController().getInterpreter());
+		if ((tmp < 0) || (tmp > 255)) {
+		        throw MSXException("outside range 0..255");
+		}
+		return narrow_cast<byte>(tmp);
+	} catch (MSXException& e) {
+		getCliComm().printWarning(
+			"Wrong result for callback function \"",
+			inCallback.getSetting().getFullName(),
+			"\": ", e.getMessage());
+		return 255;
+	}
+}
+
+void ProgrammableDevice::reset(EmuTime::param /*time*/)
+{
+	resetCallback.execute();
+}
+
+REGISTER_MSXDEVICE(ProgrammableDevice, "ProgrammableDevice");
+
+} // namespace openmsx

--- a/src/ProgrammableDevice.hh
+++ b/src/ProgrammableDevice.hh
@@ -1,0 +1,33 @@
+#ifndef PROGRAMMABLEDEVICE_HH
+#define PROGRAMMABLEDEVICE_HH
+
+#include "MSXDevice.hh"
+#include "StringSetting.hh"
+#include "TclCallback.hh"
+
+namespace openmsx {
+
+class ProgrammableDevice final : public MSXDevice
+                               , private Observer<Setting>
+{
+public:
+	explicit ProgrammableDevice(const DeviceConfig& config);
+	~ProgrammableDevice();
+
+	void writeIO(word port, byte value, EmuTime::param time) override;
+	[[nodiscard]] byte readIO(word port, EmuTime::param time) override;
+	void reset(EmuTime::param time) override;
+
+private:
+	void update(const Setting& setting) noexcept override;
+
+private:
+	StringSetting portListSetting;
+	TclCallback resetCallback;
+	TclCallback inCallback;
+	TclCallback outCallback;
+};
+
+} // namespace openmsx
+
+#endif


### PR DESCRIPTION
The Programmable Device is based on Debug Device and allow developers to easily create prototypes on Tcl to access hardware ports. There are three TclCallbacks for read write and reset.

```
variable {Programmable Device ports} {6 7 242}  ;# read and write ports 6, 7 and 242.
variable {Programmable Device reset callback}  "reset"
variable {Programmable Device input callback}  "read_port"
variable {Programmable Device output callback} "write_port"
```