### PR TITLE
packages: Update zlib to 1.3.1.

### DIFF
--- a/build/3rdparty/3rdparty.props
+++ b/build/3rdparty/3rdparty.props
@@ -22,7 +22,7 @@
     <LibNameTcl>tcl8.6.15</LibNameTcl>
     <LibNameTheora>libtheora-1.1.1</LibNameTheora>
     <LibNameVorbis>libvorbis-1.3.7</LibNameVorbis>
-    <LibNameZlib>zlib-1.2.11</LibNameZlib>
+    <LibNameZlib>zlib-1.3.1</LibNameZlib>
   </PropertyGroup>
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>

--- a/build/packages.py
+++ b/build/packages.py
@@ -185,14 +185,14 @@ class Vorbis(DownloadablePackage):
 		return 'VORBIS'
 
 class ZLib(DownloadablePackage):
-	downloadURL = 'http://downloads.sourceforge.net/libpng'
+	downloadURL = 'https://zlib.net/fossils/'
 	niceName = 'zlib'
 	sourceName = 'zlib'
-	version = '1.2.11'
-	fileLength = 607698
+	version = '1.3.1'
+	fileLength = 1512791
 	checksums = {
 		'sha256':
-			'c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1',
+			'9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23',
 		}
 
 # Build a dictionary of packages using introspection.


### PR DESCRIPTION
The 1.2.11 release has a compatibility issue with the XCode 16.4 SDK. Something to do with a macro that nulls `fdopen(fd,mode)`. This issue does not occur with zlib 1.3.1 (latest version).

```
In file included from zutil.c:10:
In file included from ./gzguts.h:21:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/stdio.h:61:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/_stdio.h:318:7: error: expected identifier or '('
  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
      |          ^
./zutil.h:140:33: note: expanded from macro 'fdopen'
  140 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:16: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |                ^
```