### PR TITLE
Get rid of GCC -Wstringop-overflow false positive warnings

### DIFF
--- a/src/fdc/DirAsDSK.cc
+++ b/src/fdc/DirAsDSK.cc
@@ -240,7 +240,10 @@ static std::array<char, 11> hostToMsxName(string hostName)
 	std::array<char, 8 + 3> result;
 	std::ranges::fill(result, ' ');
 	copy_to_range(subspan(file, 0, std::min<size_t>(8, file.size())), subspan<8>(result, 0));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 	copy_to_range(subspan(ext,  0, std::min<size_t>(3, ext .size())), subspan<3>(result, 8));
+#pragma GCC diagnostic pop
 	std::ranges::replace(result, '.', '_');
 	return result;
 }

--- a/src/fdc/MSXtar.cc
+++ b/src/fdc/MSXtar.cc
@@ -505,8 +505,11 @@ FileName MSXtar::hostToMSXFileName(string_view hostName) const
 	transform_in_place(extS,  toFileNameChar);
 
 	// add correct number of spaces
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 	copy_to_range(fileS, subspan<8>(result, 0));
 	copy_to_range(extS,  subspan<3>(result, 8));
+#pragma GCC diagnostic pop
 	return result;
 }
 


### PR DESCRIPTION
Get rid of GCC -Wstringop-overflow false positive warnings.