### PR TITLE
Replace use of pkg-config with pkgconf

### DIFF
--- a/build/3rdparty.mk
+++ b/build/3rdparty.mk
@@ -83,7 +83,8 @@ TARGET_TRIPLE:=$(TARGET_TRIPLE)eabi
 endif
 endif
 
-export PKG_CONFIG:=$(PWD)/$(TOOLS_DIR)/bin/$(TARGET_TRIPLE)-pkg-config
+export PACKAGE_PKG_CONFIG=pkgconf-2.4.3
+export PKG_CONFIG:=$(PWD)/$(TOOLS_DIR)/bin/$(TARGET_TRIPLE)-pkgconf
 
 # Ask the compiler for the names and locations of other toolchain components.
 # This works with GCC and Clang at least, so it should be pretty safe.

--- a/build/3rdparty.mk
+++ b/build/3rdparty.mk
@@ -163,12 +163,9 @@ $(BUILD_DIR)/$(PACKAGE_PKG_CONFIG)/Makefile: \
   $(SOURCE_DIR)/$(PACKAGE_PKG_CONFIG)/.extracted
 	mkdir -p $(@D)
 	cd $(@D) && $(PWD)/$(<D)/configure \
-		--with-internal-glib \
-		--disable-host-tool \
 		--program-prefix=$(TARGET_TRIPLE)- \
 		--prefix=$(PWD)/$(TOOLS_DIR) \
 		--libdir=$(PWD)/$(INSTALL_DIR)/lib \
-		CFLAGS="-Wno-error=int-conversion" \
 		CC= LD= AR= RANLIB= STRIP=
 
 # Configure SDL2.

--- a/build/libraries.py
+++ b/build/libraries.py
@@ -19,11 +19,11 @@ from os import environ
 
 def _get_pkg_config(distroRoot):
 	if distroRoot is None:
-		return 'pkg-config'
+		return 'pkgconf'
 	elif distroRoot.startswith('derived/'):
 		toolsDir = '%s/../tools/bin' % distroRoot
 		for name in listdir(toolsDir):
-			if name.endswith('-pkg-config'):
+			if name.endswith('-pkgconf'):
 				return toolsDir + '/' + name
 		raise RuntimeError('No cross-pkg-config found in 3rdparty build')
 	else:

--- a/build/packages.py
+++ b/build/packages.py
@@ -102,15 +102,15 @@ class OpenGL(Package):
 	niceName = 'OpenGL'
 	sourceName = 'gl'
 
-class PkgConfig(DownloadablePackage):
-	downloadURL = 'https://pkg-config.freedesktop.org/releases'
+class PkgConf(DownloadablePackage):
+	downloadURL = 'https://distfiles.ariadne.space/pkgconf'
 	niceName = 'pkg-config'
-	sourceName = 'pkg-config'
-	version = '0.29.2'
-	fileLength = 2016830
+	sourceName = 'pkgconf'
+	version = '2.4.3'
+	fileLength = 468948
 	checksums = {
 		'sha256':
-			'6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591',
+			'cf6be37c79265802f2cb1dfc412e18de23a35b5204fc5868bc09fcfd092ac225',
 		}
 
 class SDL2(DownloadablePackage):


### PR DESCRIPTION
Makefile target staticbindist uses pkg-config that is several years old and it seems like the project is not maintained anymore. Operating systems like Fedora and FreeBSD have already switched to a replacement called 'pkgconf' that is actively maintained.

Using the current git master, target staticbindist does not build without patching on Fedora 42. On FreeBSD 14.2 I could not build it at all due to some strange libiconv related error that has to do with the pkg-config using its internal, very outdated version of glib.

Using this patch, staticbindist builds cleanly on Fedora 42.

Despite working hard for two evenings, I could not get it to build it on FreeBSD 14.2 but the situation is no worse than now.