### PR TITLE
Visual Studio Code complains about C++23ism

### DIFF
--- a/src/debugger/DasmTables.hh
+++ b/src/debugger/DasmTables.hh
@@ -12,7 +12,7 @@ extern const std::array<const char*, 256> mnemonic_ed;
 extern const std::array<const char*, 256> mnemonic_xx;
 extern const std::array<const char*, 256> mnemonic_main;
 
-extern const std::array<uint8_t, 3uz * 256> instr_len_tab;
+extern const std::array<uint8_t, 3u * 256> instr_len_tab;
 
 } // namespace openmsx
 


### PR DESCRIPTION
"3uz" is a size_t (or ptrdiff_t) suffix introduced in C++23 which VC doesn't recognize.