### PR TITLE
Allow user to call a Tcl proc on exit

### DIFF
--- a/src/GlobalSettings.cc
+++ b/src/GlobalSettings.cc
@@ -13,6 +13,9 @@ GlobalSettings::GlobalSettings(GlobalCommandController& commandController_)
 	        "turn power on/off", false, Setting::Save::NO)
 	, autoSaveSetting(commandController, "save_settings_on_exit",
 	        "automatically save settings when openMSX exits", true)
+	, exitCallBackSetting(commandController, "exit_callback",
+		"Tcl proc to call automatically when openMSX exits", "",
+		Setting::Save::YES)
 	, umrCallBackSetting(commandController, "umr_callback",
 		"Tcl proc to call when an UMR is detected", {})
 	, invalidPsgDirectionsSetting(commandController,
@@ -37,6 +40,7 @@ GlobalSettings::GlobalSettings(GlobalCommandController& commandController_)
 GlobalSettings::~GlobalSettings()
 {
 	getPowerSetting().detach(*this);
+	exitCallBackSetting.execute();
 	commandController.getSettingsConfig().setSaveSettings(
 		autoSaveSetting.getBoolean());
 }

--- a/src/GlobalSettings.hh
+++ b/src/GlobalSettings.hh
@@ -7,6 +7,7 @@
 #include "IntegerSetting.hh"
 #include "StringSetting.hh"
 #include "SpeedManager.hh"
+#include "TclCallback.hh"
 #include "ThrottleManager.hh"
 #include "ResampledSoundDevice.hh"
 #include <memory>
@@ -35,6 +36,9 @@ public:
 	}
 	[[nodiscard]] BooleanSetting& getAutoSaveSetting() {
 		return autoSaveSetting;
+	}
+	[[nodiscard]] TclCallback& getExitCallBackSetting() {
+		return exitCallBackSetting;
 	}
 	[[nodiscard]] StringSetting& getUMRCallBackSetting() {
 		return umrCallBackSetting;
@@ -65,6 +69,7 @@ private:
 	BooleanSetting pauseSetting;
 	BooleanSetting powerSetting;
 	BooleanSetting autoSaveSetting;
+	TclCallback    exitCallBackSetting;
 	StringSetting  umrCallBackSetting;
 	StringSetting  invalidPsgDirectionsSetting;
 	StringSetting  invalidPpiModeSetting;


### PR DESCRIPTION
This allow advanced users to mitigate some of the problems of the lack of a complete session management by giving them power to do things automatically when openMSX exits, such as saving breakpoints to a file. Obviously the user must provide their own Tcl script with session management procs, but this setting makes it possible.