### PR TITLE
Make openMSX compile and run with tcl 9

### DIFF
--- a/build/3rdparty.mk
+++ b/build/3rdparty.mk
@@ -314,7 +314,6 @@ $(BUILD_DIR)/$(PACKAGE_TCL)/Makefile: \
 		--prefix=$(PWD)/$(INSTALL_DIR) \
 		--libdir=$(PWD)/$(INSTALL_DIR)/lib \
 		--disable-shared \
-		--disable-threads \
 		--without-tzdata \
 		$(CONFIGURE_OVERRIDE_TCL) \
 		CFLAGS="$(_CFLAGS)" \

--- a/build/3rdparty/pkg-config-0.29.2.diff
+++ b/build/3rdparty/pkg-config-0.29.2.diff
@@ -1,0 +1,20 @@
+--- pkg-config-0.29.2-orig/glib/glib/goption.c	2016-04-12 00:39:26.000000000 +0300
++++ pkg-config-0.29.2/glib/glib/goption.c	2025-04-22 01:20:52.436090405 +0300
+@@ -166,7 +166,7 @@ typedef struct
+   gpointer arg_data;
+   union
+   {
+-    gboolean bool;
++    gboolean bool2;
+     gint integer;
+     gchar *str;
+     gchar **array;
+@@ -1600,7 +1600,7 @@ free_changes_list (GOptionContext *conte
+           switch (change->arg_type)
+             {
+             case G_OPTION_ARG_NONE:
+-              *(gboolean *)change->arg_data = change->prev.bool;
++              *(gboolean *)change->arg_data = change->prev.bool2;
+               break;
+             case G_OPTION_ARG_INT:
+               *(gint *)change->arg_data = change->prev.integer;

--- a/build/libraries.py
+++ b/build/libraries.py
@@ -372,7 +372,7 @@ class TCL(Library):
 						if isdir(libpath):
 							yield libpath
 							for entry in listdir(libpath):
-								if entry.startswith('tcl8.'):
+								if entry.startswith('tcl9.'):
 									tclpath = libpath + '/' + entry
 									if isdir(tclpath):
 										yield tclpath

--- a/build/packages.py
+++ b/build/packages.py
@@ -139,11 +139,11 @@ class TCL(DownloadablePackage):
 	downloadURL = 'http://downloads.sourceforge.net/tcl'
 	niceName = 'Tcl'
 	sourceName = 'tcl'
-	version = '8.6.15'
-	fileLength = 11765231
+	version = '9.0.1'
+	fileLength = 11697609
 	checksums = {
 		'sha256':
-			'861e159753f2e2fbd6ec1484103715b0be56be3357522b858d3cbb5f893ffef1',
+			'a72b1607d7a399c75148c80fcdead88ed3371a29884181f200f2200cdee33bbc',
 		}
 
 	@classmethod

--- a/share/init.tcl
+++ b/share/init.tcl
@@ -197,8 +197,8 @@ namespace eval openmsx {
 
 # Source all .tcl files in user and system scripts directory. Prefer
 # the version in the user directory in case a script exists in both
-set user_scripts [glob -dir $env(OPENMSX_USER_DATA)/scripts -tails -nocomplain *.tcl]
-set system_scripts [glob -dir $env(OPENMSX_SYSTEM_DATA)/scripts -tails -nocomplain *.tcl]
+set user_scripts [glob -dir $::env(OPENMSX_USER_DATA)/scripts -tails -nocomplain *.tcl]
+set system_scripts [glob -dir $::env(OPENMSX_SYSTEM_DATA)/scripts -tails -nocomplain *.tcl]
 set profile_list [list]
 foreach script [lsort -unique [concat $user_scripts $system_scripts]] {
 	# Skip scripts that start with a '_' character. (By convention) those

--- a/src/commands/Interpreter.cc
+++ b/src/commands/Interpreter.cc
@@ -35,8 +35,7 @@ namespace {
 static std::vector<Trace> traces; // sorted on id
 static uintptr_t traceCount = 0;
 
-
-static int dummyClose(ClientData /*instanceData*/, Tcl_Interp* /*interp*/)
+static int dummyClose(void *foo, Tcl_Interp *bar, int baz)
 {
 	return 0;
 }
@@ -55,8 +54,8 @@ static int dummyGetHandle(ClientData /*instanceData*/, int /*direction*/,
 }
 Tcl_ChannelType Interpreter::channelType = {
 	"openMSX console",	 // Type name
-	nullptr,		 // Always non-blocking
-	dummyClose,		 // Close proc
+	TCL_CHANNEL_VERSION_5,
+	nullptr,		 // Close proc
 	dummyInput,		 // Input proc
 	Interpreter::outputProc, // Output proc
 	nullptr,		 // Seek proc
@@ -64,7 +63,7 @@ Tcl_ChannelType Interpreter::channelType = {
 	nullptr,		 // Get option proc
 	dummyWatch,		 // Watch for events on console
 	dummyGetHandle,		 // Get a handle from the device
-	nullptr,		 // Tcl_DriverClose2Proc
+	dummyClose,		 // Tcl_DriverClose2Proc
 	nullptr,		 // Tcl_DriverBlockModeProc
 	nullptr,		 // Tcl_DriverFlushProc
 	nullptr,		 // Tcl_DriverHandlerProc

--- a/src/commands/TclObject.cc
+++ b/src/commands/TclObject.cc
@@ -140,14 +140,14 @@ std::optional<double> TclObject::getOptionalDouble() const
 
 zstring_view TclObject::getString() const
 {
-	int length;
+	long int length;
 	const char* buf = Tcl_GetStringFromObj(obj, &length);
 	return {buf, size_t(length)};
 }
 
 std::span<const uint8_t> TclObject::getBinary() const
 {
-	int length;
+	long int length;
 	const auto* buf = Tcl_GetByteArrayFromObj(obj, &length);
 	return {buf, size_t(length)};
 }
@@ -155,7 +155,7 @@ std::span<const uint8_t> TclObject::getBinary() const
 unsigned TclObject::getListLength(Interpreter& interp_) const
 {
 	auto* interp = interp_.interp;
-	int result;
+	long int result;
 	if (Tcl_ListObjLength(interp, obj, &result) != TCL_OK) {
 		throwException(interp);
 	}
@@ -163,7 +163,7 @@ unsigned TclObject::getListLength(Interpreter& interp_) const
 }
 unsigned TclObject::getListLengthUnchecked() const
 {
-	int result;
+	long int result;
 	if (Tcl_ListObjLength(nullptr, obj, &result) != TCL_OK) {
 		return 0; // error
 	}

--- a/src/commands/TclParser.cc
+++ b/src/commands/TclParser.cc
@@ -98,7 +98,7 @@ void TclParser::parse(std::string parseStr, int offset, ParseType type)
 		bool allowComplete = ((offset + parseStr.size()) >= colors.size()) &&
 		                     (retryCount < 10);
 		Tcl_Obj* resObj = Tcl_GetObjResult(interp);
-		int resLen;
+		long int resLen;
 		const char* resStr = Tcl_GetStringFromObj(resObj, &resLen);
 		std::string_view error(resStr, resLen);
 


### PR DESCRIPTION
Fedora Linux 42 is out now, shipping with tcl 9. Make openMSX compile and run with tcl 9.
Note that these changes are not backward compatible so this patch cannot be used with tcl 8 systems.