### PR TITLE
Modify Tcl_ChannelType so that openMSX can be compiled either with Tcl8 or Tcl9

### DIFF
--- a/src/commands/Interpreter.cc
+++ b/src/commands/Interpreter.cc
@@ -36,7 +36,11 @@ static std::vector<Trace> traces; // sorted on id
 static uintptr_t traceCount = 0;
 
 
+#if TCL_MAJOR_VERSION < 9
 static int dummyClose(ClientData /*instanceData*/, Tcl_Interp* /*interp*/)
+#else
+static int dummyClose(void* unused1, Tcl_Interp* unused2, int unused3)
+#endif
 {
 	return 0;
 }
@@ -55,8 +59,13 @@ static int dummyGetHandle(ClientData /*instanceData*/, int /*direction*/,
 }
 Tcl_ChannelType Interpreter::channelType = {
 	"openMSX console",	 // Type name
+#if TCL_MAJOR_VERSION < 9
 	nullptr,		 // Always non-blocking
 	dummyClose,		 // Close proc
+#else
+	TCL_CHANNEL_VERSION_5,
+	nullptr,		 // Not used with Tcl9
+#endif
 	dummyInput,		 // Input proc
 	Interpreter::outputProc, // Output proc
 	nullptr,		 // Seek proc
@@ -64,7 +73,11 @@ Tcl_ChannelType Interpreter::channelType = {
 	nullptr,		 // Get option proc
 	dummyWatch,		 // Watch for events on console
 	dummyGetHandle,		 // Get a handle from the device
+#if TCL_MAJOR_VERSION < 9
 	nullptr,		 // Tcl_DriverClose2Proc
+#else
+	dummyClose,		 // Tcl_DriverClose2Proc
+#endif
 	nullptr,		 // Tcl_DriverBlockModeProc
 	nullptr,		 // Tcl_DriverFlushProc
 	nullptr,		 // Tcl_DriverHandlerProc


### PR DESCRIPTION
Modify Tcl_ChannelType using preprocessor directives so that openMSX can be compiled either with Tcl8 or Tcl9.