### PR TITLE
fix: Improve UI responsiveness when paused/breaked (#2024)

### DIFF
--- a/src/RTScheduler.hh
+++ b/src/RTScheduler.hh
@@ -5,6 +5,7 @@
 #include "Timer.hh"
 
 #include <cstdint>
+#include <optional>
 
 namespace openmsx {
 
@@ -27,6 +28,14 @@ public:
 				scheduleHelper(limit); // slow path not inlined
 			}
 		}
+	}
+
+	/** Get the next scheduled time point (absolute, in microseconds).
+	  * @return The earliest scheduled time, or nullopt if queue is empty.
+	  */
+	[[nodiscard]] std::optional<uint64_t> getNextTime() const {
+		return queue.empty() ? std::nullopt
+		                     : std::optional(queue.front().time);
 	}
 
 private:

--- a/src/Reactor.cc
+++ b/src/Reactor.cc
@@ -685,7 +685,7 @@ void Reactor::run()
 
 	while (running) {
 		auto isBlocked = [&] { return (blockedCounter > 0) || !activeBoard; };
-		if (isBlocked) {
+		if (isBlocked()) {
 			// Compute timeout, min of MAX_WAIT_MS and time until next
 			// RTScheduler event. This keeps UI responsive while avoiding
 			// busy-waiting when paused.

--- a/src/Reactor.cc
+++ b/src/Reactor.cc
@@ -682,10 +682,14 @@ void Reactor::powerOn()
 void Reactor::run()
 {
 	static constexpr int MAX_WAIT_MS = 8;
+	bool executionFailed = false;
 
 	while (running) {
-		auto isBlocked = [&] { return (blockedCounter > 0) || !activeBoard; };
+		auto isBlocked = [&] {
+			return executionFailed || (blockedCounter > 0) || !activeBoard;
+		};
 		if (isBlocked()) {
+			executionFailed = false;  // Reset when blocked by other conditions
 			// Compute timeout, min of MAX_WAIT_MS and time until next
 			// RTScheduler event. This keeps UI responsive while avoiding
 			// busy-waiting when paused.
@@ -712,7 +716,7 @@ void Reactor::run()
 			// copy shared_ptr to keep Board alive (e.g. in case of Tcl
 			// callbacks)
 			auto copy = activeBoard;
-			blocked = !copy->execute();
+			executionFailed = !copy->execute();
 		}
 	}
 }

--- a/src/Reactor.cc
+++ b/src/Reactor.cc
@@ -692,7 +692,7 @@ void Reactor::run()
 			// to also use a sleep/poll loop, with even shorter
 			// sleep periods as we use here. Maybe in future
 			// SDL implementations this will be improved.
-			eventDistributor->sleep(20 * 1000);
+			eventDistributor->sleep(8 * 1000); // 8ms
 		}
 	}
 }

--- a/src/events/EventDistributor.hh
+++ b/src/events/EventDistributor.hh
@@ -4,9 +4,9 @@
 #include "Event.hh"
 
 #include <array>
-#include <condition_variable>
 #include <cstdint>
 #include <mutex>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -59,16 +59,11 @@ public:
 	/** This actually delivers the events. It may only be called from the
 	  * main loop in Reactor (and only from the main thread). Also see
 	  * the distributeEvent() method.
+	  * @param timeoutMs If provided, wait up to this many milliseconds for
+	  *        SDL events before processing. Used when emulation is blocked
+	  *        to avoid busy-waiting while remaining responsive to input.
 	  */
-	void deliverEvents();
-
-	/** Sleep for the specified amount of time, but return early when
-	  * (another thread) called the distributeEvent() method.
-	  * @param us Amount of time to sleep, in micro seconds.
-	  * @result true  if we return because time has passed
-	  *         false if we return because distributeEvent() was called
-	  */
-	bool sleep(unsigned us);
+	void deliverEvents(std::optional<int> timeoutMs = std::nullopt);
 
 private:
 	[[nodiscard]] bool isRegistered(EventType type, EventListener* listener) const;
@@ -85,8 +80,6 @@ private:
 	using EventQueue = std::vector<Event>;
 	EventQueue scheduledEvents;
 	std::mutex mutex; // lock data structures
-	std::mutex cvMutex; // lock condition_variable
-	std::condition_variable condition;
 };
 
 } // namespace openmsx

--- a/src/events/InputEventGenerator.hh
+++ b/src/events/InputEventGenerator.hh
@@ -10,6 +10,7 @@
 #include <SDL.h>
 
 #include <cstdint>
+#include <optional>
 
 namespace openmsx {
 
@@ -37,7 +38,13 @@ public:
 	/** Must be called when 'grabinput' or 'fullscreen' setting changes. */
 	void updateGrab(bool grab);
 
-	void poll();
+	/** Poll for SDL events and dispatch them.
+	  * @param timeoutMs If provided, wait up to this many milliseconds for
+	  *        the first event using SDL_WaitEventTimeout(). Subsequent
+	  *        events in the same batch use SDL_PollEvent(). If nullopt,
+	  *        uses SDL_PollEvent() for all events (non-blocking).
+	  */
+	void poll(std::optional<int> timeoutMs = std::nullopt);
 
 	[[nodiscard]] JoystickManager& getJoystickManager() { return joystickManager; }
 

--- a/src/video/Display.cc
+++ b/src/video/Display.cc
@@ -357,7 +357,7 @@ void Display::repaintImpl()
 
 	// TODO maybe revisit this later (and/or simplify other calls to repaintDelayed())
 	// This ensures a minimum framerate for ImGui
-	repaintDelayed(40 * 1000); // 25fps
+	repaintDelayed(16 * 1000); // 60fps
 }
 
 void Display::repaintImpl(OutputSurface& surface)

--- a/src/video/Display.cc
+++ b/src/video/Display.cc
@@ -357,7 +357,7 @@ void Display::repaintImpl()
 
 	// TODO maybe revisit this later (and/or simplify other calls to repaintDelayed())
 	// This ensures a minimum framerate for ImGui
-	repaintDelayed(16 * 1000); // 60fps
+	repaintDelayed(40 * 1000); // 25fps
 }
 
 void Display::repaintImpl(OutputSurface& surface)


### PR DESCRIPTION
Fixes #2024, context on background and implementation justificaiton can be found in that issue's thread.

tldr; paused-state ImGui FPS drop in openMSX is intentional and caused by the combined `repaintDelayed()` throttle and a 20 ms sleep in `Reactor::run()`, my changes tunes the delays to be lower and ensure it only affects block state