### PR TITLE
Extend EmuDuration static methods

### DIFF
--- a/src/EmuDuration.hh
+++ b/src/EmuDuration.hh
@@ -39,14 +39,36 @@ public:
 	constexpr explicit EmuDuration(double duration)
 		: time(uint64_t(duration * MAIN_FREQ + 0.5)) {}
 
-	static constexpr EmuDuration sec(unsigned x)
-		{ return EmuDuration(x * MAIN_FREQ); }
-	static constexpr EmuDuration msec(unsigned x)
-		{ return EmuDuration(x * MAIN_FREQ / 1000); }
-	static constexpr EmuDuration usec(unsigned x)
-		{ return EmuDuration(x * MAIN_FREQ / 1000000); }
-	static constexpr EmuDuration hz(unsigned x)
-		{ return EmuDuration(MAIN_FREQ / x); }
+	template<std::integral I>
+	static constexpr EmuDuration sec(I x)
+		{ return EmuDuration(uint64_t(x * MAIN_FREQ)); }
+	template<std::floating_point F>
+	static constexpr EmuDuration sec(F x)
+		{ return EmuDuration(uint64_t(x * MAIN_FREQ + 0.5)); }
+	template<std::integral I>
+	static constexpr EmuDuration msec(I x)
+		{ return EmuDuration(uint64_t(x * MAIN_FREQ / 1000)); }
+	template<std::floating_point F>
+	static constexpr EmuDuration msec(F x)
+		{ return EmuDuration(uint64_t(x * MAIN_FREQ / 1e3 + 0.5)); }
+	template<std::integral I>
+	static constexpr EmuDuration usec(I x)
+		{ return EmuDuration(uint64_t(x * MAIN_FREQ / 1000000)); }
+	template<std::floating_point F>
+	static constexpr EmuDuration usec(F x)
+		{ return EmuDuration(uint64_t(x * MAIN_FREQ / 1e6 + 0.5)); }
+	template<std::integral I>
+	static constexpr EmuDuration nsec(I x)
+		{ return EmuDuration(uint64_t(x * MAIN_FREQ / 1000000000)); }
+	template<std::floating_point F>
+	static constexpr EmuDuration nsec(F x)
+		{ return EmuDuration(uint64_t(x * MAIN_FREQ / 1e9 + 0.5)); }
+	template<std::integral I>
+	static constexpr EmuDuration hz(I x)
+		{ return EmuDuration(uint64_t(MAIN_FREQ / x)); }
+	template<std::floating_point F>
+	static constexpr EmuDuration hz(F x)
+		{ return EmuDuration(uint64_t(MAIN_FREQ / x + 0.5)); }
 
 	// conversions
 	[[nodiscard]] constexpr double toDouble() const { return double(time) * RECIP_MAIN_FREQ; }

--- a/src/EmuDuration.hh
+++ b/src/EmuDuration.hh
@@ -35,9 +35,8 @@ public:
 
 	// constructors
 	constexpr EmuDuration() = default;
-	constexpr explicit EmuDuration(uint64_t n) : time(n) {}
-	constexpr explicit EmuDuration(double duration)
-		: time(uint64_t(duration * MAIN_FREQ + 0.5)) {}
+	template<std::unsigned_integral I>
+	constexpr explicit EmuDuration(I n) : time(n) {}
 
 	template<std::integral I>
 	static constexpr EmuDuration sec(I x)

--- a/src/RealTime.cc
+++ b/src/RealTime.cc
@@ -61,7 +61,7 @@ double RealTime::getRealDuration(EmuTime::param time1, EmuTime::param time2) con
 
 EmuDuration RealTime::getEmuDuration(double realDur) const
 {
-	return EmuDuration(realDur * speedManager.getSpeed());
+	return EmuDuration::sec(realDur * speedManager.getSpeed());
 }
 
 bool RealTime::timeLeft(uint64_t us, EmuTime::param time) const

--- a/src/ReverseManager.cc
+++ b/src/ReverseManager.cc
@@ -40,11 +40,11 @@ static constexpr double SNAPSHOT_PERIOD = 1.0;
 // Max number of snapshots in a replay file
 static constexpr unsigned MAX_NOF_SNAPSHOTS = 10;
 
-// Min distance between snapshots in replay file (in seconds)
-static constexpr auto MIN_PARTITION_LENGTH = EmuDuration(60.0);
+// Min distance between snapshots in replay file
+static constexpr auto MIN_PARTITION_LENGTH = EmuDuration::sec(60.0);
 
-// Max distance of one before last snapshot before the end time in replay file (in seconds)
-static constexpr auto MAX_DIST_1_BEFORE_LAST_SNAPSHOT = EmuDuration(30.0);
+// Max distance of one before last snapshot before the end time in replay file
+static constexpr auto MAX_DIST_1_BEFORE_LAST_SNAPSHOT = EmuDuration::sec(30.0);
 
 // A replay is a struct that contains a vector of motherboards and an MSX event
 // log. Those combined are a replay, because you can replay the events from an
@@ -284,14 +284,14 @@ void ReverseManager::goBack(std::span<const TclObject> tokens)
 	EmuTime now = getCurrentTime();
 	EmuTime target(EmuTime::dummy());
 	if (t >= 0) {
-		EmuDuration d(t);
+		EmuDuration d = EmuDuration::sec(t);
 		if (d < (now - EmuTime::zero())) {
 			target = now - d;
 		} else {
 			target = EmuTime::zero();
 		}
 	} else {
-		target = now + EmuDuration(-t);
+		target = now + EmuDuration::sec(-t);
 	}
 	goTo(target, noVideo);
 }
@@ -301,7 +301,7 @@ void ReverseManager::goTo(std::span<const TclObject> tokens)
 	auto& interp = motherBoard.getReactor().getInterpreter();
 	auto [noVideo, t] = parseGoTo(interp, tokens);
 
-	EmuTime target = EmuTime::zero() + EmuDuration(t);
+	EmuTime target = EmuTime::zero() + EmuDuration::sec(t);
 	goTo(target, noVideo);
 }
 
@@ -358,7 +358,7 @@ void ReverseManager::goTo(
 		// time. This is quite complex to get and the difference between
 		// 2 PAL and 2 NTSC frames isn't that big.
 		static constexpr double dur2frames = 2.0 * (313.0 * 1368.0) / (3579545.0 * 6.0);
-		EmuDuration preDelta(noVideo ? 0.0 : dur2frames);
+		EmuDuration preDelta = EmuDuration::sec(noVideo ? 0.0 : dur2frames);
 		EmuTime preTarget = ((targetTime - firstTime) > preDelta)
 		                  ? targetTime - preDelta
 		                  : firstTime;
@@ -394,7 +394,7 @@ void ReverseManager::goTo(
 		if (sameTimeLine &&
 		    (currentTime <= preTarget) &&
 		    ((snapshotTime <= currentTime) ||
-		     ((preTarget - currentTime) < EmuDuration(1.0)))) {
+		     ((preTarget - currentTime) < EmuDuration::sec(1.0)))) {
 			newBoard = &motherBoard; // use current board
 			// suppress messages just in case, as we're later going
 			// to fast forward to the right time
@@ -455,7 +455,7 @@ void ReverseManager::goTo(
 			auto nextSnapshotTarget = std::min(
 				preTarget,
 				lastSnapshotTarget + std::max(
-					EmuDuration(SNAPSHOT_PERIOD),
+					EmuDuration::sec(SNAPSHOT_PERIOD),
 					(preTarget - lastSnapshotTarget) / 2
 					));
 			auto nextTarget = std::min(nextSnapshotTarget, currentTimeNewBoard + EmuDuration::sec(1));
@@ -703,7 +703,7 @@ void ReverseManager::loadReplay(
 	} else if (*where == "savetime") {
 		destination = replay.currentTime;
 	} else {
-		destination += EmuDuration(where->getDouble(interp));
+		destination += EmuDuration::sec(where->getDouble(interp));
 	}
 
 	// OK, we are going to be actually changing states now
@@ -945,7 +945,7 @@ void ReverseManager::dropOldSnapshots(unsigned count)
 
 void ReverseManager::schedule(EmuTime::param time)
 {
-	syncNewSnapshot.setSyncPoint(time + EmuDuration(SNAPSHOT_PERIOD));
+	syncNewSnapshot.setSyncPoint(time + EmuDuration::sec(SNAPSHOT_PERIOD));
 }
 
 

--- a/src/cassette/CassettePlayer.cc
+++ b/src/cassette/CassettePlayer.cc
@@ -237,7 +237,7 @@ void CassettePlayer::setTapePos(EmuTime::param time, double newPos)
 	assert(getState() != State::RECORD);
 	sync(time);
 	auto pos = std::clamp(newPos, 0.0, getTapeLength(time));
-	tapePos = EmuTime::zero() + EmuDuration(pos);
+	tapePos = EmuTime::zero() + EmuDuration::sec(pos);
 	wind(time);
 }
 

--- a/src/events/AfterCommand.cc
+++ b/src/events/AfterCommand.cc
@@ -501,7 +501,7 @@ double AfterTimedCmd::getTime() const
 void AfterTimedCmd::reschedule()
 {
 	removeSyncPoint();
-	setSyncPoint(getCurrentTime() + EmuDuration(time));
+	setSyncPoint(getCurrentTime() + EmuDuration::sec(time));
 }
 
 void AfterTimedCmd::executeUntil(EmuTime::param /*time*/)

--- a/src/input/EventDelay.cc
+++ b/src/input/EventDelay.cc
@@ -69,7 +69,7 @@ void EventDelay::sync(EmuTime::param curEmu)
 	prevEmu = curEmu;
 
 	double factor = emuDuration.toDouble() / narrow_cast<double>(realDuration);
-	EmuDuration extraDelay(delaySetting.getDouble());
+	EmuDuration extraDelay = EmuDuration::sec(delaySetting.getDouble());
 
 #if PLATFORM_ANDROID
 	// The virtual keyboard on Android sends a key press and the
@@ -135,7 +135,7 @@ void EventDelay::sync(EmuTime::param curEmu)
 		auto sdlOffset = int32_t(sdlNow - eventSdlTime);
 		assert(sdlOffset >= 0);
 		auto offset = 1000 * int64_t(sdlOffset); // ms -> us
-		EmuDuration emuOffset(factor * narrow_cast<double>(offset));
+		EmuDuration emuOffset = EmuDuration::sec(factor * narrow_cast<double>(offset));
 		auto schedTime = (emuOffset < extraDelay)
 		               ? time - emuOffset
 		               : curEmu;

--- a/src/serial/MSXMidi.cc
+++ b/src/serial/MSXMidi.cc
@@ -26,8 +26,8 @@ MSXMidi::MSXMidi(const DeviceConfig& config)
 	, i8251(getScheduler(), interface, getCurrentTime())
 	, i8254(getScheduler(), &cntr0, nullptr, &cntr2, getCurrentTime())
 {
-	EmuDuration total(1.0 / 4e6); // 4MHz
-	EmuDuration hi   (1.0 / 8e6); // 8MHz half clock period
+	EmuDuration total = EmuDuration::hz(4e6); // 4MHz
+	EmuDuration hi    = EmuDuration::hz(8e6); // 8MHz half clock period
 	EmuTime::param time = getCurrentTime();
 	i8254.getClockPin(0).setPeriodicState(total, hi, time);
 	i8254.getClockPin(1).setState(false, time);

--- a/src/serial/MSXRS232.cc
+++ b/src/serial/MSXRS232.cc
@@ -48,8 +48,8 @@ MSXRS232::MSXRS232(DeviceConfig& config)
 		throw MSXException("RS232C only supports 8kB or 16kB ROMs.");
 	}
 
-	EmuDuration total(1.0 / 1.8432e6); // 1.8432MHz
-	EmuDuration hi   (1.0 / 3.6864e6); //   half clock period
+	EmuDuration total = EmuDuration::hz(1.8432e6); // 1.8432MHz
+	EmuDuration hi    = EmuDuration::hz(3.6864e6); //   half clock period
 	EmuTime::param time = getCurrentTime();
 	i8254.getClockPin(0).setPeriodicState(total, hi, time);
 	i8254.getClockPin(1).setPeriodicState(total, hi, time);

--- a/src/sound/MSXMixer.cc
+++ b/src/sound/MSXMixer.cc
@@ -616,7 +616,7 @@ void MSXMixer::unmute()
 void MSXMixer::reInit()
 {
 	prevTime.reset(getCurrentTime());
-	prevTime.setPeriod(EmuDuration(getEffectiveSpeed() / double(hostSampleRate)));
+	prevTime.setPeriod(EmuDuration::sec(getEffectiveSpeed() / double(hostSampleRate)));
 	reschedule();
 }
 void MSXMixer::reschedule()

--- a/src/sound/ResampledSoundDevice.cc
+++ b/src/sound/ResampledSoundDevice.cc
@@ -59,7 +59,7 @@ void ResampledSoundDevice::createResampler()
 {
 	const DynamicClock& hostClock = getHostSampleClock();
 	EmuDuration outputPeriod = hostClock.getPeriod();
-	EmuDuration inputPeriod(getEffectiveSpeed() / double(getInputRate()));
+	EmuDuration inputPeriod = EmuDuration::sec(getEffectiveSpeed() / double(getInputRate()));
 	emuClock.reset(hostClock.getTime());
 	emuClock.setPeriod(inputPeriod);
 


### PR DESCRIPTION
To include `nsec` and floating point versions of `sec`, `msec`, `usec` and `hz`. Using concepts to prevent ambiguity errors.

Also remove the `double` overload of the constructor, which was interpreted very differently from the `uint64` version. Use `EmuDuration::sec()` instead.

I resisted the urge to rename `sec`, `msec` and `usec` to `s`, `ms` and `us` respectively.

I considered using `std::unsigned_integral` for the static methods, however that’s less ergonomic since you have to add `U` suffixes to all integer literals that you pass in, and negative floating point numbers can’t be prevented either anyway.