### PR TITLE
Added the ability to specify variation indexes for .ttc font files.

### DIFF
--- a/src/console/OSDText.cc
+++ b/src/console/OSDText.cc
@@ -44,12 +44,19 @@ void OSDText::setProperty(
 		std::string val(value.getString());
 		if (fontFile != val) {
 			if (std::string file = systemFileContext().resolve(val);
-			    !FileOperations::isRegularFile(file)) {
+				!FileOperations::isRegularFile(file)) {
 				throw CommandException("Not a valid font file: ", val);
 			}
 			fontFile = val;
 			invalidateRecursive();
 		}
+	} else if (propName == "-fontfaceindex") {
+		int val = value.getInt(interp);
+		if (val < 0) {
+			throw CommandException("Not a valid value for -fontfaceindex, "
+					"should be 0 or greater integer: ", val);
+		}
+		fontFaceIndex = val;
 	} else if (propName == "-size") {
 		int size2 = value.getInt(interp);
 		if (size != size2) {
@@ -98,6 +105,8 @@ void OSDText::getProperty(std::string_view propName, TclObject& result) const
 		result = text;
 	} else if (propName == "-font") {
 		result = fontFile;
+	} else if (propName == "-fontfaceindex") {
+		result = fontFaceIndex;
 	} else if (propName == "-size") {
 		result = size;
 	} else if (propName == "-wrap") {
@@ -155,7 +164,7 @@ std::unique_ptr<GLImage> OSDText::create(OutputSurface& output)
 	if (font.empty()) {
 		try {
 			font = TTFFont(systemFileContext().resolve(fontFile),
-			               size * scale);
+			               size * scale, fontFaceIndex);
 		} catch (MSXException& e) {
 			throw MSXException("Couldn't open font: ", e.getMessage());
 		}

--- a/src/console/OSDText.hh
+++ b/src/console/OSDText.hh
@@ -20,7 +20,7 @@ private:
 		return concatArray(
 			imageBasedProperties,
 			std::array{
-				"-text"sv, "-font"sv, "-size"sv,
+				"-text"sv, "-font"sv, "-fontfaceindex"sv, "-size"sv,
 				"-wrap"sv, "-wrapw"sv, "-wraprelw"sv,
 			});
 	}();
@@ -58,6 +58,7 @@ private:
 	std::string fontFile;
 	TTFFont font;
 	int size = 12;
+	int fontFaceIndex = 0;
 	WrapMode wrapMode = NONE;
 	float wrapw = 0.0f, wraprelw = 1.0f;
 

--- a/src/console/TTFFont.cc
+++ b/src/console/TTFFont.cc
@@ -39,7 +39,7 @@ public:
 	TTFFontPool& operator=(TTFFontPool&&) = delete;
 
 	static TTFFontPool& instance();
-	TTF_Font* get(const std::string& filename, int ptSize);
+	TTF_Font* get(const std::string& filename, int ptSize, int faceIndex);
 	void release(TTF_Font* font);
 
 private:
@@ -66,6 +66,7 @@ private:
 		std::string name;
 		int size;
 		int count;
+		long faceIndex;
 	};
 	std::vector<FontInfo> pool;
 };
@@ -105,7 +106,7 @@ TTFFontPool& TTFFontPool::instance()
 	return oneInstance;
 }
 
-TTF_Font* TTFFontPool::get(const std::string& filename, int ptSize)
+TTF_Font* TTFFontPool::get(const std::string& filename, int ptSize, int faceIndex)
 {
 	if (auto it = std::ranges::find(pool, std::tuple(filename, ptSize),
 	        [](auto& info) { return std::tuple(info.name, info.size); });
@@ -117,7 +118,7 @@ TTF_Font* TTFFontPool::get(const std::string& filename, int ptSize)
 	SDLTTF::instance(); // init library
 	FontInfo info;
 	info.file = LocalFileReference(filename);
-	auto* result = TTF_OpenFont(info.file.getFilename().c_str(), ptSize);
+	auto* result = TTF_OpenFontIndex(info.file.getFilename().c_str(), ptSize, faceIndex);
 	if (!result) {
 		throw MSXException(TTF_GetError());
 	}
@@ -125,6 +126,7 @@ TTF_Font* TTFFontPool::get(const std::string& filename, int ptSize)
 	info.name = filename;
 	info.size = ptSize;
 	info.count = 1;
+	info.faceIndex = faceIndex;
 	pool.push_back(std::move(info));
 	return result;
 }
@@ -142,8 +144,9 @@ void TTFFontPool::release(TTF_Font* font)
 
 // class TTFFont
 
-TTFFont::TTFFont(const std::string& filename, int ptSize)
-	: font(TTFFontPool::instance().get(filename, ptSize))
+TTFFont::TTFFont(const std::string& filename, int ptSize, int in_faceIndex)
+	: font(TTFFontPool::instance().get(filename, ptSize, in_faceIndex)),
+	  faceIndex(in_faceIndex)
 {
 }
 

--- a/src/console/TTFFont.hh
+++ b/src/console/TTFFont.hh
@@ -25,11 +25,12 @@ public:
 	TTFFont() = default;
 
 	/** Construct new TTFFont object.
-	  * @param filename Filename of font (.fft file, possibly (g)zipped).
+	  * @param filename Filename of font (.ttf/.ttc/.otf, possibly (g)zipped).
 	  * @param ptSize Point size (based on 72DPI) to load font as.
+	  * @param faceIndex The face number when filename points .ttc font.
 	  * post-condition: !empty()
 	  */
-	TTFFont(const std::string& filename, int ptSize);
+	TTFFont(const std::string& filename, int ptSize, int faceIndex);
 
 	/** Move construct. */
 	TTFFont(TTFFont&& other) noexcept
@@ -74,8 +75,11 @@ public:
 	 */
 	[[nodiscard]] gl::ivec2 getSize(zstring_view text) const;
 
+	[[nodiscard]] int getFaceIndex() const { return faceIndex; }
+
 private:
 	void* font = nullptr;  // TTF_Font*
+	int faceIndex = 0;
 };
 
 } // namespace openmsx

--- a/src/imgui/ImGuiManager.hh
+++ b/src/imgui/ImGuiManager.hh
@@ -97,7 +97,7 @@ public:
 
 private:
 	void initializeImGui();
-	[[nodiscard]] ImFont* addFont(zstring_view filename, int fontSize);
+	[[nodiscard]] ImFont* addFont(zstring_view filename, int fontSize, long fontIndex);
 	void loadFont();
 	void reloadFont();
 	void drawStatusBar(MSXMotherBoard* motherBoard);
@@ -136,6 +136,8 @@ public:
 	IntegerSetting fontMonoSize;
 	ImFont* fontProp = nullptr;
 	ImFont* fontMono = nullptr;
+	IntegerSetting fontPropIndex;
+	IntegerSetting fontMonoIndex;
 
 	std::unique_ptr<ImGuiMachine> machine;
 	std::unique_ptr<ImGuiDebugger> debugger;

--- a/src/imgui/ImGuiSettings.cc
+++ b/src/imgui/ImGuiSettings.cc
@@ -1033,6 +1033,9 @@ void ImGuiSettings::paintFont()
 		auto selectFilename = [&](FilenameSetting& setting, float width) {
 			auto display = [](std::string_view name) {
 				if (name.ends_with(".gz" )) name.remove_suffix(3);
+				// The next line might be fixed. Because:
+				// 1) .ttc and .otf files can be loaded
+				// 2) The extension of font files may be upper case.
 				if (name.ends_with(".ttf")) name.remove_suffix(4);
 				return std::string(name);
 			};
@@ -1058,6 +1061,18 @@ void ImGuiSettings::paintFont()
 				}
 			});
 		};
+		auto selectIndex = [](IntegerSetting& setting) {
+			auto display = [](int s) { return strCat(s); };
+			auto current = setting.getInt();
+			ImGui::SetNextItemWidth(4.0f * ImGui::GetFontSize());
+			im::Combo(tmpStrCat("##", setting.getBaseName()).c_str(), display(current).c_str(), [&] {
+				for (int faceIndex : {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) {
+					if (ImGui::Selectable(display(faceIndex).c_str(), current == faceIndex)) {
+						setting.setInt(faceIndex);
+					}
+				}
+			});
+		};
 
 		auto pos = ImGui::CalcTextSize("Monospace").x + 2.0f * ImGui::GetStyle().ItemSpacing.x;
 		auto width = 12.0f * ImGui::GetFontSize(); // filename ComboBox (boxes are drawn with different font, but we want same width)
@@ -1068,6 +1083,10 @@ void ImGuiSettings::paintFont()
 		selectFilename(manager.fontPropFilename, width);
 		ImGui::SameLine();
 		selectSize(manager.fontPropSize);
+		ImGui::SameLine();
+		ImGui::TextUnformatted("pt / #");
+		ImGui::SameLine();
+		selectIndex(manager.fontPropIndex);
 		HelpMarker("You can install more fonts by copying .ttf file(s) to your \"<openmsx>/share/skins\" directory.");
 
 		ImGui::AlignTextToFramePadding();
@@ -1078,6 +1097,10 @@ void ImGuiSettings::paintFont()
 		});
 		ImGui::SameLine();
 		selectSize(manager.fontMonoSize);
+		ImGui::SameLine();
+		ImGui::TextUnformatted("pt / #");
+		ImGui::SameLine();
+		selectIndex(manager.fontMonoIndex);
 		HelpMarker("Some GUI elements (e.g. the console) require a monospaced font.");
 	});
 }


### PR DESCRIPTION
Added the ability to specify the variation index for TrueType Collection (.ttc) font files.

Four major improvements have been made:
+ Added fontPropIndex and fontMonoIndex to ImGuiManager
+ Added settings: gui_font_default_index, gui_font_mono_index
+ Updated the related GUI menu (Settings->GUI->Select Font)
+ Added an option for the osd create/info/configure commands: -fontfaceindex