### PR TITLE
VRAM access pointer should also be visible on MSX1

### DIFF
--- a/src/imgui/ImGuiVdpRegs.cc
+++ b/src/imgui/ImGuiVdpRegs.cc
@@ -610,7 +610,15 @@ void ImGuiVdpRegs::paint(MSXMotherBoard* motherBoard)
 				auto colorRegs = tms99x8 ? make_span(colorRegs1) : make_span(colorRegs2);
 				drawSection(colorRegs, registerValues, *vdp, time);
 			});
-			if (!tms99x8) {
+			if (tms99x8) {
+				im::TreeNode("Access registers", &openAccess, [&]{
+					auto addr = vdp->getVramPointer();
+					auto s = tmpStrCat("full address: ", hex_string<4>(addr), '\n');
+					im::StyleColor(ImGuiCol_Text, getColor(imColor::TEXT), [&]{
+						ImGui::TextUnformatted(s);
+					});
+				});
+			} else {
 				im::TreeNode("Display registers", &openDisplay, [&]{
 					static constexpr auto displayRegs = std::to_array<uint8_t>({18, 19, 23});
 					drawSection(displayRegs, registerValues, *vdp, time);


### PR DESCRIPTION
It is useful to know what the value of the VRAM access pointer is for debugging purposes, so it shouldn't just be connected to the MSX2 access register R14. I kept it inside the access registers fold because that is where it was before (principle of least surprise).

![image](https://github.com/user-attachments/assets/508353b9-771f-4713-8fca-cfafe450eaf6)

I know you can already read the VRAM pointer in a hex editor widget via the menu under `Debugger > Add hex editor > VRAM Pointer ...`, but this is kind of obscure for most users.