### PR TITLE
Context menu copies sprite pattern to clipboard

### DIFF
--- a/src/imgui/ImGuiSpriteViewer.hh
+++ b/src/imgui/ImGuiSpriteViewer.hh
@@ -60,6 +60,7 @@ private:
 	gl::Texture zoomGridTex{gl::Null{}};
 	gl::Texture checkerTex {gl::Null{}};
 	gl::Texture renderTex  {gl::Null{}};
+	gl::vecN<2, int> gridPosition;
 
 	static constexpr auto validSizes = {8, 16};
 	static constexpr auto persistentElements = std::tuple{


### PR DESCRIPTION
Mirrors the context menu that copies tile patterns and colours to the clipboard.
![image](https://github.com/user-attachments/assets/b151212f-9463-4b45-b48e-18df21af5d54)
