### PR TITLE
Show internal vram pointer

### DIFF
--- a/src/imgui/ImGuiVdpRegs.cc
+++ b/src/imgui/ImGuiVdpRegs.cc
@@ -278,6 +278,10 @@ static constexpr auto regFunctions = std::array{
 	R{{S{6, 0x3F}}, "sprite pattern table address", [](uint32_t v) {
 		return tmpStrCat("sprite pattern table:   0x", hex_string<5>(v << 11), '\n');
 	  }},
+	R{{S{2, 0}}, "", [](uint32_t) {
+		auto addr = g_vdp->getVramPointer();
+		return tmpStrCat("hidden internal VRAM pointer: 0x", hex_string<4>(addr), '\n');
+	}},
 	R{{S{2, 0}}, "", &spacing},
 
 	// Color registers


### PR DESCRIPTION
A developer on discord remarked that for MSX2 or higher he could see the vram pointer of the VDP but not if he was working on an MSX1 machine. Turned out that he was talking about the fact that on a V99x8 reg #14 showed the extra info of the VRAM pointer as extra info. 
Of course, since a TMS chip has no reg #14 this info wasn't displayed.
This commit displays the extra info of this 14-bits internal pointer/register under the table base registers.