### PR TITLE
Unify tab completion for file path

### DIFF
--- a/share/init.tcl
+++ b/share/init.tcl
@@ -154,10 +154,9 @@ proc tabcompletion {args} {
 	set result ""
 	if {[info exists tabcompletion_proc_sensitive($command)]} {
 		set result [namespace eval :: $tabcompletion_proc_sensitive($command) $args]
-		lappend result true
 	} elseif {[info exists tabcompletion_proc_insensitive($command)]} {
-		set result [namespace eval :: $tabcompletion_proc_insensitive($command) $args]
-		lappend result false
+		set result ---nocase
+		lappend result {*}[namespace eval :: $tabcompletion_proc_insensitive($command) $args]
 	}
 	return $result
 }

--- a/share/scripts/_utils.tcl
+++ b/share/scripts/_utils.tcl
@@ -109,12 +109,102 @@ proc clip {min max val} {
 	expr {($val < $min) ? $min : (($val > $max) ? $max : $val)}
 }
 
-# Provides file completion.
+# Provides tab completion for file, intend to use the 2nd argment
+# of 'set_tabcompletion_proc' procedure.
 proc file_completion {args} {
-	set my_arg [lindex $args end]
-	lassign [gather_directory_contents $my_arg] \
-		dirstr tail dir_candidates file_candidates
-	set entries [list {*}$dir_candidates {*}$file_candidates]
+	return [filetabcompletion 80 {} {} {*}$args]
+}
+
+#
+# BE CAREFUL TO RENAME OR/AND REPLACE! See 'src/command/Completer.cc'
+# Tab completion procedure for file path.
+# Directly used from C++ code and indirectly called from Tcl codes.
+#
+proc filetabcompletion {console_width target_paths extras args} {
+	puts "--- [lindex $args end]"
+	if {![llength $target_paths]} { lappend target_paths ./ }
+	set target_full_paths ""
+	foreach p $target_paths {
+		# [file join] expands "." to current working directory,
+		# and drop previous path when a following one is absolute path.
+		set fp [weak_normalize_path . $p]
+		if {[string index $fp end] ne "/"} { append fp / }
+		lappend target_full_paths $fp
+	}
+	set child_dirs ""
+	set child_files ""
+	# $args should have two or more elements here.
+	# (When only one or zero, this procedure is not called.)
+	set our_arg [lindex $args end]
+	# Check number mode.
+	set number_order -2
+	if {[regexp -indices "^(,\\d*)$|.*/(,\\d*)$" $our_arg m0 m1 m2]} {
+		set midx [lindex $m1 0]
+		if {$midx == -1} { set midx [lindex $m2 0] }
+		set number_order [string range $our_arg [expr {$midx + 1}] end]
+		if {$number_order eq ""} { set number_order -1 }
+		set our_arg [string range $our_arg 0 [expr {$midx - 1}]]
+	}
+	# make clear to point directory by "/" for some dot paths.
+	if {$our_arg eq "" || $our_arg eq "." } { set our_arg ./ }
+	if {$our_arg eq ".." || [regexp /\\.\\.\$ $our_arg]} { append our_arg / }
+
+	if {[file pathtype $our_arg] ne "relative"} {
+		lassign [gather_directory_contents $our_arg] \
+			dirstr tail child_dirs child_files
+	} else {
+		foreach p $target_full_paths {
+			set full_path [weak_normalize_path $p $our_arg]
+			# Note: because $our_arg is not empty, $full_path never be empty.
+			if {[string index $our_arg end] eq "/" && \
+				[string index $full_path end] ne "/" \
+			} {
+				append full_path /
+			}
+			lassign [gather_directory_contents $full_path] \
+				dirstr tail child_dirs_for_p child_files_for_p
+			lappend child_dirs {*}$child_dirs_for_p
+			lappend child_files {*}$child_files_for_p
+		}
+		# Only one time fixing $dirstr is enough,
+		# Because it should be relative path from $target_full_paths.
+		if {![string first $p $dirstr]} {
+			set po [expr {[string length $p] - 1}]
+			for {} {$po >= 0 && [string index $p $po] ne "/"} {incr po -1} { }
+			set dirstr [string range $dirstr [expr {$po + 1}] end]
+		} else {
+			set pos_last_common_separator 0
+			for {set cnt 0} {true} {incr cnt} {
+				set pc [string index $p $cnt]
+				set dc [string index $dirstr $cnt]
+				if {$pc eq $dc} {
+					if {$pc eq "/"} { set pos_last_common_separator $cnt }
+					continue
+				}
+				set plcs [expr {$pos_last_common_separator + 1}]
+				set p_unmatch [string range $p $plcs end]
+				set d_unmatch [string range $dirstr $plcs end]
+				set up_dir_cnt [llength [file split $p_unmatch]]
+				set dirstr "[string repeat ../ $up_dir_cnt]$d_unmatch"
+				break
+			}
+		}
+	}
+	set child_dirs [lsort -dictionary -unique $child_dirs]
+	set child_files [lsort -dictionary -unique $child_files]
+	set entries [list {*}$child_dirs {*}$child_files {*}$extras]
+	if {$number_order != -2} {
+		return [update_in_number_mode_file_completion \
+			$number_order $console_width $our_arg \
+			$entries $dirstr $tail $target_full_paths]
+	}
+	return [filter_and_update_in_file_competion \
+		$console_width $our_arg $entries $dirstr $tail $target_full_paths]
+}
+
+proc filter_and_update_in_file_competion { \
+	console_width our_arg entries dirstr tail possible_parents \
+} {
 	set result $entries
 	if {[string length $tail]} {
 		set result ""
@@ -123,14 +213,13 @@ proc file_completion {args} {
 		}
 	}
 	if {![llength $result]} {
-		puts "No file matches: $my_arg"
-		return [list ---rewrite $my_arg]
+		puts "No file matches: $our_arg"
+		return [list ---rewrite $our_arg]
 	} elseif {1 == [llength $result]} {
-		return [make_rewrite_or_done $dirstr$result]
+		set result [lindex $result 0] ; # {any text} to "any text". Required.
+		return [make_rewrite_or_done $dirstr$result $possible_parents]
 	}
-	set result_text ""
-	foreach e $result { append result_text "$e  " }
-	puts $result_text
+	show_possibilities $console_width $result
 	set pos [string length $tail]
 	while {true} {
 		set c [string index [lindex $result 0] $pos]
@@ -142,58 +231,53 @@ proc file_completion {args} {
 			}
 		}
 		if {$pos == -1} { break }
-		append my_arg $c
+		append our_arg $c
 		incr pos
 	}
-	return [list ---rewrite $my_arg]
+	return [list ---rewrite $our_arg]
 }
 
-# Another file completion.
-proc file_completion_by_number {args} {
-	set my_arg [lindex $args end]
-	lassign [gather_directory_contents $my_arg] \
-		dirstr tail dir_candidates file_candidates
-	set result [list {*}$dir_candidates {*}$file_candidates]
+proc update_in_number_mode_file_completion { \
+	order_number console_width our_arg entries \
+	dirstr tail possible_parents \
+} {
+	set result $entries
 	if {![llength $result]} {
-		puts "No file matches: $my_arg"
-		return [list ---rewrite $my_arg]
+		puts "No file matches: $our_arg"
+		return [list ---rewrite $our_arg]
 	} elseif {1 == [llength $result]} {
-		set tail 0
+		set result [lindex $result 0] ; # {any text} to "any text". Required.
+		return [make_rewrite_or_done $dirstr$result $possible_parents]
 	}
-	if {![string is integer $tail]} {
-		puts "Give the number for last component of the path."
-		puts [make_numbered_list_str $result]
-		return [list ---rewrite $dirstr]
-	} elseif {$tail < 0 || [llength $result] <= $tail} {
-		puts "Give the number from 0 to [expr {[llength $result]-1}]"
-		puts [make_numbered_list_str $result]
-		return [list ---rewrite $dirstr]
+	if {0 <= $order_number && $order_number < [llength $entries]} {
+		set result [lindex $entries $order_number]
+		return [make_rewrite_or_done $dirstr$result $possible_parents]
 	}
-	set p "$dirstr[lindex $result $tail]"
-	set r [make_rewrite_or_done $p]
-	if {![string first $r "---rewrite"]} {
-		lassign [gather_directory_contents $p] \
-			dmy1 dmy1 new_dir_candidates new_file_candidates
-		set new_result [list {*}$new_dir_candidates {*}$new_file_candidates]
-		puts [make_numbered_list_str $new_result]
-	}
-	return $r
-}
-
-proc make_numbered_list_str {entries} {
-	set cnt 0
 	set result ""
-	foreach e $entries { set result "$result$cnt:$e  "; incr cnt }
-	return $result
+	set cnt 0
+	foreach e $entries {
+		lappend result ",${cnt}:$e"
+		incr cnt
+	}
+	puts "Please type comma and number as the last component."
+	puts "ex1) ,1   ex2) some/path/,4   ex3) /from/root/,7"
+	show_possibilities $console_width $result
+	return [list ---rewrite $our_arg,]
 }
 
-proc make_rewrite_or_done {path} {
+proc make_rewrite_or_done {path {possible_parents {}} } {
 	set is_dir [file isdirectory $path]
+	foreach p $possible_parents {
+		if {$is_dir} { break }
+		if {[file isdirectory [file join $p $path]]} {
+			set is_dir true
+		}
+	}
 	return [list [expr {$is_dir ? "---rewrite": "---done"}] $path]
 }
 
 proc gather_directory_contents {path} {
-	lassign [split_dir_and_tail $path] dirstr tail
+	lassign [split_dir_and_tail $path false] dirstr tail
 	set dir_candidates ""
 	set file_candidates ""
 	foreach i [glob -nocomplain -path $dirstr *] {
@@ -210,13 +294,49 @@ proc gather_directory_contents {path} {
 }
 
 #
+# Used when you don't want to resolve symbolic link but do
+# [file normalize [file join ...]] .
+#
+proc weak_normalize_path {args} {
+	if {[llength $args] < 1} {
+		# [file join ...] requires at least one name.
+		retun $args
+	}
+	set append_to_last ""
+	if {[string index [lindex $args end] end] eq "/"} {
+		set append_to_last /
+	}
+	set joined [file join {*}$args]
+	set splitted [file split $joined]
+	set components ""
+	foreach e $splitted {
+		if {$e eq ".."} {
+			if {[lsearch -exact {"~" "." ".."} [lindex $components end]]<0} {
+				set components [lreplace $components end end]
+			} else {
+				lappend components $e    
+			}
+		} elseif {$e eq "." && [llength $components]} {
+			# just skip
+		} else {
+			lappend components $e
+		}
+	}
+	if {[llength $components] < 1} {
+		return "$joined$append_to_last"
+	}
+	return "[file join {*}$components]$append_to_last"
+}
+
+#
 # Return [list <dirname> <tail>] from given path.
 # <dirname> never be empty string and always ends with "/".
-# When given path ends with "/" and the path is directory,
-# <tail> is always empty string. If not, the tail won't be
-# empty string and not ends with "/".
+# When given path ends with "/", <tail> is empty string.
+# If last_separator_is_ignorable is true (as default) and
+# when given path is not accesible as directory, the last
+# component of given path will split to <tail> and snip last "/".
 #
-proc split_dir_and_tail {path} {
+proc split_dir_and_tail {path {last_separator_is_ignorable true}} {
 	if {$path eq "" || $path eq "." } { set $path ./ }
 	if {$path eq ".."} { set $path ../ }
 	set dirstr ""
@@ -227,7 +347,7 @@ proc split_dir_and_tail {path} {
 	}
 	set tail [lindex $splitted end]        ; # only few case ends with "/".
 	if {[string index $path end] eq "/"} { ; # so check with $path, not $tail.
-		if {[file isdirectory $path]} {
+		if {!$last_separator_is_ignorable || [file isdirectory $path]} {
 			set dirstr $path
 			set tail ""
 		} else {
@@ -235,6 +355,112 @@ proc split_dir_and_tail {path} {
 		}
 	}
 	return [list $dirstr $tail]
+}
+
+proc show_possibilities {console_width result} {
+	foreach l [format_to_columns $result $console_width] {
+		puts $l
+	}
+}
+
+#
+# Clone procedure of C++ 'openmsx::format_helper' in
+# 'src/commands/Completer.cc'.
+#
+proc format_helper {input column_limit result_name} {
+	upvar $result_name result
+	set len_i [llength $input]
+	set len_r [llength $result]
+	set column 0
+	set it 0
+	while {true} {
+		set max_column $column
+		for {set i 0} {$it < $len_i && $i < $len_r} {incr i; incr it} {
+			set cur_size [get_mono_width_in_sequence $result $i]
+			set spaces [string repeat " " [expr {$column - $cur_size}]]
+			lset result $i "[lindex $result $i]$spaces[lindex $input $it]"
+			set l [get_mono_width_in_sequence $result $i]
+			if {$max_column < $l} { set max_column $l }
+			if {$max_column > $column_limit} { return false }
+		}
+		set column [expr {$max_column + 2}]
+		if {!($it < $len_i)} { break }
+	}
+	return true
+}
+
+#
+# Clone procedure of C++ 'openmsx::format' in 'src/commands/Completer.cc'.
+#
+proc format_to_columns {input column_limit} {
+	incr column_list -1
+	set result ""
+	for {set lines 1} {$lines < [llength $input]} {incr lines} {
+		set result [lrepeat $lines ""]
+		if {[format_helper $input $column_limit result]} {
+			return $result
+		}
+	}
+	return $input
+}
+
+variable monospace_width_proc [namespace code monospace_width_proc_default]
+
+::set_tabcompletion_proc utils::set_monospace_width_proc \
+	[namespace code get_mono_width_types]
+
+proc get_mono_width_types {args} {
+	return {default east_asian jp}
+}
+
+proc set_monospace_width_proc {proc} {
+	variable monospace_width_proc
+	switch $proc {
+		east_asian - 
+		jp { 
+			set monospace_width_proc \
+				[namespace code monospace_width_proc_east_asian]
+		}
+		default { ; # argument is "default"
+			set monospace_width_proc \
+				[namespace code monospace_width_proc_default]
+		}
+		default { ; # argument is others.
+			set monospace_width_proc $proc
+		}
+	}
+}
+
+proc get_mono_width_in_sequence {str_seqs idx} {
+	variable monospace_width_proc
+	# Because [lindex ...] will make empty string, include it by [list ...].
+	# Note that "[lindex ...]" is NOT the solution with this case.
+	return [eval $monospace_width_proc [list [lindex $str_seqs $idx]]]
+}
+
+#
+# Returns mono-spaced width of given string.
+#
+# Currently, only detect "definitely" fullwidth characters,
+# indicated "F" or "W" in Unicode database.
+# https://www.unicode.org/reports/tr11/
+#
+# Only BMP (Basic Multilingual Plane) is supported because
+# Tcl 8 does not support other Planes.
+#  
+proc monospace_width_proc_default {s} {
+	set f_and_w_re {[ᄀ-ᅟ⌚-⌛〈-〉⏩-⏬⏰⏳◽-◾☔-☕☰-☷♈-♓♿⚊-⚏⚓⚡⚪-⚫⚽-⚾⛄-⛅⛎⛔⛪⛲-⛳⛵⛺⛽✅✊-✋✨❌❎❓-❕❗➕-➗➰➿⬛-⬜⭐⭕⺀-⺙⺛-⻳⼀-⿕⿰-〾ぁ-ゖ゙-ヿㄅ-ㄯㄱ-ㆎ㆐-㇥㇯-㈞㈠-㉇㉐-ꒌ꒐-꓆ꥠ-ꥼ가-힣豈-﫿︐-︙︰-﹒﹔-﹦﹨-﹫！-｠￠-￦]}
+	set c [regexp -all $f_and_w_re $s]
+	return [expr {[string length $s] + $c}]
+}
+
+#
+# Addition to default, "A" characters are valued as fullwidth.
+#
+proc monospace_width_proc_east_asian {s} {
+	set f_and_w_re {[¡¤§-¨ª­-®°-´¶-º¼-¿ÆÐ×-ØÞ-áæè-êì-íðò-ó÷-úüþāđēěĦ-ħīı-ĳĸĿ-łńň-ŋōŒ-œŦ-ŧūǎǐǒǔǖǘǚǜɑɡ˄ˇˉ-ˋˍː˘-˛˝˟̀-ͯΑ-ΡΣ-Ωα-ρσ-ωЁА-яёᄀ-ᅟ‐–-‖‘-’“-”†-•․-‧‰′-″‵※‾⁴ⁿ₁-₄€℃℅℉ℓ№℡-™ΩÅ⅓-⅔⅛-⅞Ⅰ-Ⅻⅰ-ⅹ↉←-↙↸-↹⇒⇔⇧∀∀∂-∃∇-∈∋∏∑∕√∝-∠∣∥∧-∬∮∴-∷∼-∽≈≌≒≠-≡≤-≧≪-≫≮-≯⊂-⊃⊆-⊇⊕⊙⊥⊿⌒⌚-⌛〈-〉⏩-⏬⏰⏳①-ⓩ⓫-╋═-╳▀-▏▒-▕■-□▣-▩▲-△▶-▷▼-▽◀-◁◆-◈○◎-◑◢-◥◯◽-◾★-☆☉☎-☏☔-☕☜☞☰-☷♀♂♈-♓♠-♡♣-♥♧-♪♬-♭♯♿⚊-⚏⚓⚞-⚟⚡⚪-⚫⚽-⚿⛄-⛡⛣⛨-⛿✅✊-✋✨✽❌❎❓-❕❗❶-❿➕-➗➰➿⬛-⬜⭐⭕-⭙⺀-⺙⺛-⻳⼀-⿕⿰-〾ぁ-ゖ゙-ヿㄅ-ㄯㄱ-ㆎ㆐-㇥㇯-㈞㈠-ꒌ꒐-꓆ꥠ-ꥼ가-힣-﫿︀-︙︰-﹒﹔-﹦﹨-﹫！-｠￠-￦�]}
+	set c [regexp -all $f_and_w_re $s]
+	return [expr {[string length $s] + $c}]
 }
 
 # Replaces characters that are invalid in file names on the host OS or
@@ -283,6 +509,7 @@ namespace export file_completion
 namespace export file_completion_by_number
 namespace export filename_clean
 namespace export get_next_numbered_filename
+namespace export set_monospace_width_proc
 
 } ;# namespace utils
 

--- a/src/CartridgeSlotManager.cc
+++ b/src/CartridgeSlotManager.cc
@@ -459,7 +459,7 @@ void CartridgeSlotManager::CartCmd::tabCompletion(std::vector<std::string>& toke
 {
 	using namespace std::literals;
 	static constexpr std::array extra = {"eject"sv, "insert"sv};
-	completeFileName(tokens, userFileContext(),
+	completeFileName(commandController, tokens, userFileContext(),
 	                 (tokens.size() < 3) ? extra : std::span<const std::string_view>{});
 
 }

--- a/src/Reactor.cc
+++ b/src/Reactor.cc
@@ -1099,7 +1099,7 @@ std::string RestoreMachineCommand::help(std::span<const TclObject> /*tokens*/) c
 
 void RestoreMachineCommand::tabCompletion(std::vector<std::string>& tokens) const
 {
-	completeFileName(tokens, userFileContext());
+	completeFileName(commandController, tokens, userFileContext());
 }
 
 

--- a/src/ReverseManager.cc
+++ b/src/ReverseManager.cc
@@ -1016,7 +1016,7 @@ void ReverseManager::ReverseCmd::tabCompletion(std::vector<std::string>& tokens)
 	} else if ((tokens.size() == 3) || (tokens[1] == "loadreplay")) {
 		if (tokens[1] == one_of("loadreplay", "savereplay")) {
 			static constexpr std::array cmds = {"-goto"sv, "-viewonly"sv};
-			completeFileName(tokens, userDataFileContext(REPLAY_DIR),
+			completeFileName(commandController, tokens, userDataFileContext(REPLAY_DIR),
 				(tokens[1] == "loadreplay") ? cmds : std::span<const std::string_view>{});
 		} else if (tokens[1] == "viewonlymode") {
 			static constexpr std::array options = {"true"sv, "false"sv};

--- a/src/cassette/CassettePlayerCommand.cc
+++ b/src/cassette/CassettePlayerCommand.cc
@@ -225,9 +225,9 @@ void CassettePlayerCommand::tabCompletion(std::vector<std::string>& tokens) cons
 			"play"sv, "getpos"sv, "setpos"sv, "getlength"sv,
 			//"record"sv,
 		};
-		completeFileName(tokens, userFileContext(), cmds);
+		completeFileName(commandController, tokens, userFileContext(), cmds);
 	} else if ((tokens.size() == 3) && (tokens[1] == "insert")) {
-		completeFileName(tokens, userFileContext());
+		completeFileName(commandController, tokens, userFileContext());
 	} else if ((tokens.size() == 3) && (tokens[1] == "motorcontrol")) {
 		static constexpr std::array extra = {"on"sv, "off"sv};
 		completeString(tokens, extra);

--- a/src/commands/Command.hh
+++ b/src/commands/Command.hh
@@ -37,7 +37,6 @@ protected:
 	[[nodiscard]] GlobalCommandController& getGlobalCommandController() const;
 	[[nodiscard]] CliComm& getCliComm() const;
 
-private:
 	CommandController& commandController;
 };
 

--- a/src/commands/Completer.hh
+++ b/src/commands/Completer.hh
@@ -13,6 +13,7 @@
 
 namespace openmsx {
 
+class CommandController;
 class FileContext;
 class Interpreter;
 class InterpreterOutput;
@@ -46,11 +47,16 @@ public:
 	                           Range&& possibleValues,
 	                           bool caseSensitive = true);
 	template<std::ranges::forward_range Range>
-	static void completeFileName(std::vector<std::string>& tokens,
+	static void completeFileName(CommandController& controller,
+	                             std::vector<std::string>& tokens,
 	                             const FileContext& context,
 	                             const Range& extra);
-	static void completeFileName(std::vector<std::string>& tokens,
+	static void completeFileName(CommandController& controller,
+	                             std::vector<std::string>& tokens,
 	                             const FileContext& context);
+	static void doTabCompletion(TclObject& command,
+	                            Interpreter& interpreter,
+	                            std::vector<std::string>& tokens);
 
 	static std::vector<std::string> formatListInColumns(
 		std::span<const std::string_view> input);
@@ -86,7 +92,8 @@ private:
 		std::string_view str, Range&& range, bool caseSensitive);
 	static bool completeImpl(std::string& str, std::vector<std::string_view> matches,
 	                         bool caseSensitive);
-	static void completeFileNameImpl(std::vector<std::string>& tokens,
+	static void completeFileNameImpl(CommandController& controller,
+	                                 std::vector<std::string>& tokens,
 	                                 const FileContext& context,
 	                                 std::vector<std::string_view> matches);
 
@@ -121,11 +128,12 @@ void Completer::completeString(
 
 template<std::ranges::forward_range Range>
 void Completer::completeFileName(
+	CommandController& controller,
 	std::vector<std::string>& tokens,
 	const FileContext& context,
 	const Range& extra)
 {
-	completeFileNameImpl(tokens, context, filter(tokens.back(), extra, true));
+	completeFileNameImpl(controller, tokens, context, filter(tokens.back(), extra, true));
 }
 
 } // namespace openmsx

--- a/src/commands/GlobalCommandController.cc
+++ b/src/commands/GlobalCommandController.cc
@@ -406,16 +406,31 @@ void GlobalCommandController::tabCompletion(std::vector<std::string>& tokens)
 			try {
 				TclObject list = command.executeCommand(interpreter);
 				bool sensitive = true;
+				bool doneOrRewrite = false;
 				auto begin = list.begin();
 				auto end = list.end();
-				if (begin != end) {
-					if (auto back = end[-1]; back == one_of("true", "false")) {
-						--end;
-						sensitive = back == "true";
+				for (/**/; begin != end; ++begin) {
+					if (*begin == one_of("---case", "---nocase")) {
+						sensitive = *begin == "---case";
+					}
+					else if (*begin == one_of("---done", "---rewrite")) {
+						bool done = *begin == "---done";
+						if (++begin != end) {
+							tokens.back() = std::string(*begin);
+						}
+						if (done) { tokens.emplace_back(); }
+						doneOrRewrite = true;
+						break;
+					}
+					else {
+						if (*begin == "---") { ++begin; }
+						break;
 					}
 				}
-				Completer::completeString(
-					tokens, std::ranges::subrange(begin, end), sensitive);
+				if (!doneOrRewrite) {
+					Completer::completeString(
+						tokens, std::ranges::subrange(begin, end), sensitive);
+				}
 			} catch (CommandException& e) {
 				cliComm.printWarning(
 					"Error while executing tab-completion "

--- a/src/commands/GlobalCommandController.cc
+++ b/src/commands/GlobalCommandController.cc
@@ -402,35 +402,8 @@ void GlobalCommandController::tabCompletion(std::vector<std::string>& tokens)
 			(*v)->tabCompletion(tokens);
 		} else {
 			TclObject command = makeTclList("openmsx::tabcompletion");
-			command.addListElements(tokens);
 			try {
-				TclObject list = command.executeCommand(interpreter);
-				bool sensitive = true;
-				bool doneOrRewrite = false;
-				auto begin = list.begin();
-				auto end = list.end();
-				for (/**/; begin != end; ++begin) {
-					if (*begin == one_of("---case", "---nocase")) {
-						sensitive = *begin == "---case";
-					}
-					else if (*begin == one_of("---done", "---rewrite")) {
-						bool done = *begin == "---done";
-						if (++begin != end) {
-							tokens.back() = std::string(*begin);
-						}
-						if (done) { tokens.emplace_back(); }
-						doneOrRewrite = true;
-						break;
-					}
-					else {
-						if (*begin == "---") { ++begin; }
-						break;
-					}
-				}
-				if (!doneOrRewrite) {
-					Completer::completeString(
-						tokens, std::ranges::subrange(begin, end), sensitive);
-				}
+				Completer::doTabCompletion(command, getInterpreter(), tokens);
 			} catch (CommandException& e) {
 				cliComm.printWarning(
 					"Error while executing tab-completion "

--- a/src/config/SettingsConfig.cc
+++ b/src/config/SettingsConfig.cc
@@ -250,7 +250,7 @@ std::string SettingsConfig::SaveSettingsCommand::help(std::span<const TclObject>
 void SettingsConfig::SaveSettingsCommand::tabCompletion(std::vector<std::string>& tokens) const
 {
 	if (tokens.size() == 2) {
-		completeFileName(tokens, systemFileContext());
+		completeFileName(commandController, tokens, systemFileContext());
 	}
 }
 
@@ -279,7 +279,7 @@ std::string SettingsConfig::LoadSettingsCommand::help(std::span<const TclObject>
 void SettingsConfig::LoadSettingsCommand::tabCompletion(std::vector<std::string>& tokens) const
 {
 	if (tokens.size() == 2) {
-		completeFileName(tokens, systemFileContext());
+		completeFileName(commandController, tokens, systemFileContext());
 	}
 }
 

--- a/src/fdc/DiskChanger.cc
+++ b/src/fdc/DiskChanger.cc
@@ -282,7 +282,7 @@ void DiskCommand::tabCompletion(std::vector<std::string>& tokens) const
 		static constexpr std::array extra = {
 			"eject"sv, "ramdsk"sv, "insert"sv,
 		};
-		completeFileName(tokens, userFileContext(), extra);
+		completeFileName(commandController, tokens, userFileContext(), extra);
 	}
 }
 

--- a/src/fdc/DiskManipulator.cc
+++ b/src/fdc/DiskManipulator.cc
@@ -455,7 +455,7 @@ void DiskManipulator::tabCompletion(std::vector<std::string>& tokens) const
 		completeString(tokens, cmds);
 
 	} else if ((tokens.size() == 3) && (tokens[1] == "create")) {
-		completeFileName(tokens, userFileContext());
+		completeFileName(commandController, tokens, userFileContext());
 
 	} else if (tokens.size() == 3) {
 		std::vector<std::string> names;
@@ -493,7 +493,7 @@ void DiskManipulator::tabCompletion(std::vector<std::string>& tokens) const
 	} else if (tokens.size() >= 4) {
 		if (tokens[1] == one_of("savedsk", "import", "export")) {
 			static constexpr std::array extra = {"-overwrite"sv};
-			completeFileName(tokens, userFileContext(),
+			completeFileName(commandController, tokens, userFileContext(),
 				(tokens[1] == "import") ? extra : std::span<const std::string_view>{});
 		} else if (tokens[1] == one_of("create", "partition", "format")) {
 			static constexpr std::array cmds = {

--- a/src/fdc/NowindCommand.cc
+++ b/src/fdc/NowindCommand.cc
@@ -341,7 +341,7 @@ void NowindCommand::tabCompletion(std::vector<std::string>& tokens) const
 		"-i"sv, "--image"sv,
 		"-m"sv, "--hdimage"sv,
 	};
-	completeFileName(tokens, userFileContext(), extra);
+	completeFileName(commandController, tokens, userFileContext(), extra);
 }
 
 } // namespace openmsx

--- a/src/file/FilePool.cc
+++ b/src/file/FilePool.cc
@@ -187,7 +187,7 @@ std::string FilePool::Sha1SumCommand::help(std::span<const TclObject> /*tokens*/
 
 void FilePool::Sha1SumCommand::tabCompletion(std::vector<std::string>& tokens) const
 {
-	completeFileName(tokens, userFileContext());
+	completeFileName(commandController, tokens, userFileContext());
 }
 
 } // namespace openmsx

--- a/src/ide/HDCommand.cc
+++ b/src/ide/HDCommand.cc
@@ -77,7 +77,7 @@ void HDCommand::tabCompletion(std::vector<std::string>& tokens) const
 {
 	using namespace std::literals;
 	static constexpr std::array extra = {"insert"sv};
-	completeFileName(tokens, userFileContext(),
+	completeFileName(commandController, tokens, userFileContext(),
 		(tokens.size() < 3) ? extra : std::span<const std::string_view>{});
 
 }

--- a/src/ide/IDECDROM.cc
+++ b/src/ide/IDECDROM.cc
@@ -398,7 +398,7 @@ void CDXCommand::tabCompletion(std::vector<std::string>& tokens) const
 {
 	using namespace std::literals;
 	static constexpr std::array extra = {"eject"sv, "insert"sv};
-	completeFileName(tokens, userFileContext(), extra);
+	completeFileName(commandController, tokens, userFileContext(), extra);
 }
 
 

--- a/src/ide/SCSILS120.cc
+++ b/src/ide/SCSILS120.cc
@@ -824,7 +824,7 @@ void LSXCommand::tabCompletion(std::vector<std::string>& tokens) const
 {
 	using namespace std::literals;
 	static constexpr std::array extra = {"eject"sv, "insert"sv};
-	completeFileName(tokens, userFileContext(), extra);
+	completeFileName(commandController, tokens, userFileContext(), extra);
 }
 
 

--- a/src/laserdisc/LaserdiscPlayer.cc
+++ b/src/laserdisc/LaserdiscPlayer.cc
@@ -95,7 +95,7 @@ void LaserdiscPlayer::Command::tabCompletion(std::vector<std::string>& tokens) c
 		static constexpr std::array extra = {"eject"sv, "insert"sv};
 		completeString(tokens, extra);
 	} else if (tokens.size() == 3 && tokens[1] == "insert") {
-		completeFileName(tokens, userFileContext());
+		completeFileName(commandController, tokens, userFileContext());
 	}
 }
 

--- a/src/settings/FilenameSetting.cc
+++ b/src/settings/FilenameSetting.cc
@@ -22,7 +22,7 @@ std::string_view FilenameSetting::getTypeString() const
 
 void FilenameSetting::tabCompletion(std::vector<std::string>& tokens) const
 {
-	Completer::completeFileName(tokens, systemFileContext());
+	Completer::completeFileName(commandController, tokens, systemFileContext());
 }
 
 } // namespace openmsx

--- a/src/settings/Setting.hh
+++ b/src/settings/Setting.hh
@@ -170,12 +170,13 @@ protected:
 	void init();
 	void notifyPropertyChange() const;
 
+	CommandController& commandController;
+
 private:
 	[[nodiscard]] GlobalCommandController& getGlobalCommandController() const;
 	void notify() const;
 
 private:
-	CommandController& commandController;
 	const static_string_view description;
 	std::function<void(TclObject&)> checkFunc;
 	TclObject value; // TODO can we share the underlying Tcl var storage?

--- a/src/video/AviRecorder.cc
+++ b/src/video/AviRecorder.cc
@@ -355,7 +355,7 @@ void AviRecorder::Cmd::tabCompletion(std::vector<std::string>& tokens) const
 			"-doublesize"sv, "-triplesize"sv,
 			"-mono"sv, "-stereo"sv,
 		};
-		completeFileName(tokens, userFileContext(), options);
+		completeFileName(commandController, tokens, userFileContext(), options);
 	}
 }
 


### PR DESCRIPTION
[Not working, cancelled] This PR has a bug. Until `scripts/_utils.tcl` are loaded, any tab completion does not work.

### Introduction
On the discussion #2003, I noticed the reviewer want to keep consistency between 2 versions of tab completion (C++ one and Tcl one). The issue would be done by this Pull Request.

### Main Enhancements
This PR replaces C++ version with the code calling Tcl one. The profits are:
- Ofcourse keep consistensy of tab completion for file path between commands implemented by C++ and by Tcl.
- End users can fix or replace tab completion for all command which they want to use it.
- All features only in C++ version previously are enabled to any tcl commands you want.

### Addtional features
Because of my initial motivation is this side (Also see #2003 discussion), new functionalities below are added. 
- Number Selection Mode
  - When type comma for the last component of the path and hit TAB key, the entries are shown with `,0`, `,1`, `,2` ... prefixed.
  - When type comma and number, tab completion replace it with associated path component. 
  - This is implemented as a _last resort_ to follow IMs/IMEs are not correctly working. Because of the reason, to make minimum changes, it does not support narrowing down like normal completion.

- Supporting Fullwidth characters to align possibility strings.
  - See https://www.unicode.org/reports/tr11/

### Implementation Details

In fact C++ version was not originally same as Tcl version at least 2 points below, even after #2004 applied. But this PR contains both.
- It has ability to merge contents of multiple parent directories (Try tab completion against `load_settings`).
- It has ability to add name of subcommands (Try one against `diska` or `carta`, etc.)
