### PR TITLE
fix: enum serialization with std::initializer_list breaks toolchain builds.

### DIFF
--- a/src/DebugDevice.cc
+++ b/src/DebugDevice.cc
@@ -160,12 +160,12 @@ void DebugDevice::openOutput(std::string_view name)
 	}
 }
 
-static constexpr std::initializer_list<enum_string<DebugDevice::Mode>> debugModeInfo = {
+static constexpr auto debugModeInfo = std::to_array<enum_string<DebugDevice::Mode>>({
 	{ "OFF",        DebugDevice::Mode::OFF },
 	{ "SINGLEBYTE", DebugDevice::Mode::SINGLEBYTE },
 	{ "MULTIBYTE",  DebugDevice::Mode::MULTIBYTE },
-	{ "ASCII",      DebugDevice::Mode::ASCII }
-};
+	{ "ASCII",      DebugDevice::Mode::ASCII },
+});
 SERIALIZE_ENUM(DebugDevice::Mode, debugModeInfo);
 
 template<typename Archive>

--- a/src/cassette/CassettePlayer.cc
+++ b/src/cassette/CassettePlayer.cc
@@ -676,11 +676,11 @@ void CassettePlayer::execSyncAudioEmu(EmuTime time)
 	syncScheduled = false;
 }
 
-static constexpr std::initializer_list<enum_string<CassettePlayer::State>> stateInfo = {
+static constexpr auto stateInfo = std::to_array<enum_string<CassettePlayer::State>>({
 	{ "PLAY",   CassettePlayer::State::PLAY   },
 	{ "RECORD", CassettePlayer::State::RECORD },
-	{ "STOP",   CassettePlayer::State::STOP   }
-};
+	{ "STOP",   CassettePlayer::State::STOP   },
+});
 SERIALIZE_ENUM(CassettePlayer::State, stateInfo);
 
 // version 1: initial version

--- a/src/config/HardwareConfig.cc
+++ b/src/config/HardwareConfig.cc
@@ -457,11 +457,11 @@ void HardwareConfig::setSlot(std::string_view slotName)
 	}
 }
 
-static constexpr std::initializer_list<enum_string<HardwareConfig::Type>> configTypeInfo = {
+static constexpr auto configTypeInfo = std::to_array<enum_string<HardwareConfig::Type>>({
 	{ "MACHINE",   HardwareConfig::Type::MACHINE   },
 	{ "EXTENSION", HardwareConfig::Type::EXTENSION },
 	{ "ROM",       HardwareConfig::Type::ROM       },
-};
+});
 SERIALIZE_ENUM(HardwareConfig::Type, configTypeInfo);
 
 // version 1: initial version

--- a/src/fdc/DriveMultiplexer.cc
+++ b/src/fdc/DriveMultiplexer.cc
@@ -146,13 +146,13 @@ void DriveMultiplexer::invalidateWd2793ReadTrackQuirk()
 }
 
 
-static constexpr std::initializer_list<enum_string<DriveMultiplexer::Drive>> driveNumInfo = {
+static constexpr auto driveNumInfo = std::to_array<enum_string<DriveMultiplexer::Drive>>({
 	{ "A",    DriveMultiplexer::Drive::A },
 	{ "B",    DriveMultiplexer::Drive::B },
 	{ "C",    DriveMultiplexer::Drive::C },
 	{ "D",    DriveMultiplexer::Drive::D },
-	{ "none", DriveMultiplexer::Drive::NONE }
-};
+	{ "none", DriveMultiplexer::Drive::NONE },
+});
 SERIALIZE_ENUM(DriveMultiplexer::Drive, driveNumInfo);
 
 template<typename Archive>

--- a/src/fdc/NowindHost.cc
+++ b/src/fdc/NowindHost.cc
@@ -772,7 +772,7 @@ void NowindHost::callImage(const std::string& filename)
 }
 
 
-static constexpr std::initializer_list<enum_string<NowindHost::State>> stateInfo = {
+static constexpr auto stateInfo = std::to_array<enum_string<NowindHost::State>>({
 	{ "SYNC1",     NowindHost::State::SYNC1     },
 	{ "SYNC2",     NowindHost::State::SYNC2     },
 	{ "COMMAND",   NowindHost::State::COMMAND   },
@@ -780,7 +780,7 @@ static constexpr std::initializer_list<enum_string<NowindHost::State>> stateInfo
 	{ "DISKWRITE", NowindHost::State::DISKWRITE },
 	{ "DEVOPEN",   NowindHost::State::DEVOPEN   },
 	{ "IMAGE",     NowindHost::State::IMAGE     },
-};
+});
 SERIALIZE_ENUM(NowindHost::State, stateInfo);
 
 template<typename Archive>

--- a/src/fdc/TC8566AF.cc
+++ b/src/fdc/TC8566AF.cc
@@ -916,7 +916,7 @@ EmuDuration TC8566AF::getSeekDelay() const
 }
 
 
-static constexpr std::initializer_list<enum_string<TC8566AF::Command>> commandInfo = {
+static constexpr auto commandInfo = std::to_array<enum_string<TC8566AF::Command>>({
 	{ "UNKNOWN",                TC8566AF::Command::UNKNOWN                },
 	{ "READ_DATA",              TC8566AF::Command::READ_DATA              },
 	{ "WRITE_DATA",             TC8566AF::Command::WRITE_DATA             },
@@ -932,23 +932,23 @@ static constexpr std::initializer_list<enum_string<TC8566AF::Command>> commandIn
 	{ "RECALIBRATE",            TC8566AF::Command::RECALIBRATE            },
 	{ "SENSE_INTERRUPT_STATUS", TC8566AF::Command::SENSE_INTERRUPT_STATUS },
 	{ "SPECIFY",                TC8566AF::Command::SPECIFY                },
-	{ "SENSE_DEVICE_STATUS",    TC8566AF::Command::SENSE_DEVICE_STATUS    }
-};
+	{ "SENSE_DEVICE_STATUS",    TC8566AF::Command::SENSE_DEVICE_STATUS    },
+});
 SERIALIZE_ENUM(TC8566AF::Command, commandInfo);
 
-static constexpr std::initializer_list<enum_string<TC8566AF::Phase>> phaseInfo = {
+static constexpr auto phaseInfo = std::to_array<enum_string<TC8566AF::Phase>>({
 	{ "IDLE",         TC8566AF::Phase::IDLE         },
 	{ "COMMAND",      TC8566AF::Phase::COMMAND      },
 	{ "DATATRANSFER", TC8566AF::Phase::DATA_TRANSFER },
-	{ "RESULT",       TC8566AF::Phase::RESULT       }
-};
+	{ "RESULT",       TC8566AF::Phase::RESULT       },
+});
 SERIALIZE_ENUM(TC8566AF::Phase, phaseInfo);
 
-static constexpr std::initializer_list<enum_string<TC8566AF::Seek>> seekInfo = {
+static constexpr auto seekInfo = std::to_array<enum_string<TC8566AF::Seek>>({
 	{ "IDLE",        TC8566AF::Seek::IDLE },
 	{ "SEEK",        TC8566AF::Seek::SEEK },
-	{ "RECALIBRATE", TC8566AF::Seek::RECALIBRATE }
-};
+	{ "RECALIBRATE", TC8566AF::Seek::RECALIBRATE },
+});
 SERIALIZE_ENUM(TC8566AF::Seek, seekInfo);
 
 template<typename Archive>

--- a/src/fdc/WD2793.cc
+++ b/src/fdc/WD2793.cc
@@ -1076,7 +1076,7 @@ void WD2793::endCmd(EmuTime time)
 }
 
 
-static constexpr std::initializer_list<enum_string<WD2793::FSM>> fsmStateInfo = {
+static constexpr auto fsmStateInfo = std::to_array<enum_string<WD2793::FSM>>({
 	{ "NONE",              WD2793::FSM::NONE },
 	{ "SEEK",              WD2793::FSM::SEEK },
 	{ "TYPE2_LOADED",      WD2793::FSM::TYPE2_LOADED },
@@ -1094,7 +1094,7 @@ static constexpr std::initializer_list<enum_string<WD2793::FSM>> fsmStateInfo = 
 	// for bw-compat savestate
 	{ "TYPE2_WAIT_LOAD",   WD2793::FSM::TYPE2_LOADED }, // was FSM::TYPE2_WAIT_LOAD
 	{ "TYPE3_WAIT_LOAD",   WD2793::FSM::TYPE3_LOADED }, // was FSM::TYPE3_WAIT_LOAD
-};
+});
 SERIALIZE_ENUM(WD2793::FSM, fsmStateInfo);
 
 // version 1: initial version

--- a/src/ide/MB89352.cc
+++ b/src/ide/MB89352.cc
@@ -731,7 +731,7 @@ uint8_t MB89352::peekRegister(uint8_t reg) const
 
 
 // TODO duplicated in WD33C93.cc
-static constexpr std::initializer_list<enum_string<SCSI::Phase>> phaseInfo = {
+static constexpr auto phaseInfo = std::to_array<enum_string<SCSI::Phase>>({
 	{ "UNDEFINED",   SCSI::Phase::UNDEFINED   },
 	{ "BUS_FREE",    SCSI::Phase::BUS_FREE    },
 	{ "ARBITRATION", SCSI::Phase::ARBITRATION },
@@ -743,8 +743,8 @@ static constexpr std::initializer_list<enum_string<SCSI::Phase>> phaseInfo = {
 	{ "DATA_OUT",    SCSI::Phase::DATA_OUT    },
 	{ "STATUS",      SCSI::Phase::STATUS      },
 	{ "MSG_OUT",     SCSI::Phase::MSG_OUT     },
-	{ "MSG_IN",      SCSI::Phase::MSG_IN      }
-};
+	{ "MSG_IN",      SCSI::Phase::MSG_IN      },
+});
 SERIALIZE_ENUM(SCSI::Phase, phaseInfo);
 
 template<typename Archive>

--- a/src/ide/WD33C93.cc
+++ b/src/ide/WD33C93.cc
@@ -440,7 +440,7 @@ void WD33C93::reset(bool scsiReset)
 }
 
 
-static constexpr std::initializer_list<enum_string<SCSI::Phase>> phaseInfo = {
+static constexpr auto phaseInfo = std::to_array<enum_string<SCSI::Phase>>({
 	{ "UNDEFINED",   SCSI::Phase::UNDEFINED   },
 	{ "BUS_FREE",    SCSI::Phase::BUS_FREE    },
 	{ "ARBITRATION", SCSI::Phase::ARBITRATION },
@@ -452,8 +452,8 @@ static constexpr std::initializer_list<enum_string<SCSI::Phase>> phaseInfo = {
 	{ "DATA_OUT",    SCSI::Phase::DATA_OUT    },
 	{ "STATUS",      SCSI::Phase::STATUS      },
 	{ "MSG_OUT",     SCSI::Phase::MSG_OUT     },
-	{ "MSG_IN",      SCSI::Phase::MSG_IN      }
-};
+	{ "MSG_IN",      SCSI::Phase::MSG_IN      },
+});
 SERIALIZE_ENUM(SCSI::Phase, phaseInfo);
 
 template<typename Archive>

--- a/src/laserdisc/LaserdiscPlayer.cc
+++ b/src/laserdisc/LaserdiscPlayer.cc
@@ -1040,43 +1040,43 @@ void LaserdiscPlayer::createRenderer()
 	renderer = RendererFactory::createLDRenderer(*this, display);
 }
 
-static constexpr std::initializer_list<enum_string<LaserdiscPlayer::RemoteState>> RemoteStateInfo = {
+static constexpr auto RemoteStateInfo = std::to_array<enum_string<LaserdiscPlayer::RemoteState>>({
 	{ "IDLE",             LaserdiscPlayer::RemoteState::IDLE             },
 	{ "HEADER_PULSE",     LaserdiscPlayer::RemoteState::HEADER_PULSE     },
 	{ "NEC_HEADER_SPACE", LaserdiscPlayer::RemoteState::NEC_HEADER_SPACE },
 	{ "NEC_BITS_PULSE",   LaserdiscPlayer::RemoteState::NEC_BITS_PULSE   },
 	{ "NEC_BITS_SPACE",   LaserdiscPlayer::RemoteState::NEC_BITS_SPACE   },
-};
+});
 SERIALIZE_ENUM(LaserdiscPlayer::RemoteState, RemoteStateInfo);
 
-static constexpr std::initializer_list<enum_string<LaserdiscPlayer::PlayerState>> PlayerStateInfo = {
+static constexpr auto PlayerStateInfo = std::to_array<enum_string<LaserdiscPlayer::PlayerState>>({
 	{ "STOPPED",    LaserdiscPlayer::PlayerState::STOPPED     },
 	{ "PLAYING",    LaserdiscPlayer::PlayerState::PLAYING     },
 	{ "MULTISPEED", LaserdiscPlayer::PlayerState::MULTI_SPEED },
 	{ "PAUSED",     LaserdiscPlayer::PlayerState::PAUSED      },
-	{ "STILL",      LaserdiscPlayer::PlayerState::STILL       }
-};
+	{ "STILL",      LaserdiscPlayer::PlayerState::STILL       },
+});
 SERIALIZE_ENUM(LaserdiscPlayer::PlayerState, PlayerStateInfo);
 
-static constexpr std::initializer_list<enum_string<LaserdiscPlayer::SeekState>> SeekStateInfo = {
+static constexpr auto SeekStateInfo = std::to_array<enum_string<LaserdiscPlayer::SeekState>>({
 	{ "NONE",    LaserdiscPlayer::SeekState::NONE    },
 	{ "CHAPTER", LaserdiscPlayer::SeekState::CHAPTER },
 	{ "FRAME",   LaserdiscPlayer::SeekState::FRAME   },
-	{ "WAIT",    LaserdiscPlayer::SeekState::WAIT    }
-};
+	{ "WAIT",    LaserdiscPlayer::SeekState::WAIT    },
+});
 SERIALIZE_ENUM(LaserdiscPlayer::SeekState, SeekStateInfo);
 
-static constexpr std::initializer_list<enum_string<LaserdiscPlayer::StereoMode>> StereoModeInfo = {
+static constexpr auto StereoModeInfo = std::to_array<enum_string<LaserdiscPlayer::StereoMode>>({
 	{ "LEFT",   LaserdiscPlayer::StereoMode::LEFT   },
 	{ "RIGHT",  LaserdiscPlayer::StereoMode::RIGHT  },
-	{ "STEREO", LaserdiscPlayer::StereoMode::STEREO }
-};
+	{ "STEREO", LaserdiscPlayer::StereoMode::STEREO },
+});
 SERIALIZE_ENUM(LaserdiscPlayer::StereoMode, StereoModeInfo);
 
-static constexpr std::initializer_list<enum_string<LaserdiscPlayer::RemoteProtocol>> RemoteProtocolInfo = {
+static constexpr auto RemoteProtocolInfo = std::to_array<enum_string<LaserdiscPlayer::RemoteProtocol>>({
 	{ "NONE", LaserdiscPlayer::RemoteProtocol::NONE },
 	{ "NEC",  LaserdiscPlayer::RemoteProtocol::NEC  },
-};
+});
 SERIALIZE_ENUM(LaserdiscPlayer::RemoteProtocol, RemoteProtocolInfo);
 
 // version 1: initial version

--- a/src/memory/AmdFlash.cc
+++ b/src/memory/AmdFlash.cc
@@ -1041,7 +1041,7 @@ void AmdFlash::execOperation(EmuTime time)
 	}
 }
 
-static constexpr std::initializer_list<enum_string<AmdFlash::State>> stateInfo = {
+static constexpr auto stateInfo = std::to_array<enum_string<AmdFlash::State>>({
 	{ "IDLE",         AmdFlash::State::READ },       // back compat with v3
 	{ "IDENT",        AmdFlash::State::AUTOSELECT }, // back compat with v3
 	{ "PRGERR",       AmdFlash::State::ERROR },      // back compat with v3
@@ -1052,8 +1052,8 @@ static constexpr std::initializer_list<enum_string<AmdFlash::State>> stateInfo =
 	{ "ERROR",        AmdFlash::State::ERROR },
 	{ "ERASE_SECTOR", AmdFlash::State::ERASE_SECTOR },
 	{ "ERASE_CHIP",   AmdFlash::State::ERASE_CHIP },
-	{ "PROGRAM",      AmdFlash::State::PROGRAM }
-};
+	{ "PROGRAM",      AmdFlash::State::PROGRAM },
+});
 SERIALIZE_ENUM(AmdFlash::State, stateInfo);
 
 template<typename Archive>

--- a/src/memory/EEPROM_93C46.cc
+++ b/src/memory/EEPROM_93C46.cc
@@ -227,14 +227,14 @@ void EEPROM_93C46::execute_command(EmuTime time)
 	}
 }
 
-static constexpr std::initializer_list<enum_string<EEPROM_93C46::State>> stateInfo = {
+static constexpr auto stateInfo = std::to_array<enum_string<EEPROM_93C46::State>>({
 	{ "IN_RESET",           EEPROM_93C46::State::IN_RESET           },
 	{ "WAIT_FOR_START_BIT", EEPROM_93C46::State::WAIT_FOR_START_BIT },
 	{ "WAIT_FOR_COMMAND",   EEPROM_93C46::State::WAIT_FOR_COMMAND   },
 	{ "READING_DATA",       EEPROM_93C46::State::READING_DATA       },
 	{ "WAIT_FOR_WRITE",     EEPROM_93C46::State::WAIT_FOR_WRITE     },
 	{ "WAIT_FOR_WRITEALL",  EEPROM_93C46::State::WAIT_FOR_WRITE_ALL },
-};
+});
 SERIALIZE_ENUM(EEPROM_93C46::State, stateInfo);
 
 template<typename Archive>

--- a/src/memory/SdCard.cc
+++ b/src/memory/SdCard.cc
@@ -325,13 +325,13 @@ void SdCard::executeCommand()
 	}
 }
 
-static constexpr std::initializer_list<enum_string<SdCard::Mode>> modeInfo = {
+static constexpr auto modeInfo = std::to_array<enum_string<SdCard::Mode>>({
 	{ "COMMAND",     SdCard::Mode::COMMAND  },
 	{ "READ",        SdCard::Mode::READ },
 	{ "MULTI_READ",  SdCard::Mode::MULTI_READ },
 	{ "WRITE",       SdCard::Mode::WRITE },
-	{ "MULTI_WRITE", SdCard::Mode::MULTI_WRITE }
-};
+	{ "MULTI_WRITE", SdCard::Mode::MULTI_WRITE },
+});
 SERIALIZE_ENUM(SdCard::Mode, modeInfo);
 
 template<typename Archive>

--- a/src/serial/I8251.cc
+++ b/src/serial/I8251.cc
@@ -318,34 +318,34 @@ void I8251::execTrans(EmuTime time)
 }
 
 
-static constexpr std::initializer_list<enum_string<SerialDataInterface::DataBits>> dataBitsInfo = {
-		{ "5", SerialDataInterface::DataBits::D5 },
-		{ "6", SerialDataInterface::DataBits::D6 },
-		{ "7", SerialDataInterface::DataBits::D7 },
-		{ "8", SerialDataInterface::DataBits::D8 }
-};
+static constexpr auto dataBitsInfo = std::to_array<enum_string<SerialDataInterface::DataBits>>({
+	{ "5", SerialDataInterface::DataBits::D5 },
+	{ "6", SerialDataInterface::DataBits::D6 },
+	{ "7", SerialDataInterface::DataBits::D7 },
+	{ "8", SerialDataInterface::DataBits::D8 },
+});
 SERIALIZE_ENUM(SerialDataInterface::DataBits, dataBitsInfo);
 
-static constexpr std::initializer_list<enum_string<SerialDataInterface::StopBits>> stopBitsInfo = {
+static constexpr auto stopBitsInfo = std::to_array<enum_string<SerialDataInterface::StopBits>>({
 	{ "INVALID", SerialDataInterface::StopBits::INV },
 	{ "1",       SerialDataInterface::StopBits::S1   },
 	{ "1.5",     SerialDataInterface::StopBits::S1_5  },
-	{ "2",       SerialDataInterface::StopBits::S2   }
-};
+	{ "2",       SerialDataInterface::StopBits::S2   },
+});
 SERIALIZE_ENUM(SerialDataInterface::StopBits, stopBitsInfo);
 
-static constexpr std::initializer_list<enum_string<SerialDataInterface::Parity>> parityBitInfo = {
+static constexpr auto parityBitInfo = std::to_array<enum_string<SerialDataInterface::Parity>>({
 	{ "EVEN", SerialDataInterface::Parity::EVEN },
-	{ "ODD",  SerialDataInterface::Parity::ODD  }
-};
+	{ "ODD",  SerialDataInterface::Parity::ODD  },
+});
 SERIALIZE_ENUM(SerialDataInterface::Parity, parityBitInfo);
 
-static constexpr std::initializer_list<enum_string<I8251::CmdPhase>> cmdFazeInfo = {
+static constexpr auto cmdFazeInfo = std::to_array<enum_string<I8251::CmdPhase>>({
 	{ "MODE",  I8251::CmdPhase::MODE  },
 	{ "SYNC1", I8251::CmdPhase::SYNC1 },
 	{ "SYNC2", I8251::CmdPhase::SYNC2 },
-	{ "CMD",   I8251::CmdPhase::CMD   }
-};
+	{ "CMD",   I8251::CmdPhase::CMD   },
+});
 SERIALIZE_ENUM(I8251::CmdPhase, cmdFazeInfo);
 
 // version 1: initial version

--- a/src/serial/I8254.cc
+++ b/src/serial/I8254.cc
@@ -464,10 +464,10 @@ void Counter::advance(EmuTime time)
 }
 
 
-static constexpr std::initializer_list<enum_string<Counter::ByteOrder>> byteOrderInfo = {
+static constexpr auto byteOrderInfo = std::to_array<enum_string<Counter::ByteOrder>>({
 	{ "LOW",  Counter::ByteOrder::LOW  },
-	{ "HIGH", Counter::ByteOrder::HIGH }
-};
+	{ "HIGH", Counter::ByteOrder::HIGH },
+});
 SERIALIZE_ENUM(Counter::ByteOrder, byteOrderInfo);
 
 template<typename Archive>

--- a/src/serialize_core.hh
+++ b/src/serialize_core.hh
@@ -79,25 +79,23 @@ template<typename T1, typename T2> struct SerializeClassVersion<std::pair<T1, T2
  *
  * The serialize_as_enum class has the following members:
  *  - static bool value
- *      True iff this type must be serialized as an enum.
+ *      True if this type must be serialized as an enum.
  *      The fields below are only valid (even only present) if this variable
  *      is true.
- *  - std::string toString(T t)
- *      convert enum value to string
- *  - T fromString(const std::string& str)
- *      convert from string back to enum value
+ *  - static constexpr std::span<const enum_string<T>> info()
+ *      Returns a view over the enum-to-string mapping table.
  *
  * If the enum has all consecutive values, starting from zero (as is the case
  * if you don't explicitly mention the numeric values in the enum definition),
  * you can use the SERIALIZE_ENUM macro as a convenient way to define a
  * specialization of serialize_as_enum:
-
+ *
  * example:
  *    enum MyEnum { FOO, BAR };
- *    std::initializer_list<enum_string<MyEnum>> myEnumInfo = {
+ *    static constexpr auto myEnumInfo = std::to_array<enum_string<MyEnum>>({
  *          { "FOO", FOO },
  *          { "BAR", BAR },
- *    };
+ *    });
  *    SERIALIZE_ENUM(MyEnum, myEnumInfo);
  *
  * Note: when an enum definition evolves it has impact on the serialization,

--- a/src/serialize_core.hh
+++ b/src/serialize_core.hh
@@ -10,8 +10,8 @@
 
 #include <array>
 #include <cassert>
-#include <initializer_list>
 #include <memory>
+#include <span>
 #include <string>
 #include <type_traits>
 #include <variant>
@@ -115,9 +115,9 @@ template<typename T> struct enum_string {
 [[noreturn]] void enumError(std::string_view str);
 
 template<typename T>
-inline std::string_view toString(std::initializer_list<enum_string<T>> list, T t_)
+inline std::string_view toString(std::span<const enum_string<T>> list, T t_)
 {
-	for (auto& [str, t] : list) {
+	for (const auto& [str, t] : list) {
 		if (t == t_) return str;
 	}
 	assert(false);
@@ -125,23 +125,24 @@ inline std::string_view toString(std::initializer_list<enum_string<T>> list, T t
 }
 
 template<typename T>
-T fromString(std::initializer_list<enum_string<T>> list, std::string_view str_)
+T fromString(std::span<const enum_string<T>> list, std::string_view str_)
 {
-	for (auto& [str, t] : list) {
+	for (const auto& [str, t] : list) {
 		if (str == str_) return t;
 	}
 	enumError(str_); // does not return (throws)
 	return T(); // avoid warning
 }
 
-#define SERIALIZE_ENUM(TYPE,INFO) \
-template<> struct serialize_as_enum< TYPE > : std::true_type { \
-	serialize_as_enum() : info(INFO) {} \
-	std::initializer_list<enum_string< TYPE >> info; \
+#define SERIALIZE_ENUM(TYPE, INFO) \
+template<> struct serialize_as_enum<TYPE> : std::true_type { \
+	static constexpr std::span<const enum_string<TYPE>> info() { \
+		return INFO; \
+	} \
 };
 
 template<typename Archive, typename T, typename SaveAction>
-void saveEnum(std::initializer_list<enum_string<T>> list, T t, SaveAction save)
+void saveEnum(std::span<const enum_string<T>> list, T t, SaveAction save)
 {
 	if constexpr (Archive::TRANSLATE_ENUM_TO_STRING) {
 		save(toString(list, t));
@@ -151,7 +152,7 @@ void saveEnum(std::initializer_list<enum_string<T>> list, T t, SaveAction save)
 }
 
 template<typename Archive, typename T, typename LoadAction>
-void loadEnum(std::initializer_list<enum_string<T>> list, T& t, LoadAction load)
+void loadEnum(std::span<const enum_string<T>> list, T& t, LoadAction load)
 {
 	if constexpr (Archive::TRANSLATE_ENUM_TO_STRING) {
 		std::string str;
@@ -395,8 +396,7 @@ template<typename T> struct EnumSaver
 	template<typename Archive> void operator()(Archive& ar, const T& t,
 	                                           bool /*saveId*/) const
 	{
-		serialize_as_enum<T> sae;
-		saveEnum<Archive>(sae.info, t,
+		saveEnum<Archive>(serialize_as_enum<T>::info(), t,
 			[&](const auto& s) { ar.save(s); });
 	}
 };
@@ -564,8 +564,8 @@ template<typename T> struct EnumLoader
 	{
 		static_assert(std::tuple_size_v<TUPLE> == 0,
 		              "can't have constructor arguments");
-		serialize_as_enum<T> sae;
-		loadEnum<Archive>(sae.info, t, [&](auto& l) { ar.load(l); });
+		loadEnum<Archive>(serialize_as_enum<T>::info(), t,
+			[&](auto& l) { ar.load(l); });
 	}
 };
 

--- a/src/sound/SCC.cc
+++ b/src/sound/SCC.cc
@@ -543,11 +543,11 @@ void SCC::Debuggable::write(unsigned address, uint8_t value, EmuTime time)
 }
 
 
-static constexpr std::initializer_list<enum_string<SCC::Mode>> chipModeInfo = {
+static constexpr auto chipModeInfo = std::to_array<enum_string<SCC::Mode>>({
 	{ "Real",       SCC::Mode::Real       },
 	{ "Compatible", SCC::Mode::Compatible },
 	{ "Plus",       SCC::Mode::Plus   },
-};
+});
 SERIALIZE_ENUM(SCC::Mode, chipModeInfo);
 
 template<typename Archive>

--- a/src/sound/VLM5030.cc
+++ b/src/sound/VLM5030.cc
@@ -537,7 +537,7 @@ VLM5030::~VLM5030()
 	unregisterSound();
 }
 
-static constexpr std::initializer_list<enum_string<VLM5030::Phase>> phaseInfo = {
+static constexpr auto phaseInfo = std::to_array<enum_string<VLM5030::Phase>>({
 	{ "RESET", VLM5030::Phase::RESET },
 	{ "IDLE",  VLM5030::Phase::IDLE  },
 	{ "SETUP", VLM5030::Phase::SETUP },
@@ -545,7 +545,7 @@ static constexpr std::initializer_list<enum_string<VLM5030::Phase>> phaseInfo = 
 	{ "RUN",   VLM5030::Phase::RUN   },
 	{ "STOP",  VLM5030::Phase::STOP  },
 	{ "END",   VLM5030::Phase::END   },
-};
+});
 SERIALIZE_ENUM(VLM5030::Phase, phaseInfo);
 
 // version 1: initial version

--- a/src/sound/Y8950.cc
+++ b/src/sound/Y8950.cc
@@ -1249,13 +1249,13 @@ void Y8950::Patch::serialize(Archive& ar, unsigned /*version*/)
 	             "RR", RR);
 }
 
-static constexpr std::initializer_list<enum_string<Y8950::EnvelopeState>> envelopeStateInfo = {
+static constexpr auto envelopeStateInfo = std::to_array<enum_string<Y8950::EnvelopeState>>({
 	{ "ATTACK",  Y8950::EnvelopeState::ATTACK  },
 	{ "DECAY",   Y8950::EnvelopeState::DECAY   },
 	{ "SUSTAIN", Y8950::EnvelopeState::SUSTAIN },
 	{ "RELEASE", Y8950::EnvelopeState::RELEASE },
-	{ "FINISH",  Y8950::EnvelopeState::FINISH  }
-};
+	{ "FINISH",  Y8950::EnvelopeState::FINISH  },
+});
 SERIALIZE_ENUM(Y8950::EnvelopeState, envelopeStateInfo);
 
 // version 1: initial version

--- a/src/sound/YM2413Burczynski.cc
+++ b/src/sound/YM2413Burczynski.cc
@@ -1277,14 +1277,14 @@ std::span<const uint8_t, 64> YM2413::peekRegs() const
 
 } // namespace YM2413Burczynski
 
-static constexpr std::initializer_list<enum_string<YM2413Burczynski::Slot::EnvelopeState>> envelopeStateInfo = {
+static constexpr auto envelopeStateInfo = std::to_array<enum_string<YM2413Burczynski::Slot::EnvelopeState>>({
 	{ "DUMP",    YM2413Burczynski::Slot::EnvelopeState::DUMP    },
 	{ "ATTACK",  YM2413Burczynski::Slot::EnvelopeState::ATTACK  },
 	{ "DECAY",   YM2413Burczynski::Slot::EnvelopeState::DECAY   },
 	{ "SUSTAIN", YM2413Burczynski::Slot::EnvelopeState::SUSTAIN },
 	{ "RELEASE", YM2413Burczynski::Slot::EnvelopeState::RELEASE },
-	{ "OFF",     YM2413Burczynski::Slot::EnvelopeState::OFF     }
-};
+	{ "OFF",     YM2413Burczynski::Slot::EnvelopeState::OFF     },
+});
 SERIALIZE_ENUM(YM2413Burczynski::Slot::EnvelopeState, envelopeStateInfo);
 
 namespace YM2413Burczynski {

--- a/src/sound/YM2413NukeYKT.cc
+++ b/src/sound/YM2413NukeYKT.cc
@@ -924,12 +924,12 @@ void YM2413::setSpeed(double speed)
 } // namespace YM2413NukeYKT
 
 
-static constexpr std::initializer_list<enum_string<YM2413NukeYKT::YM2413::EgState>> egStateInfo = {
+static constexpr auto egStateInfo = std::to_array<enum_string<YM2413NukeYKT::YM2413::EgState>>({
 	{ "attack",  YM2413NukeYKT::YM2413::EgState::attack },
 	{ "decay",   YM2413NukeYKT::YM2413::EgState::decay },
 	{ "sustain", YM2413NukeYKT::YM2413::EgState::sustain },
-	{ "release", YM2413NukeYKT::YM2413::EgState::release }
-};
+	{ "release", YM2413NukeYKT::YM2413::EgState::release },
+});
 SERIALIZE_ENUM(YM2413NukeYKT::YM2413::EgState, egStateInfo);
 
 namespace YM2413NukeYKT {

--- a/src/sound/YM2413Okazaki.cc
+++ b/src/sound/YM2413Okazaki.cc
@@ -1592,15 +1592,15 @@ std::span<const uint8_t, 64> YM2413::peekRegs() const
 
 } // namespace YM2413Okazaki
 
-static constexpr std::initializer_list<enum_string<YM2413Okazaki::Slot::EnvelopeState>> envelopeStateInfo = {
+static constexpr auto envelopeStateInfo = std::to_array<enum_string<YM2413Okazaki::Slot::EnvelopeState>>({
 	{ "ATTACK",  YM2413Okazaki::Slot::EnvelopeState::ATTACK  },
 	{ "DECAY",   YM2413Okazaki::Slot::EnvelopeState::DECAY   },
 	{ "SUSHOLD", YM2413Okazaki::Slot::EnvelopeState::SUSHOLD },
 	{ "SUSTAIN", YM2413Okazaki::Slot::EnvelopeState::SUSTAIN },
 	{ "RELEASE", YM2413Okazaki::Slot::EnvelopeState::RELEASE },
 	{ "SETTLE",  YM2413Okazaki::Slot::EnvelopeState::SETTLE  },
-	{ "FINISH",  YM2413Okazaki::Slot::EnvelopeState::FINISH  }
-};
+	{ "FINISH",  YM2413Okazaki::Slot::EnvelopeState::FINISH  },
+});
 SERIALIZE_ENUM(YM2413Okazaki::Slot::EnvelopeState, envelopeStateInfo);
 
 namespace YM2413Okazaki {

--- a/src/sound/YMF262.cc
+++ b/src/sound/YMF262.cc
@@ -1593,13 +1593,13 @@ void YMF262::generateChannels(std::span<float*> bufs, unsigned num)
 }
 
 
-static constexpr std::initializer_list<enum_string<YMF262::EnvelopeState>> envelopeStateInfo = {
+static constexpr auto envelopeStateInfo = std::to_array<enum_string<YMF262::EnvelopeState>>({
 	{ "ATTACK",  YMF262::EnvelopeState::ATTACK  },
 	{ "DECAY",   YMF262::EnvelopeState::DECAY   },
 	{ "SUSTAIN", YMF262::EnvelopeState::SUSTAIN },
 	{ "RELEASE", YMF262::EnvelopeState::RELEASE },
-	{ "OFF",     YMF262::EnvelopeState::OFF     }
-};
+	{ "OFF",     YMF262::EnvelopeState::OFF     },
+});
 SERIALIZE_ENUM(YMF262::EnvelopeState, envelopeStateInfo);
 
 template<typename Archive>

--- a/src/video/v9990/V9990.cc
+++ b/src/video/v9990/V9990.cc
@@ -894,13 +894,13 @@ void V9990::scheduleHscan(EmuTime time)
 	syncHScan.setSyncPoint(hScanSyncTime);
 }
 
-static constexpr std::initializer_list<enum_string<V9990DisplayMode>> displayModeInfo = {
+static constexpr auto displayModeInfo = std::to_array<enum_string<V9990DisplayMode>>({
 	{ "P1", V9990DisplayMode::P1 }, { "P2", V9990DisplayMode::P2 },
 	{ "B0", V9990DisplayMode::B0 }, { "B1", V9990DisplayMode::B1 },
 	{ "B2", V9990DisplayMode::B2 }, { "B3", V9990DisplayMode::B3 },
 	{ "B4", V9990DisplayMode::B4 }, { "B5", V9990DisplayMode::B5 },
-	{ "B6", V9990DisplayMode::B6 }, { "B7", V9990DisplayMode::B7 }
-};
+	{ "B6", V9990DisplayMode::B6 }, { "B7", V9990DisplayMode::B7 },
+});
 SERIALIZE_ENUM(V9990DisplayMode, displayModeInfo);
 
 // version 1: initial version


### PR DESCRIPTION
Fixes #985 

---

**tldr;** storing `std::initializer_list` as data members caused undefined behavior on all toolchains, update to use modern C++20  `std::span` and `std::array`

Since we also have to update all call sites to init with `std::array`, started by splitting this PR into two commits:

1. Change `SERIALIZE_ENUM` macro to take in `std::span`
2. Update all 35 usage of `SERIALIZE_ENUM` across 23 files to pass in `std::array` to make lifetime unambigious