### PR TITLE
Silence implicit conversion warnings.

### DIFF
--- a/src/fdc/MSXFDC.cc
+++ b/src/fdc/MSXFDC.cc
@@ -5,6 +5,7 @@
 #include "ConfigException.hh"
 #include "CacheLine.hh"
 #include "enumerate.hh"
+#include "narrow.hh"
 #include "serialize.hh"
 #include <array>
 #include <memory>
@@ -87,10 +88,11 @@ void MSXFDC::parseRomVisibility(DeviceConfig& config, unsigned defaultBase, unsi
 	if (base & CacheLine::LOW) throw ConfigException("rom_visibility base must be a multiple of 0x100.");
 	if (size & CacheLine::LOW) throw ConfigException("rom_visibility size must be a multiple of 0x100.");
 	if (base >= 0x10000) throw ConfigException("rom_visibility base must be between 0 and 0xFFFF.");
-	if (size > 0x10000) throw ConfigException("rom_visibility size must be between 0 and 0x10000.");
+	if (size < 1 || size > 0x10000) throw ConfigException("rom_visibility size must be between 1 and 0x10000.");
+	if (base + size > 0x10000) throw ConfigException("rom_visibility base + size must be between 1 and 0x10000.");
 
-	romVisibilityStart = base;
-	romVisibilityLast = base + size - 1;
+	romVisibilityStart = narrow_cast<uint16_t>(base);
+	romVisibilityLast = narrow_cast<uint16_t>(base + size - 1);
 }
 
 

--- a/src/imgui/ImGuiCharacter.cc
+++ b/src/imgui/ImGuiCharacter.cc
@@ -412,7 +412,7 @@ void ImGuiCharacter::paint(MSXMotherBoard* motherBoard)
 				printAddressRange8("Color", colTable.getAddress((mode == SCR1) ? (pattern / 8) : (8 * pattern)));
 			}
 		};
-		auto formatBinaryData = [&](uint16_t address) {
+		auto formatBinaryData = [&](unsigned address) {
 			return formatToString([&](unsigned addr){ return vram[addr]; }, address, address + 7, {}, 1, {}, "%02X", manager.getInterpreter());
 		};
 		auto getPatternFromGrid = [&]() {

--- a/src/imgui/ImGuiSpriteViewer.cc
+++ b/src/imgui/ImGuiSpriteViewer.cc
@@ -334,7 +334,7 @@ void ImGuiSpriteViewer::paint(MSXMotherBoard* motherBoard)
 				}
 			});
 		};
-		auto formatClipboardData = [&](uint16_t address, size_t size) {
+		auto formatClipboardData = [&](unsigned address, unsigned size) {
 			return formatToString([&](unsigned addr) { return vram[addr]; }, address, address + size - 1, {}, 1, {}, "%02X", manager.getInterpreter());
 		};
 


### PR DESCRIPTION
Getting these when compiling with Apple Clang.

```
src/fdc/MSXFDC.cc:92:23: warning: implicit conversion loses integer precision: 'unsigned int' to 'uint16_t' (aka 'unsigned short') [-Wimplicit-int-conversion]
        romVisibilityStart = base;
                           ~ ^~~~
src/fdc/MSXFDC.cc:93:34: warning: implicit conversion loses integer precision: 'unsigned int' to 'uint16_t' (aka 'unsigned short') [-Wimplicit-int-conversion]
        romVisibilityLast = base + size - 1;
                          ~ ~~~~~~~~~~~~^~~
```

```
src/imgui/ImGuiCharacter.cc:429:69: warning: implicit conversion loses integer precision: 'unsigned int' to 'uint16_t' (aka 'unsigned short') [-Wimplicit-int-conversion]
                                        auto text = strCat("Pattern data\n", formatBinaryData(patTable.getAddress(8 * pattern)));
                                                                             ~~~~~~~~~~~~~~~~ ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
src/imgui/ImGuiCharacter.cc:432:65: warning: implicit conversion loses integer precision: 'unsigned int' to 'uint16_t' (aka 'unsigned short') [-Wimplicit-int-conversion]
                                                strAppend(text, "Color data\n", formatBinaryData(colTable.getAddress(cp)));
                                                                                ~~~~~~~~~~~~~~~~ ~~~~~~~~~^~~~~~~~~~~~~~
```

```
src/imgui/ImGuiSpriteViewer.cc:338:93: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'unsigned int' [-Wshorten-64-to-32]
                        return formatToString([&](unsigned addr) { return vram[addr]; }, address, address + size - 1, {}, 1, {}, "%02X", manager.getInterpreter());
                               ~~~~~~~~~~~~~~                                                     ~~~~~~~~~~~~~~~^~~
src/imgui/ImGuiSpriteViewer.cc:428:43: warning: implicit conversion loses integer precision: 'unsigned int' to 'uint16_t' (aka 'unsigned short') [-Wimplicit-int-conversion]
                                                return formatClipboardData(patTable.getAddress(8 * pattern), size == 16 ? 32 : 8);
                                                       ~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
src/imgui/ImGuiSpriteViewer.cc:510:43: warning: implicit conversion loses integer precision: 'unsigned int' to 'uint16_t' (aka 'unsigned short') [-Wimplicit-int-conversion]
                                                return formatClipboardData(attTable.getAddress(getSpriteColorAddr(sprite, mode)), size);
                                                       ~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```