### PR TITLE
Enable tcl scripts to perform its own tab completion.

### DIFF
--- a/share/init.tcl
+++ b/share/init.tcl
@@ -154,10 +154,9 @@ proc tabcompletion {args} {
 	set result ""
 	if {[info exists tabcompletion_proc_sensitive($command)]} {
 		set result [namespace eval :: $tabcompletion_proc_sensitive($command) $args]
-		lappend result true
 	} elseif {[info exists tabcompletion_proc_insensitive($command)]} {
-		set result [namespace eval :: $tabcompletion_proc_insensitive($command) $args]
-		lappend result false
+		set result ---nocase
+		lappend result {*}[namespace eval :: $tabcompletion_proc_insensitive($command) $args]
 	}
 	return $result
 }

--- a/src/commands/GlobalCommandController.cc
+++ b/src/commands/GlobalCommandController.cc
@@ -406,16 +406,31 @@ void GlobalCommandController::tabCompletion(std::vector<std::string>& tokens)
 			try {
 				TclObject list = command.executeCommand(interpreter);
 				bool sensitive = true;
+				bool doneOrRewrite = false;
 				auto begin = list.begin();
 				auto end = list.end();
-				if (begin != end) {
-					if (auto back = end[-1]; back == one_of("true", "false")) {
-						--end;
-						sensitive = back == "true";
+				for (/**/; begin != end; ++begin) {
+					if (*begin == one_of("---case", "---nocase")) {
+						sensitive = *begin == "---case";
+					}
+					else if (*begin == one_of("---done", "---rewrite")) {
+						bool done = *begin == "---done";
+						if (++begin != end) {
+							tokens.back() = std::string(*begin);
+						}
+						if (done) { tokens.emplace_back(); }
+						doneOrRewrite = true;
+						break;
+					}
+					else {
+						if (*begin == "---") { ++begin; }
+						break;
 					}
 				}
-				Completer::completeString(
-					tokens, std::ranges::subrange(begin, end), sensitive);
+				if (!doneOrRewrite) {
+					Completer::completeString(
+						tokens, std::ranges::subrange(begin, end), sensitive);
+				}
 			} catch (CommandException& e) {
 				cliComm.printWarning(
 					"Error while executing tab-completion "


### PR DESCRIPTION
### Purpose
By this PR, we can improve `file_completion` procedure defined in `share/scripts/_utils.tcl`. No need to press back-space for each path component and new candidates are shown only last component of full path.

I also add `file_completion_by_number` to enable select every last component by number. I need this because current openMSX can't cooperate with IMs/IMEs well.

### Imprementation detail
To make enable these functions, I made little fix on `src/commands/GlobalCommandController.cc` (and `share/init.tcl`). Options controlling tab completion take the position before candidates and make clear its functionality.

Options are: `---done`, `---rewrite`, `---case`, `---nocase`  and `---`. These enhancement can be used any purporse tab completion, not only for file path.

### ---done, ---rewrite
When the callback returns `---done <any string>` or `---rewrite <any string>`, the last argument of command line on console are replaced with given string and other internal processes (includes `---case` and `---nocase`) are skipped. Following any string in the returned list are ignored. If you want to show next candidates, use `puts` before return from callback procedure.

The difference between `---done` and `---rewrite` is to proceed or not to next new argument on the command line. For example, while selecting the file path, use `---done` for files and `---rewrite` for directories.

### ---case, ---nocase
`---case` or `---nocase` overrides default case sensitiveness for the completion, which defined by the 3rd argument of `set_tabcompletion_proc`.  This overrides affects only each callback.
These options can take effect only when neither `---done` nor `---rewrite` are used.

### "---" as terminator
At last, `---` is also defined to make clear the end of completion controlling commands. Required only when the first candidate is `---`.

Thanks for reading long description.
