### PR TITLE
better looking palette widget

### DIFF
--- a/src/imgui/ImGuiPalette.cc
+++ b/src/imgui/ImGuiPalette.cc
@@ -153,12 +153,13 @@ void ImGuiPalette::paint(MSXMotherBoard* motherBoard)
 				im::Table("grid", 4, [&]{
 					im::ID_for_range(16, [&](int i) {
 						if (ImGui::TableNextColumn()) {
-							if (i == selectedColor) {
-								ImGui::TableSetBgColor(ImGuiTableBgTarget_CellBg, ImGui::GetColorU32(ImGuiCol_HeaderActive));
-							}
-							if (coloredButton("", paletteRGB[i], {44.0f, 30.0f})) {
-								selectedColor = i;
-							}
+							im::StyleColor(i == selectedColor, ImGuiCol_Border, ImGui::GetColorU32(ImGuiCol_HeaderActive), [&]{
+								ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, i == selectedColor ? 3.0f : 1.0f);
+								if (coloredButton("", paletteRGB[i], {44.0f, 30.0f})) {
+									selectedColor = i;
+								}
+								ImGui::PopStyleVar();
+							});
 						}
 					});
 				});


### PR DESCRIPTION
Changed old palette widget from this:
![image](https://github.com/user-attachments/assets/862b339a-ab26-4180-a1a0-a079b7d84d0f)
into this:
![image](https://github.com/user-attachments/assets/d3ac3692-dc95-41cf-a844-2deba7be4abb)
* left and right border are now visible when first and last column buttons are selected;
* black button on black background has an outline now;