### PR TITLE
Fixed an issue where full-width characters could not be displayed correctly in console input. 

### DIFF
--- a/src/imgui/ImGuiConsole.cc
+++ b/src/imgui/ImGuiConsole.cc
@@ -263,7 +263,6 @@ void ImGuiConsole::paint(MSXMotherBoard* /*motherBoard*/)
 		/**/ gl::vec2 drawPos = topLeft + gl::vec2(style.FramePadding);
 		/**/ ImVec4 clipRect = gl::vec4(topLeft, bottomRight);
 		/**/ auto* drawList = ImGui::GetWindowDrawList();
-		/**/ auto charWidth = font->GetFontBaked(fontSize)->GetCharAdvance('A'); // assumes fixed-width font
 		/**/ if (ImGui::IsItemActive()) {
 		/**/	auto id = ImGui::GetID("##Input");
 		/**/	if (const auto* state = ImGui::GetInputTextState(id)) { // Internal API !!!
@@ -272,8 +271,9 @@ void ImGuiConsole::paint(MSXMotherBoard* /*motherBoard*/)
 		/**/		// redraw cursor (it was drawn transparent before)
 		/**/		bool cursorIsVisible = (state->CursorAnim <= 0.0f) || ImFmod(state->CursorAnim, 1.20f) <= 0.80f;
 		/**/		if (cursorIsVisible) {
-		/**/			// This assumes a single line and fixed-width font
-		/**/			gl::vec2 cursorOffset(float(state->GetCursorPos()) * charWidth, 0.0f);
+		/**/			// This assumes a single line
+		/**/			auto strToCursor = zstring_view(coloredInputBuf.str()).substr(0, state->GetCursorPos());
+		/**/			gl::vec2 cursorOffset(ImGui::CalcTextSize(strToCursor).x, 0.0f);
 		/**/			gl::vec2 cursorScreenPos = ImTrunc(drawPos + cursorOffset);
 		/**/			ImRect cursorScreenRect(cursorScreenPos.x, cursorScreenPos.y - 0.5f, cursorScreenPos.x + 1.0f, cursorScreenPos.y + fontSize - 1.5f);
 		/**/			if (cursorScreenRect.Overlaps(clipRect)) {
@@ -288,8 +288,7 @@ void ImGuiConsole::paint(MSXMotherBoard* /*motherBoard*/)
 		/**/ 	const char* begin = text.data();
 		/**/ 	const char* end = begin + text.size();
 		/**/ 	drawList->AddText(font, fontSize, drawPos, rgba, begin, end, 0.0f, &clipRect);
-		/**/    // avoid ImGui::CalcTextSize(): it's off-by-one for sizes >= 256 pixels
-		/**/    drawPos.x += charWidth * float(utf8::unchecked::distance(begin, end));
+		/**/    drawPos.x += ImGui::CalcTextSize(text).x;
 		/**/ }
 	});
 }


### PR DESCRIPTION
As a side effect, they now display properly even when proportional fonts are used (although other parts that require a monospaced font will be displayed incorrectly).

About FullWidth characters, see https://www.unicode.org/reports/tr11/

Note:
At Sep. 2023 (ImGuiConsole: fix rendering of wider than 256 pixel (colored) chunks, a0f43326e1f69ded8265f98f9b38f69fd98a9977), The comment says "avoid ImGui::CalcTextSize(): it's off-by-one for sizes >= 256 pixels". That's because overdrawing causes too bright or too bold text appearance at that time.

As another comment says "... we use ImGui::InputText() as-is, but then overdraw the text using the correct colors.", colored text is drawn on the text drawn by internally Imgui code.

But later, Mar. 2024 (ImGuiConsole: improve drawing of console input line, 723ba959f5be026298bd2e46dcf0272d04ff953a), The default color of console input text, given to Imgui system, is changed to transparent. After that, overdrawing problems are dissappered, like too bright or too bold.

This means, Sep. 2023 fix can be reverted at that time. Now we can safely call ImGui::CalcTextSize().