### PR TITLE
rename loadOnStartup to reloadBreakpoints

### DIFF
--- a/src/imgui/ImGuiDebugger.cc
+++ b/src/imgui/ImGuiDebugger.cc
@@ -112,7 +112,7 @@ void ImGuiDebugger::signalContinue()
 
 void ImGuiDebugger::signalQuit()
 {
-	if (saveOnExit) loadSaveBreakpoints(SAVE);
+	if (reloadBreakpoints) loadSaveBreakpoints(SAVE);
 }
 
 template<typename T>
@@ -161,7 +161,7 @@ void ImGuiDebugger::loadStart()
 
 void ImGuiDebugger::loadEnd()
 {
-	if (loadOnStartup) loadSaveBreakpoints(LOAD);
+	if (reloadBreakpoints) loadSaveBreakpoints(LOAD);
 }
 
 void ImGuiDebugger::loadLine(std::string_view name, zstring_view value)
@@ -291,8 +291,7 @@ void ImGuiDebugger::showMenu(MSXMotherBoard* motherBoard)
 				}
 			});
 			ImGui::Separator();
-			ImGui::MenuItem("Save on exit", nullptr, &saveOnExit);
-			ImGui::MenuItem("Load on startup", nullptr, &loadOnStartup);
+			ImGui::MenuItem("Reload on startup", nullptr, &reloadBreakpoints);
 		});
 		ImGui::MenuItem("Symbol manager", nullptr, &manager.symbols->show);
 		ImGui::MenuItem("Watch expression", nullptr, &manager.watchExpr->show);

--- a/src/imgui/ImGuiDebugger.hh
+++ b/src/imgui/ImGuiDebugger.hh
@@ -98,25 +98,23 @@ private:
 	bool showXYFlags = false;
 	int flagsLayout = 1;
 	std::string breakpointFile;
-	bool loadOnStartup = false;
-	bool saveOnExit = false;
+	bool reloadBreakpoints = false;
 
         std::string confirmText;
         std::function<void()> confirmAction;
 
 	static constexpr auto persistentElements = std::tuple{
-		PersistentElement{"showControl",     &ImGuiDebugger::showControl},
-		PersistentElement{"showRegisters",   &ImGuiDebugger::showRegisters},
-		PersistentElement{"showSlots",       &ImGuiDebugger::showSlots},
-		PersistentElement{"showStack",       &ImGuiDebugger::showStack},
-		PersistentElement{"showFlags",       &ImGuiDebugger::showFlags},
-		PersistentElement{"showXYFlags",     &ImGuiDebugger::showXYFlags},
-		PersistentElementMax{"flagsLayout",  &ImGuiDebugger::flagsLayout, 2},
-		PersistentElement{"showChanges",     &ImGuiDebugger::showChanges},
-		PersistentElement{"changesColor",    &ImGuiDebugger::changesColor},
-		PersistentElement{"breakpointFile",  &ImGuiDebugger::breakpointFile},
-		PersistentElement{"loadOnStartup",   &ImGuiDebugger::loadOnStartup},
-		PersistentElement{"saveOnExit",      &ImGuiDebugger::saveOnExit},
+		PersistentElement{"showControl",       &ImGuiDebugger::showControl},
+		PersistentElement{"showRegisters",     &ImGuiDebugger::showRegisters},
+		PersistentElement{"showSlots",         &ImGuiDebugger::showSlots},
+		PersistentElement{"showStack",         &ImGuiDebugger::showStack},
+		PersistentElement{"showFlags",         &ImGuiDebugger::showFlags},
+		PersistentElement{"showXYFlags",       &ImGuiDebugger::showXYFlags},
+		PersistentElementMax{"flagsLayout",    &ImGuiDebugger::flagsLayout, 2},
+		PersistentElement{"showChanges",       &ImGuiDebugger::showChanges},
+		PersistentElement{"changesColor",      &ImGuiDebugger::changesColor},
+		PersistentElement{"breakpointFile",    &ImGuiDebugger::breakpointFile},
+		PersistentElement{"reloadBreakpoints", &ImGuiDebugger::reloadBreakpoints},
 
 		// manually handle "showDebuggable.xxx"
 	};


### PR DESCRIPTION
Doesn't make sense to keep both saveOnExit and loadOnStartup since the only purpose is to restore session breakpoints. A single variable is enough.