### PR TITLE
Make the setup view editable

### DIFF
--- a/src/imgui/ImGuiConnector.cc
+++ b/src/imgui/ImGuiConnector.cc
@@ -66,7 +66,9 @@ void ImGuiConnector::paintPluggableSelectables(const Connector& connector, const
 
 void ImGuiConnector::showPluggables(PluggingController& pluggingController, Mode mode)
 {
-	im::Table("table", 2, [&]{
+	im::Table("##shared-table", 2, [&]{
+		ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("Value");
 		const auto& pluggables = pluggingController.getPluggables();
 		for (const auto* connector : pluggingController.getConnectors()) {
 			if (ImGui::TableNextColumn()) { // connector

--- a/src/imgui/ImGuiConnector.hh
+++ b/src/imgui/ImGuiConnector.hh
@@ -6,6 +6,8 @@
 namespace openmsx {
 
 class PluggingController;
+class Connector;
+class Pluggable;
 
 class ImGuiConnector final : public ImGuiPart
 {
@@ -14,7 +16,14 @@ public:
 
 	void showMenu(MSXMotherBoard* motherBoard) override;
 
-	void showPluggables(PluggingController& pluggingController, bool viewOnly);
+	enum class Mode {
+		COMBO,
+		VIEW,
+		SUBMENU
+	};
+	void showPluggables(PluggingController& pluggingController, Mode mode);
+private:
+	void paintPluggableSelectables(const Connector& connector, const std::vector<std::unique_ptr<Pluggable>>& pluggables);
 };
 
 } // namespace openmsx

--- a/src/imgui/ImGuiCpp.hh
+++ b/src/imgui/ImGuiCpp.hh
@@ -5,6 +5,7 @@
 #include "xrange.hh"
 
 #include <imgui.h>
+#include <imgui_internal.h>
 
 #include <concepts>
 
@@ -330,6 +331,21 @@ inline void TreeNode(const char* label, bool* p_open, std::invocable<> auto next
 		next();
 		ImGui::TreePop();
 	}
+}
+
+inline bool TreeNodeWithoutID(const char* label, ImGuiTreeNodeFlags flags, std::invocable<> auto next)
+{
+	ImGuiID id_before = ImGui::GetID(""); // capture the current ID stack top
+
+	// TreeNodeEx pushes its own ID(s)
+	bool open = ImGui::TreeNodeEx(label, flags);
+	if (open) {
+		ImGui::PushOverrideID(id_before); // restore ID stack for children (internal API)
+		next();
+		ImGui::PopID();
+		ImGui::TreePop();
+	}
+	return open;
 }
 
 // im::ListBox(): wrapper around ImGui::BeginListBox() / ImGui::EndListBox()

--- a/src/imgui/ImGuiMachine.cc
+++ b/src/imgui/ImGuiMachine.cc
@@ -449,6 +449,23 @@ void ImGuiMachine::showNonExistingPreview()
 
 void ImGuiMachine::showSetupOverview(MSXMotherBoard& motherBoard, ViewMode viewMode)
 {
+	showSetupOverviewMachine(motherBoard, viewMode);
+
+	const ImGuiTreeNodeFlags flags = (viewMode == ViewMode::VIEW || viewMode == ViewMode::EDIT) ? ImGuiTreeNodeFlags_DefaultOpen :
+					viewMode == ViewMode::NO_CONTROLS ? (ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_Bullet) :
+					ImGuiTreeNodeFlags_None;
+
+	showSetupOverviewExtensions(motherBoard, viewMode, flags);
+
+	showSetupOverviewConnectors(motherBoard, viewMode, flags);
+	
+	showSetupOverviewMedia(motherBoard, viewMode, flags);
+	
+	showSetupOverviewState(motherBoard, viewMode, flags);
+}
+
+void ImGuiMachine::showSetupOverviewMachine(MSXMotherBoard& motherBoard, ViewMode viewMode)
+{
 	using enum SetupDepth;
 
 	auto configName = motherBoard.getMachineName();
@@ -486,10 +503,11 @@ void ImGuiMachine::showSetupOverview(MSXMotherBoard& motherBoard, ViewMode viewM
 		// machine config is gone... fallback: just show configName
 		showMachineWithoutInfo(configName);
 	}
+}
 
-	const ImGuiTreeNodeFlags flags = (viewMode == ViewMode::VIEW || viewMode == ViewMode::EDIT) ? ImGuiTreeNodeFlags_DefaultOpen :
-					viewMode == ViewMode::NO_CONTROLS ? (ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_Bullet) :
-					ImGuiTreeNodeFlags_None;
+void ImGuiMachine::showSetupOverviewExtensions(MSXMotherBoard& motherBoard, ViewMode viewMode, ImGuiTreeNodeFlags flags)
+{
+	using enum SetupDepth;
 
 	im::StyleColor(viewMode == ViewMode::SAVE && saveSetupDepth < EXTENSIONS, ImGuiCol_Text, getColor(imColor::TEXT_DISABLED), [&]{
 		im::TreeNode(depthNodeNames[EXTENSIONS].c_str(), flags, [&]{
@@ -562,12 +580,24 @@ void ImGuiMachine::showSetupOverview(MSXMotherBoard& motherBoard, ViewMode viewM
 			});
 		});
 	});
+}
+
+void ImGuiMachine::showSetupOverviewConnectors(MSXMotherBoard& motherBoard, ViewMode viewMode, ImGuiTreeNodeFlags flags)
+{
+	using enum SetupDepth;
+
 	im::StyleColor(viewMode == ViewMode::SAVE && saveSetupDepth < CONNECTORS, ImGuiCol_Text, getColor(imColor::TEXT_DISABLED), [&]{
 		im::TreeNode(depthNodeNames[CONNECTORS].c_str(), flags, [&]{
 			using enum ImGuiConnector::Mode;
 			manager.connector->showPluggables(motherBoard.getPluggingController(), viewMode == ViewMode::EDIT ? SUBMENU : VIEW);
 		});
 	});
+}
+
+void ImGuiMachine::showSetupOverviewMedia(MSXMotherBoard& motherBoard, ViewMode viewMode, ImGuiTreeNodeFlags flags)
+{
+	using enum SetupDepth;
+
 	im::StyleColor(viewMode == ViewMode::SAVE && saveSetupDepth < MEDIA, ImGuiCol_Text, getColor(imColor::TEXT_DISABLED), [&]{
 		im::TreeNode(depthNodeNames[MEDIA].c_str(), flags, [&]{
 			im::Table("##MediaTable", 2, [&]{
@@ -676,6 +706,11 @@ void ImGuiMachine::showSetupOverview(MSXMotherBoard& motherBoard, ViewMode viewM
 			});
 		});
 	});
+}
+
+void ImGuiMachine::showSetupOverviewState(MSXMotherBoard& motherBoard, ViewMode viewMode, ImGuiTreeNodeFlags flags)
+{
+	using enum SetupDepth;
 
 	if (viewMode != ViewMode::EDIT) {
 		auto time = (motherBoard.getCurrentTime() - EmuTime::zero()).toDouble();
@@ -689,6 +724,7 @@ void ImGuiMachine::showSetupOverview(MSXMotherBoard& motherBoard, ViewMode viewM
 		}
 	}
 }
+
 
 void ImGuiMachine::paint(MSXMotherBoard* motherBoard)
 {

--- a/src/imgui/ImGuiMachine.cc
+++ b/src/imgui/ImGuiMachine.cc
@@ -458,9 +458,9 @@ void ImGuiMachine::showSetupOverview(MSXMotherBoard& motherBoard, ViewMode viewM
 	showSetupOverviewExtensions(motherBoard, viewMode, flags);
 
 	showSetupOverviewConnectors(motherBoard, viewMode, flags);
-	
+
 	showSetupOverviewMedia(motherBoard, viewMode, flags);
-	
+
 	showSetupOverviewState(motherBoard, viewMode, flags);
 }
 
@@ -472,8 +472,10 @@ void ImGuiMachine::showSetupOverviewMachine(MSXMotherBoard& motherBoard, ViewMod
 	if (auto* info = findMachineInfo(configName)) {
 		if (viewMode != ViewMode::SAVE) {
 			if (viewMode == ViewMode::EDIT) {
-				im::TreeNode("Machine", ImGuiTreeNodeFlags_DefaultOpen, [&]{
-					im::Table("##MachineTable", 2, [&]{
+				im::TreeNodeWithoutID("Machine", ImGuiTreeNodeFlags_DefaultOpen, [&] {
+					im::Table("##shared-table", 2, [&] {
+						ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed);
+						ImGui::TableSetupColumn("Value");
 						if (ImGui::TableNextColumn()) {
 							ImGui::TextUnformatted("Brand and model");
 						}
@@ -510,10 +512,12 @@ void ImGuiMachine::showSetupOverviewExtensions(MSXMotherBoard& motherBoard, View
 	using enum SetupDepth;
 
 	im::StyleColor(viewMode == ViewMode::SAVE && saveSetupDepth < EXTENSIONS, ImGuiCol_Text, getColor(imColor::TEXT_DISABLED), [&]{
-		im::TreeNode(depthNodeNames[EXTENSIONS].c_str(), flags, [&]{
+		im::TreeNodeWithoutID(depthNodeNames[EXTENSIONS].c_str(), flags, [&]{
 			const auto& slotManager = motherBoard.getSlotManager();
 			bool anySlot = false;
-			im::Table("##ExtTable", 2, [&]{
+			im::Table("##shared-table", 2, [&]{
+				ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed);
+				ImGui::TableSetupColumn("Value");
 				for (auto i : xrange(CartridgeSlotManager::MAX_SLOTS)) {
 					if (!slotManager.slotExists(i)) continue;
 					anySlot = true;
@@ -587,7 +591,7 @@ void ImGuiMachine::showSetupOverviewConnectors(MSXMotherBoard& motherBoard, View
 	using enum SetupDepth;
 
 	im::StyleColor(viewMode == ViewMode::SAVE && saveSetupDepth < CONNECTORS, ImGuiCol_Text, getColor(imColor::TEXT_DISABLED), [&]{
-		im::TreeNode(depthNodeNames[CONNECTORS].c_str(), flags, [&]{
+		im::TreeNodeWithoutID(depthNodeNames[CONNECTORS].c_str(), flags, [&]{
 			using enum ImGuiConnector::Mode;
 			manager.connector->showPluggables(motherBoard.getPluggingController(), viewMode == ViewMode::EDIT ? SUBMENU : VIEW);
 		});
@@ -599,8 +603,10 @@ void ImGuiMachine::showSetupOverviewMedia(MSXMotherBoard& motherBoard, ViewMode 
 	using enum SetupDepth;
 
 	im::StyleColor(viewMode == ViewMode::SAVE && saveSetupDepth < MEDIA, ImGuiCol_Text, getColor(imColor::TEXT_DISABLED), [&]{
-		im::TreeNode(depthNodeNames[MEDIA].c_str(), flags, [&]{
-			im::Table("##MediaTable", 2, [&]{
+		im::TreeNodeWithoutID(depthNodeNames[MEDIA].c_str(), flags, [&]{
+			im::Table("##shared-table", 2, [&]{
+				ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed);
+				ImGui::TableSetupColumn("Value");
 				for (const auto& media : motherBoard.getMediaProviders()) {
 					TclObject info;
 					media.provider->getMediaInfo(info);

--- a/src/imgui/ImGuiMachine.cc
+++ b/src/imgui/ImGuiMachine.cc
@@ -676,14 +676,17 @@ void ImGuiMachine::showSetupOverview(MSXMotherBoard& motherBoard, ViewMode viewM
 			});
 		});
 	});
-	auto time = (motherBoard.getCurrentTime() - EmuTime::zero()).toDouble();
-	if (time > 0) {
-		// this is only useful if the time is not 0
-		im::StyleColor(viewMode == ViewMode::SAVE && saveSetupDepth < COMPLETE_STATE, ImGuiCol_Text, getColor(imColor::TEXT_DISABLED), [&]{
-			im::TreeNode(depthNodeNames[COMPLETE_STATE].c_str(), flags, [&]{
-				ImGui::StrCat("Machine time: ", formatTime(time));
+
+	if (viewMode != ViewMode::EDIT) {
+		auto time = (motherBoard.getCurrentTime() - EmuTime::zero()).toDouble();
+		if (time > 0) {
+			// this is only useful if the time is not 0
+			im::StyleColor(viewMode == ViewMode::SAVE && saveSetupDepth < COMPLETE_STATE, ImGuiCol_Text, getColor(imColor::TEXT_DISABLED), [&]{
+				im::TreeNode(depthNodeNames[COMPLETE_STATE].c_str(), flags, [&]{
+					ImGui::StrCat("Machine time: ", formatTime(time));
+				});
 			});
-		});
+		}
 	}
 }
 

--- a/src/imgui/ImGuiMachine.cc
+++ b/src/imgui/ImGuiMachine.cc
@@ -194,6 +194,8 @@ void ImGuiMachine::showMenu(MSXMotherBoard* motherBoard)
 		if (motherBoard) {
 			ImGui::Separator();
 
+			ImGui::MenuItem("Quick setup editor", nullptr, &showQuickSetupEditor);
+
 			loadSetupOpen = setupFileList.menu("Load setup");
 
 			saveSetupOpen = im::Menu("Save setup", true, [&]{
@@ -254,7 +256,7 @@ void ImGuiMachine::showMenu(MSXMotherBoard* motherBoard)
 			});
 
 			im::Menu("Current setup", true, [&]{
-				showSetupOverview(*motherBoard, ViewMode::EDIT);
+				showSetupOverview(*motherBoard, ViewMode::VIEW);
 			});
 		}
 
@@ -611,8 +613,13 @@ void ImGuiMachine::paint(MSXMotherBoard* motherBoard)
 	if (showTestHardware) {
 		paintTestHardware();
 	}
+	if (showQuickSetupEditor) {
+	        ImGui::SetNextWindowSize(ImVec2(0, 0)); // 0,0 will auto-size based on content
+		im::Window("Quick Setup Editor", &showQuickSetupEditor, [&]{
+			showSetupOverview(*motherBoard, ViewMode::EDIT);
+		});
+	}
 }
-
 
 void ImGuiMachine::paintSelectMachine(const MSXMotherBoard* motherBoard)
 {

--- a/src/imgui/ImGuiMachine.cc
+++ b/src/imgui/ImGuiMachine.cc
@@ -637,7 +637,7 @@ void ImGuiMachine::showSetupOverview(MSXMotherBoard& motherBoard, ViewMode viewM
 									}
 								}
 							}
-						} else {
+						} else if (media.name.starts_with("disk") || media.name.starts_with("cassette") || viewMode != ViewMode::EDIT) {
 							if (ImGui::TableNextColumn()) {
 									ImGui::TextUnformatted(formatMediaName(media.name));
 							}
@@ -650,6 +650,17 @@ void ImGuiMachine::showSetupOverview(MSXMotherBoard& motherBoard, ViewMode viewM
 									ImGui::TextUnformatted(FileOperations::getFilename(targetStr));
 								}
 								simpleToolTip(targetStr);
+							}
+						}
+						// all next cases are the EDIT mode of the media which are not cart, disk or cassette....
+						else if (media.name.starts_with("laserdisc")) {
+							if (ImGui::TableNextColumn()) {
+								ImGui::TextUnformatted(formatMediaName(media.name));
+							}
+							if (ImGui::TableNextColumn()) {
+								im::Menu(std::string(FileOperations::getFilename(targetStr)).c_str(), [&]{
+									manager.media->paintLaserDiscMenuContent(*target);
+								});
 							}
 						}
 					}

--- a/src/imgui/ImGuiMachine.cc
+++ b/src/imgui/ImGuiMachine.cc
@@ -454,13 +454,33 @@ void ImGuiMachine::showSetupOverview(MSXMotherBoard& motherBoard, ViewMode viewM
 	auto configName = motherBoard.getMachineName();
 	if (auto* info = findMachineInfo(configName)) {
 		if (viewMode != ViewMode::SAVE) {
-			ImGui::TextUnformatted(info->displayName);
+			if (viewMode == ViewMode::EDIT) {
+				im::TreeNode("Machine", ImGuiTreeNodeFlags_DefaultOpen, [&]{
+					im::Table("##MachineTable", 2, [&]{
+						if (ImGui::TableNextColumn()) {
+							ImGui::TextUnformatted("Brand and model");
+						}
+						if (ImGui::TableNextColumn()) {
+							if (ImGui::Selectable(info->displayName.c_str())) {
+								showSelectMachine = true;
+							}
+						}
+						if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal | ImGuiHoveredFlags_NoSharedDelay | ImGuiHoveredFlags_Stationary)) {
+							im::ItemTooltip([&]{
+								printConfigInfo(*info);
+							});
+						}
+					});
+				});
+			} else {
+				ImGui::TextUnformatted(info->displayName);
+			}
 		}
-		if (viewMode != ViewMode::NO_CONTROLS) {
+		if (viewMode != ViewMode::NO_CONTROLS && viewMode != ViewMode::EDIT) {
 			im::TreeNode(depthNodeNames[MACHINE].c_str(), [&]{
 				// alternatively, put this info in a tooltip instead of a collapsed TreeNode
 				printConfigInfo(*info);
-				});
+			});
 		}
 	} else {
 		// machine config is gone... fallback: just show configName

--- a/src/imgui/ImGuiMachine.cc
+++ b/src/imgui/ImGuiMachine.cc
@@ -254,7 +254,7 @@ void ImGuiMachine::showMenu(MSXMotherBoard* motherBoard)
 			});
 
 			im::Menu("Current setup", true, [&]{
-				showSetupOverview(*motherBoard);
+				showSetupOverview(*motherBoard, ViewMode::EDIT);
 			});
 		}
 
@@ -465,7 +465,7 @@ void ImGuiMachine::showSetupOverview(MSXMotherBoard& motherBoard, ViewMode viewM
 		showMachineWithoutInfo(configName);
 	}
 
-	const ImGuiTreeNodeFlags flags = viewMode == ViewMode::VIEW ? ImGuiTreeNodeFlags_DefaultOpen :
+	const ImGuiTreeNodeFlags flags = (viewMode == ViewMode::VIEW || viewMode == ViewMode::EDIT) ? ImGuiTreeNodeFlags_DefaultOpen :
 					viewMode == ViewMode::NO_CONTROLS ? (ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_Bullet) :
 					ImGuiTreeNodeFlags_None;
 
@@ -517,7 +517,8 @@ void ImGuiMachine::showSetupOverview(MSXMotherBoard& motherBoard, ViewMode viewM
 	});
 	im::StyleColor(viewMode == ViewMode::SAVE && saveSetupDepth < CONNECTORS, ImGuiCol_Text, getColor(imColor::TEXT_DISABLED), [&]{
 		im::TreeNode(depthNodeNames[CONNECTORS].c_str(), flags, [&]{
-			manager.connector->showPluggables(motherBoard.getPluggingController(), true);
+			using enum ImGuiConnector::Mode;
+			manager.connector->showPluggables(motherBoard.getPluggingController(), viewMode == ViewMode::EDIT ? SUBMENU : VIEW);
 		});
 	});
 	im::StyleColor(viewMode == ViewMode::SAVE && saveSetupDepth < MEDIA, ImGuiCol_Text, getColor(imColor::TEXT_DISABLED), [&]{

--- a/src/imgui/ImGuiMachine.cc
+++ b/src/imgui/ImGuiMachine.cc
@@ -653,13 +653,21 @@ void ImGuiMachine::showSetupOverview(MSXMotherBoard& motherBoard, ViewMode viewM
 							}
 						}
 						// all next cases are the EDIT mode of the media which are not cart, disk or cassette....
-						else if (media.name.starts_with("laserdisc")) {
+						else {
+							auto formattedMediaName = formatMediaName(media.name);
 							if (ImGui::TableNextColumn()) {
-								ImGui::TextUnformatted(formatMediaName(media.name));
+								ImGui::TextUnformatted(formattedMediaName);
 							}
 							if (ImGui::TableNextColumn()) {
-								im::Menu(std::string(FileOperations::getFilename(targetStr)).c_str(), [&]{
-									manager.media->paintLaserDiscMenuContent(*target);
+								im::Menu(strCat(FileOperations::getFilename(targetStr), "##", media.name).c_str(), [&]{
+									if (media.name.starts_with("laserdisc")) {
+										manager.media->paintLaserDiscMenuContent(media.name, formattedMediaName, *target);
+									} else if (media.name.starts_with("hd")) {
+										manager.media->paintHardDiskMenuContent(media.name, formattedMediaName, *target, motherBoard);
+									} else if (media.name.starts_with("cd")) {
+										manager.media->paintCDROMMenuContent(media.name, formattedMediaName, *target);
+									}
+
 								});
 							}
 						}

--- a/src/imgui/ImGuiMachine.hh
+++ b/src/imgui/ImGuiMachine.hh
@@ -42,7 +42,7 @@ private:
 	[[nodiscard]] MachineInfo* findMachineInfo(std::string_view config);
 	[[nodiscard]] const std::string& getTestResult(MachineInfo& info);
 	bool printConfigInfo(MachineInfo& info);
-	enum class ViewMode { VIEW, SAVE, NO_CONTROLS };
+	enum class ViewMode { VIEW, SAVE, NO_CONTROLS, EDIT };
 	void showSetupOverview(MSXMotherBoard& motherBoard, ViewMode = ViewMode::VIEW);
 	void loadPreviewSetup();
 	void showNonExistingPreview();

--- a/src/imgui/ImGuiMachine.hh
+++ b/src/imgui/ImGuiMachine.hh
@@ -50,6 +50,7 @@ private:
 public:
 	bool showSelectMachine = false;
 	bool showTestHardware = false;
+	bool showQuickSetupEditor = true;
 
 private:
 	std::vector<MachineInfo> machineInfo; // sorted on displayName

--- a/src/imgui/ImGuiMachine.hh
+++ b/src/imgui/ImGuiMachine.hh
@@ -44,6 +44,11 @@ private:
 	bool printConfigInfo(MachineInfo& info);
 	enum class ViewMode { VIEW, SAVE, NO_CONTROLS, EDIT };
 	void showSetupOverview(MSXMotherBoard& motherBoard, ViewMode = ViewMode::VIEW);
+	void showSetupOverviewMachine(MSXMotherBoard& motherBoard, ViewMode viewMode);
+	void showSetupOverviewExtensions(MSXMotherBoard& motherBoard, ViewMode viewMode, ImGuiTreeNodeFlags flags);
+	void showSetupOverviewConnectors(MSXMotherBoard& motherBoard, ViewMode viewMode, ImGuiTreeNodeFlags flags);
+	void showSetupOverviewMedia(MSXMotherBoard& motherBoard, ViewMode viewMode, ImGuiTreeNodeFlags flags);
+	void showSetupOverviewState(MSXMotherBoard& motherBoard, ViewMode viewMode, ImGuiTreeNodeFlags flags);
 	void loadPreviewSetup();
 	void showNonExistingPreview();
 

--- a/src/imgui/ImGuiMedia.cc
+++ b/src/imgui/ImGuiMedia.cc
@@ -194,6 +194,28 @@ void ImGuiMedia::loadLine(std::string_view name, zstring_view value)
 	}
 }
 
+void ImGuiMedia::showMediaWindow(std::string_view mediaName)
+{
+		auto getIndex = [&] (std::string_view prefix) {
+			if ((mediaName.size() > prefix.size()) && mediaName.starts_with(prefix)) {
+				char c = mediaName[prefix.size()];
+				return c - 'a';
+			}
+			return -1;
+		};
+
+		if (auto diskIndex = getIndex("disk"); diskIndex >= 0) {
+			diskMediaInfo[diskIndex].show = true;
+		} else if (auto cartIndex = getIndex("cart"); cartIndex >= 0) {
+			cartridgeMediaInfo[cartIndex].show = true;
+	//	} else if (auto index = getIndex("hd")) {
+	//	} else if (auto index = getIndex("cd")) {
+		} else if (mediaName.starts_with("cassette")) {
+			cassetteMediaInfo.show = true;
+	//	} else if (mediaName.starts_with("laserdisc")) {
+		}
+}
+
 static std::string buildFilter(std::string_view description, std::span<const std::string_view> extensions)
 {
 	auto formatExtensions = [&] -> std::string {

--- a/src/imgui/ImGuiMedia.hh
+++ b/src/imgui/ImGuiMedia.hh
@@ -62,6 +62,8 @@ public:
 
 	static void printRomInfo(ImGuiManager& manager, const TclObject& mediaTopic, std::string_view filename, RomType romType);
 
+	void paintLaserDiscMenuContent(const TclObject& currentImage);
+
 public:
 	enum class SelectDiskType : int {
 		IMAGE, DIR_AS_DISK, RAMDISK, EMPTY,
@@ -142,6 +144,11 @@ private:
 	void cartridgeMenu(int cartNum);
 	void cassetteMenu(CassettePlayer& cassettePlayer);
 	void insertMedia(std::string_view mediaName, const MediaItem& item, bool delayed = true);
+	void paintCurrent(const TclObject& current, std::string_view type);
+	void paintRecent(const std::string& mediaName, ItemGroup& group,
+		function_ref<std::string(const std::string&)> displayFunc = std::identity{},
+		const std::function<void(const std::string&)>& toolTip = {},
+		std::function<void()>* actionToSet = nullptr);
 
 	void printExtensionInfo(ExtensionInfo& info);
 	bool drawExtensionFilter(std::string& filterType, std::string& filterString, bool& theFilterOpen, int id = 0);

--- a/src/imgui/ImGuiMedia.hh
+++ b/src/imgui/ImGuiMedia.hh
@@ -124,6 +124,8 @@ public:
 
 	static std::string diskFilter();
 
+	void showMediaWindow(std::string_view mediaName);
+
 private:
 	bool selectRecent(ItemGroup& group, function_ref<std::string(const std::string&)> displayFunc, float width) const;
 	bool selectImage(ItemGroup& group, const std::string& title,

--- a/src/imgui/ImGuiMedia.hh
+++ b/src/imgui/ImGuiMedia.hh
@@ -62,7 +62,9 @@ public:
 
 	static void printRomInfo(ImGuiManager& manager, const TclObject& mediaTopic, std::string_view filename, RomType romType);
 
-	void paintLaserDiscMenuContent(const TclObject& currentImage);
+	void paintLaserDiscMenuContent(std::string_view mediaSlotName, const std::string& slotDisplayName, const TclObject& currentImage);
+	void paintCDROMMenuContent(std::string_view mediaSlotName, const std::string& slotDisplayName, const TclObject& currentImage);
+	void paintHardDiskMenuContent(std::string_view mediaSlotName, const std::string& slotDisplayName, const TclObject& currentImage, const MSXMotherBoard& motherBoard);
 
 public:
 	enum class SelectDiskType : int {

--- a/src/imgui/ImGuiMedia.hh
+++ b/src/imgui/ImGuiMedia.hh
@@ -96,6 +96,9 @@ public:
 		array_with_enum_index<SelectCartridgeType, ItemGroup> groups;
 		SelectCartridgeType select = SelectCartridgeType::IMAGE;
 		bool show = false;
+		bool filterOpen = false;
+		std::string filterType;
+		std::string filterString;
 	};
 	struct DiskMediaInfo {
 		DiskMediaInfo() {
@@ -113,6 +116,8 @@ public:
 
 public:
 	bool resetOnCartChanges = true;
+
+	bool showExtensionSelector(int cartNum, std::optional<std::string> itemToShowAsSelected = std::nullopt);
 
 	static void printDatabase(const RomInfo& romInfo, const char* buf);
 	static bool selectMapperType(const char* label, RomType& romType);
@@ -137,7 +142,7 @@ private:
 	void insertMedia(std::string_view mediaName, const MediaItem& item, bool delayed = true);
 
 	void printExtensionInfo(ExtensionInfo& info);
-	bool drawExtensionFilter();
+	bool drawExtensionFilter(std::string& filterType, std::string& filterString, bool& theFilterOpen, int id = 0);
 
 private:
 	std::array<DiskMediaInfo, RealDrive::MAX_DRIVES> diskMediaInfo;
@@ -148,9 +153,10 @@ private:
 	std::array<ItemGroup, IDECDROM::MAX_CD> cdMediaInfo;
 	ItemGroup laserdiscMediaInfo;
 
-	std::string filterType;
-	std::string filterString;
-	bool filterOpen = false;
+	// for the generic extension selector (slot independent)
+	std::string genericFilterType;
+	std::string genericFilterString;
+	bool genericFilterOpen = false;
 	bool hideNonWorking = false;
 	std::function<void(void)> switchHdAction;
 


### PR DESCRIPTION
Experiments to make the setup view editable.

When we have a clue on what works and what not, we can merge this after properly rebasing.

TODO:

- [x] Make the setup view also a separate window, that is open at first run (similar to Catapult)
- [x] Make the machine view simpler: do not show the details, move the select new machine option in there (and the machine details are visible there).
- [x] Extensions section: investigate if we can highlight the full row on hover, or in other sections also only highlight the last column.
- [x] Connectors section: use sub menus instead of dropdown. The submenu then contains the list that's currently in the dropdown box (to be clear: not move the dropdown box itself to the menu, but the content of that box). 
- [x] Connectors section: highlight full row vs last column.
- [x] Media section: highlight full row vs last column.
- [x] Run time state section: remove
- [x] Fix flickering submenu/simpleToolTip stuff


Closes #1950 