### PR TITLE
Fix SIGABRT caused by empty list item

### DIFF
--- a/src/imgui/ImGuiSettings.cc
+++ b/src/imgui/ImGuiSettings.cc
@@ -310,25 +310,23 @@ void ImGuiSettings::showMenu(MSXMotherBoard* motherBoard)
 		im::Menu("GUI", [&]{
 			auto getExistingLayouts = [] {
 				std::vector<std::string> names;
-				for (auto context = userDataFileContext("layouts");
-				     const auto& path : context.getPaths()) {
-					foreach_file(path, [&](const std::string& fullName, std::string_view name) {
+				foreach_file(FileOperations::join(openmsx::FileOperations::getUserOpenMSXDir(), "layouts"),
+					[&](const std::string& fullName, std::string_view name) {
 						if (name.ends_with(".ini")) {
 							names.emplace_back(fullName);
 						}
 					});
-				}
 				std::ranges::sort(names, StringOp::caseless{});
 				return names;
 			};
 			auto listExistingLayouts = [&](const std::vector<std::string>& names) {
 				std::optional<std::pair<std::string, std::string>> selectedLayout;
 				im::ListBox("##select-layout", [&]{
-					for (const auto& name : names) {
+					for (const auto& [id, name] : enumerate(names)) {
 						auto displayName = std::string(FileOperations::stripExtension(FileOperations::getFilename(name)));
-						if (ImGui::Selectable(displayName.c_str())) {
-							selectedLayout = std::pair{name, displayName};
-						}
+						im::ID(id, [&]{
+							if (ImGui::Selectable(displayName.c_str())) selectedLayout = std::pair{name, displayName};
+						});
 						im::PopupContextItem([&]{
 							if (ImGui::MenuItem("delete")) {
 								confirmText = strCat("Delete layout: ", displayName);


### PR DESCRIPTION
How to reproduce this error:
* Go to directory ~/.openMSX/layouts and create a file called ".ini";
* Execute openMSX and open the layout file window in Settings > GUI > Restore layout
* openMSX will crash with the message:
```
openmsx: src/3rdparty/imgui/imgui.cc:11308: bool ImGui::ItemAdd(const ImRect&, ImGuiID, const ImRect*, ImGuiItemFlags): Assertion `id != window->ID && "Cannot have an empty ID at the root of a window. If you need an empty label, use ## and read the FAQ about how the ID Stack works!"' failed.

Thread 1 "openmsx" received signal SIGABRT, Aborted.
0x00007ffff7399b54 in __pthread_kill_implementation () from /lib64/libc.so.6
```