### PR TITLE
enhancement: Simplify Reactor::run() and InputEventGenerator timeout handling.

### DIFF
--- a/src/events/InputEventGenerator.cc
+++ b/src/events/InputEventGenerator.cc
@@ -86,12 +86,10 @@ void InputEventGenerator::poll(std::optional<int> timeoutMs)
 	// For the first event, optionally wait with timeout. This allows
 	// efficient blocking when the emulator is paused, waking immediately
 	// on any SDL event (mouse, keyboard, etc.) or on timeout.
-	auto getNextEvent = [&, firstEvent = true]() mutable -> bool {
-		if (firstEvent && timeoutMs) {
-			firstEvent = false;
-			return SDL_WaitEventTimeout(curr, *timeoutMs) == 1;
-		}
-		return SDL_PollEvent(curr) == 1;
+	auto getNextEvent = [&] {
+		return timeoutMs
+			? SDL_WaitEventTimeout(curr, *std::exchange(timeoutMs, {}))
+			: SDL_PollEvent(curr);
 	};
 
 	while (getNextEvent()) {

--- a/src/events/InputEventGenerator.hh
+++ b/src/events/InputEventGenerator.hh
@@ -44,7 +44,7 @@ public:
 	  *        events in the same batch use SDL_PollEvent(). If nullopt,
 	  *        uses SDL_PollEvent() for all events (non-blocking).
 	  */
-	void poll(std::optional<int> timeoutMs = std::nullopt);
+	void poll(std::optional<int> timeoutMs = {});
 
 	[[nodiscard]] JoystickManager& getJoystickManager() { return joystickManager; }
 


### PR DESCRIPTION
Follow up on #2059, which fixed #2024

---

Reviewer mentioned the following improvements. I verified these do not add regressions to the improvements on `break` mode imgui framerate / responsiveness.

- Streamline `Reactor::run()` branching logic
- Simplify `getNextEvent()` with `std::exhange` usage
- `poll(std::optional<int> timeoutMs = {})` instead of `= std::nulptr` to align with rest of codebase