### PR TITLE
macOS: Fix CI build for pull requests.

### DIFF
--- a/.github/workflows/build_release_from_tag_via_tarball.yml
+++ b/.github/workflows/build_release_from_tag_via_tarball.yml
@@ -108,8 +108,8 @@ jobs:
       with:
         os: ${{ matrix.os }}
     - name: Perform build on extracted tarball
-      env: 
-        CODE_SIGN_IDENTITY: 748867M822
+      env:
+        CODE_SIGN_IDENTITY: ${{ vars.CODE_SIGN_IDENTITY }}
       # Directory name only
       uses: ./.github/actions/build
       with:

--- a/.github/workflows/build_snapshots.yml
+++ b/.github/workflows/build_snapshots.yml
@@ -79,7 +79,8 @@ jobs:
       if: ${{ matrix.xcode_version }}
       run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer
     - name: Preparations for signing binaries on Darwin builds
-      if: ${{ matrix.os == 'darwin' }}
+      # Don't fail build for pull requests if vars and secrets are not defined.
+      if: ${{ matrix.os == 'darwin' && vars.CODE_SIGN_IDENTITY }}
       uses: ./.github/actions/prepare-sign
       env:
         BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
@@ -88,8 +89,8 @@ jobs:
       with:
         os: ${{ matrix.os }}
     - name: Perform the actual build
-      env: 
-        CODE_SIGN_IDENTITY: 748867M822
+      env:
+        CODE_SIGN_IDENTITY: ${{ vars.CODE_SIGN_IDENTITY }}
       # Directory name only
       uses: ./.github/actions/build
       with:


### PR DESCRIPTION
Code sign identity is now specified in a GitHub Actions repository variable. This will allow forks to do their own code signing. If not configured, then the code is not signed (and can’t be distributed) but the build will succeed.

See 244eabd for the previous fix, which was lost in 2d060e7 / a281e5d.

I configured the following secrets:

![afbeelding](https://github.com/user-attachments/assets/a6d931ec-e05a-4efe-98d2-51e37755cc81)

And the following variables:

![afbeelding](https://github.com/user-attachments/assets/5e794d49-1fc9-4d4a-bab8-8d6d7756f4e3)

In the current openMSX repository the secrets will already have been configured, but for this change the `CODE_SIGN_IDENTITY` variable should be added with the value `748867M822`.