### PR TITLE
save_breakpoint saves all to single file

### DIFF
--- a/share/scripts/breakpoints.tcl
+++ b/share/scripts/breakpoints.tcl
@@ -1,77 +1,43 @@
 # Easily save breakpoints to and restore from a file
 
-namespace eval breakpoints {
-
-proc save {type filename} {
-	set all [dict values [debug $type list]]
+proc save_breakpoints {filename} {
 	set fh [open $filename "w"]
-	puts $fh [join [dict values [debug $type list]] \n]
-	close $fh
-}
-
-proc load {type filename} {
-	set current_bps [dict values [debug $type list]]
-	set fh [open $filename "r"]
-	# compare and create breakpoints if not found
-	foreach bp [split [read -nonewline $fh] \n] {
-		if {$bp in $current_bps} continue
-		debug $type create {*}$bp
+	foreach type {breakpoint watchpoint condition} {
+		puts $fh "\[$type\]\n[join [dict values [debug $type list]] \n]\n"
 	}
 	close $fh
 }
 
-proc make_save_help {type name} {
-	set body "return \"save_$type <filename>\n\nSave all $type to a given file.\""
-	proc $name {args} $body
+proc load_breakpoints {filename} {
+	foreach type {breakpoint watchpoint condition} {
+		set existing_bps($type) [dict values [debug $type list]]
+	}
+	set section {}
+	set fh [open $filename "r"]
+	foreach line [split [read -nonewline $fh] \n] {
+		set line [string trim $line]
+		# load valid file section only
+		if {[regexp {^\[([^\]]+)\]$} $line -> section]} continue
+		if {!($section in {breakpoint watchpoint condition})} continue
+		# compare and create breakpoints if not found
+		if {$line eq {} || $line in $existing_bps($section)} continue
+		debug $section create {*}$line
+	}
+	close $fh
 }
 
-proc make_load_help {type name} {
-	set body "return \"load_$type <filename>\n\nLoad only new $type from a given file, while preserving pre-existing ones if any.\""
-	proc $name {args} $body
-}
+proc save_breakpoints_help {args} {
+	return \
+{save_breakpoints <filename>
 
-make_save_help breakpoints save_breakpoints_help
+Save all breakpoint subtypes (breakpoints, watchpoint, conditions) to a given file.
+}}
 set_help_proc save_breakpoints breakpoints::save_breakpoints_help
 
-make_save_help watchpoints save_watchpoints_help
-set_help_proc save_watchpoints breakpoints::save_watchpoints_help
+proc load_breakpoints_help {args} {
+	return \
+{load_breakpoints <filename>
 
-make_save_help conditions save_conditions_help
-set_help_proc save_conditions breakpoints::save_conditions_help
-
-make_load_help breakpoints load_breakpoints_help
+Load all breakpoint subtypes (breakpoints, watchpoints and conditions) from a given file.
+}}
 set_help_proc load_breakpoints breakpoints::load_breakpoints_help
-
-make_load_help watchpoints load_watchpoints_help
-set_help_proc load_watchpoints breakpoints::load_watchpoints_help
-
-make_load_help conditions load_conditions_help
-set_help_proc load_conditions breakpoints::load_conditions_help
-
-namespace export breakpoints
-
-}
-
-proc save_breakpoints {filename} {
-	breakpoints::save breakpoint $filename
-}
-
-proc save_watchpoints {filename} {
-	breakpoints::save watchpoint $filename
-}
-
-proc save_conditions {filename} {
-	breakpoints::save condition $filename
-}
-
-proc load_breakpoints {filename} {
-	breakpoints::load breakpoint $filename
-}
-
-proc load_watchpoints {filename} {
-	breakpoints::load watchpoint $filename
-}
-
-proc load_conditions {filename} {
-	breakpoints::load condition $filename
-}


### PR DESCRIPTION
GUI command "Breakpoints > Save to file" (#1891) expects a single file to save breakpoints, watchpoints and conditions. This change makes it possible to use a single save_breakpoints function to accommodate this behaviour.