### PR TITLE
Enable file completion using tcl

### DIFF
--- a/share/init.tcl
+++ b/share/init.tcl
@@ -153,11 +153,11 @@ proc tabcompletion {args} {
 	lazy_handler $command
 	set result ""
 	if {[info exists tabcompletion_proc_sensitive($command)]} {
-		set result [namespace eval :: $tabcompletion_proc_sensitive($command) $args]
-		lappend result true
+		set result ---case
+		lappend result {*}[namespace eval :: $tabcompletion_proc_sensitive($command) $args]
 	} elseif {[info exists tabcompletion_proc_insensitive($command)]} {
-		set result [namespace eval :: $tabcompletion_proc_insensitive($command) $args]
-		lappend result false
+		set result ---nocase
+		lappend result {*}[namespace eval :: $tabcompletion_proc_insensitive($command) $args]
 	}
 	return $result
 }

--- a/share/scripts/_utils.tcl
+++ b/share/scripts/_utils.tcl
@@ -136,7 +136,8 @@ proc file_completion_by_number {args} {
 		}
 	}
 	if {[string length $last_arg]} {
-		puts "Give last component by number after: $last_arg"
+		set last_component [file tail $last_arg]
+		puts "Give last component by number instead of '$last_component'"
 	}
 	lassign [file_complete_common {*}$args] sub_params dirs files 
 	set entries ""

--- a/src/commands/Completer.hh
+++ b/src/commands/Completer.hh
@@ -42,13 +42,14 @@ public:
 	[[nodiscard]] virtual Interpreter& getInterpreter() const = 0;
 
 	struct SubParams {
-		bool caseSensitive;
-		bool doSort;
 		std::string commonPrefix;
 		std::string goableRegex;
+		bool caseSensitive;
+		bool doSort;
+		bool appendable;
 
 		SubParams(bool caseSensitive_ = true) :
-			caseSensitive(caseSensitive_), doSort(true)
+			caseSensitive(caseSensitive_), doSort(true), appendable(true)
 		{
 		}
 	};

--- a/src/memory/RomInfoTopic.cc
+++ b/src/memory/RomInfoTopic.cc
@@ -41,7 +41,8 @@ std::string RomInfoTopic::help(std::span<const TclObject> /*tokens*/) const
 void RomInfoTopic::tabCompletion(std::vector<std::string>& tokens) const
 {
 	if (tokens.size() == 3) {
-		completeString(tokens, RomInfo::getAllRomTypes(), false);
+		completeString(tokens, RomInfo::getAllRomTypes(),
+		               Completer::SubParams(false));
 	}
 }
 

--- a/src/settings/BooleanSetting.cc
+++ b/src/settings/BooleanSetting.cc
@@ -33,7 +33,7 @@ void BooleanSetting::tabCompletion(std::vector<std::string>& tokens) const
 		"true"sv,  "on"sv,  "yes"sv,
 		"false"sv, "off"sv, "no"sv,
 	};
-	Completer::completeString(tokens, values, false); // case insensitive
+	Completer::completeString(tokens, values, Completer::SubParams(false));
 }
 
 

--- a/src/settings/EnumSetting.cc
+++ b/src/settings/EnumSetting.cc
@@ -42,7 +42,7 @@ void EnumSettingBase::additionalInfoBase(TclObject& result) const
 void EnumSettingBase::tabCompletionBase(std::vector<std::string>& tokens) const
 {
 	Completer::completeString(tokens, getPossibleValues(),
-	                          false); // case insensitive
+	                          Completer::SubParams(false));
 }
 
 } // namespace openmsx

--- a/src/settings/SettingsManager.cc
+++ b/src/settings/SettingsManager.cc
@@ -192,7 +192,8 @@ void SettingsManager::SetCompleter::tabCompletion(std::vector<std::string>& toke
 	switch (tokens.size()) {
 	case 2: {
 		// complete setting name
-		completeString(tokens, manager.getTabSettingNames(), false); // case insensitive
+		completeString(tokens, manager.getTabSettingNames(),
+		               Completer::SubParams(false));
 		break;
 	}
 	case 3:

--- a/src/settings/VideoSourceSetting.cc
+++ b/src/settings/VideoSourceSetting.cc
@@ -97,7 +97,7 @@ void VideoSourceSetting::additionalInfo(TclObject& result) const
 void VideoSourceSetting::tabCompletion(std::vector<std::string>& tokens) const
 {
 	Completer::completeString(tokens, getPossibleValues(),
-	                          false); // case insensitive
+	                          Completer::SubParams(false));
 }
 
 int VideoSourceSetting::registerVideoSource(const std::string& source)


### PR DESCRIPTION
The description below may seem to be long, but my purpose is simple: I want to make better file-path tab completion usable from tcl script.

To see how this work instantly, try a script included in the zip file below.
[test_enhanced_tab_competion.zip](https://github.com/user-attachments/files/22992073/test_enhanced_tab_competion.zip)

Also, the patch code is not so difficult in C++ side. Tcl side is a bit complecated.

By this Pull Request, callback procedure, the 2nd argument of '`set_tabcompletion_proc`', will get the ability to control tab completion from Tcl code. I select triple-hyphen prefix and easy to understand English for me, but more better idea is acceptable. The callback procedure should prepend these options before candidates.

Compatibility is kept, only exception is when the candidates originally contain the same string options below. That's the reason I selected triple-hyphen which is similar but different from standard Tcl style.

All options you need should be written each callback. Otherwise they will be restored default behavior for each callback.

'`---rewritewith`', '`---donewith`' and '`---noappendable`' are used to select entry by number. In that case, candidates contain both number and result to show. I want this feature to select the path that contains non-ASCII string, because Input Method Editor (IME for Windows, IM for others) cannot work well. But ofcouse you can use any other purpose.

`---commonprefix <string>`
Set partially completed string. For example, parent directory path for a file. Given string should not be included in candidate tokens. Otherwise the string may be doubled.
Generally, even when the last component of the path is partially completed, just give the path of its parent directory to this option and candidates should have common beginning part of last component of the path. That manner makes usual behaivior of console.
Default is empty string.

`---goable <string for regular expression>`
When only one candidate matchs with last token and the token matches given regular expression, append new empty token to console input.
Default is empty string, means all the case appends new token.
For example,  if you want not to append new token only when the path points directory, set '`---goable .*\[^/\]$`' in tcl script.
Note that this regular expression is used with std::regex_match in C++ context, not std::regex_search.

`---sort`, `---nosort`
Sort candidates or not.
Use '---nosort' when your candiates are already sorted.
Default is `---sort`.

`---case`, `---nocase`
Set case-sensitive or case-insensitive for completion match.
It can overwrite previous or initial setting.
Default depends on the 3rd argument given to '`set_tabcompletion_proc`' procedure.
Currently (and originally), this opiton doesn't affect sorting.

`---rewritewith <string>`
Replace last token with given string. Even when only one candidate matchs the given string, no token added to console. Also, given string should be match one of candidate strings.
If you use `---commonprefix`, generally you should also prepend that string to the string for this option.
Default is empty string.

`---donewith <string>`
Complete the last token with given string and append new empty token. The candidates will be ignored.
If you use `---commonprefix`, generally also prepend that string to the string for this option.
Default is empty string.

`---appendable`, `---noappendable`
Allow append partially common matched string or not.
'`---noappendable`' especially works when only one candidate matches with current last token.
For exapmle, use '`---noappendable`' for the case the candidate strings contain the number or guide for each entry.
Default is `---appendable`.

`---`
Make clear the tab completion candidates start from next token.

