### PR TITLE
Add utils::subdir_completion to improve symboltracer parameter completion

### DIFF
--- a/share/scripts/_utils.tcl
+++ b/share/scripts/_utils.tcl
@@ -109,7 +109,7 @@ proc clip {min max val} {
 	expr {($val < $min) ? $min : (($val > $max) ? $max : $val)}
 }
 
-# provides.... file completion. Currently has a small issue: it adds a space at
+# provides.... file completion. Currently has a small issue: it adds a space
 # after a /, which you need to erase to continue completing
 proc file_completion {args} {
 	set result [list]
@@ -118,6 +118,32 @@ proc file_completion {args} {
 			append i /
 		}
 		lappend result $i
+	}
+	return $result
+}
+
+# provides.... file completion with path and extension. If path is empty, it
+# uses the current path. Currently has a small issue: it adds a space after
+# a /, which you need to erase to continue completing
+proc subdir_completion {args} {
+	set result [list]
+	set path [lindex $args end]
+	if {$path eq {} || [file isdirectory $path]} {
+		foreach i [glob -nocomplain -path $path *] {
+			if {[file isdirectory $i]} {
+				lappend result $i/
+			} elseif {[file extension $i] in [lrange $args 0 end-1]} {
+				lappend result $i
+			}
+		}
+	} elseif {![file exists $path]} {
+		foreach i [glob -nocomplain $path*] {
+			if {[file isdirectory $i]} {
+				lappend result $i/
+			} elseif {[file extension $i] in [lrange $args 0 end-1]} {
+				lappend result $i
+			}
+		}
 	}
 	return $result
 }
@@ -165,6 +191,7 @@ namespace export get_ordered_machine_list
 namespace export get_random_number
 namespace export clip
 namespace export file_completion
+namespace export subdir_completion
 namespace export filename_clean
 namespace export get_next_numbered_filename
 

--- a/share/scripts/lazy.tcl
+++ b/share/scripts/lazy.tcl
@@ -74,7 +74,8 @@ register_lazy "_utils.tcl" {
 	get_display_name_by_config_name get_machine_time format_time
 	format_time_subseconds format_time_hours_and_subseconds
 	get_machine_total_ram get_ordered_machine_list get_random_number clip
-	file_completion filename_clean get_next_numbered_filename}
+	file_completion subdir_completion filename_clean
+	get_next_numbered_filename}
 register_lazy "_vdp.tcl" {
 	getcolor setcolor get_screen_mode get_screen_mode_number vdpreg vdpregs
 	v9990regs vpeek vpoke palette vdpvramaddress vdpstatus

--- a/share/scripts/profiler.tcl
+++ b/share/scripts/profiler.tcl
@@ -43,7 +43,7 @@ Syntax: symboltracer stop
 	}
 }
 
-proc _enter_function name {
+proc _enter_function {name} {
 	# find function return address
 	set retaddr [peek16 [reg SP]]
 	# check if we create caller breakpoint for CALL or RST
@@ -57,7 +57,7 @@ proc _enter_function name {
 	}
 }
 
-proc _exit_function name {
+proc _exit_function {name} {
 	variable counters
 	# ignore a probable dangling breakpoint from a previous session
 	if {![dict exists $counters $name]} { return }
@@ -81,7 +81,7 @@ proc add {name addr} {
 	}
 }
 
-proc add_symbol_set symbols {
+proc add_symbol_set {symbols} {
 	# run through collection of symbols
 	foreach entry $symbols {
 		dict with entry {
@@ -129,6 +129,30 @@ proc stop {} {
 		debug symbols remove $file
 	}
 	set symbolfiles {}
+}
+
+set_tabcompletion_proc symboltracer [namespace code _tab_symboltracer]
+
+proc _tab_symboltracer {args} {
+	lassign $args prefix cmd path
+	switch -glob -- $cmd {
+		add -
+		stop {
+			concat
+		}
+		a* {
+			concat add
+		}
+		start {
+			utils::subdir_completion .sym .map .noi .symbol .publics .sys $path
+		}
+		s* {
+			concat start stop
+		}
+		default {
+			concat start add stop
+		}
+	}
 }
 
 }


### PR DESCRIPTION
Based on `utils::file_completion`, `utils::subdir_completion` works like this example:

```utils::subdir_completion *.noi *.sym *.map /home/pedro```

to show a popup with all files ending with ".noi", ".sym" and ".map" from the subdirectory "/home/pedro/"