### PR TITLE
Rename profiler.tcl to force lazy evaluation

### DIFF
--- a/share/scripts/_profiler.tcl
+++ b/share/scripts/_profiler.tcl
@@ -43,7 +43,7 @@ Syntax: symboltracer stop
 	}
 }
 
-proc _enter_function name {
+proc _enter_function {name} {
 	# find function return address
 	set retaddr [peek16 [reg SP]]
 	# check if we create caller breakpoint for CALL or RST
@@ -57,7 +57,7 @@ proc _enter_function name {
 	}
 }
 
-proc _exit_function name {
+proc _exit_function {name} {
 	variable counters
 	# ignore a probable dangling breakpoint from a previous session
 	if {![dict exists $counters $name]} { return }
@@ -81,7 +81,7 @@ proc add {name addr} {
 	}
 }
 
-proc add_symbol_set symbols {
+proc add_symbol_set {symbols} {
 	# run through collection of symbols
 	foreach entry $symbols {
 		dict with entry {
@@ -131,4 +131,12 @@ proc stop {} {
 	set symbolfiles {}
 }
 
+set_tabcompletion_proc symboltracer [namespace code _tab_symboltracer]
+
+proc _tab_symboltracer {args} {
+	list "start" "add" "stop"
 }
+
+} ;# namespace symboltracer
+
+namespace import symboltracer::*

--- a/share/scripts/lazy.tcl
+++ b/share/scripts/lazy.tcl
@@ -84,3 +84,4 @@ register_lazy "_vdp_busy.tcl" toggle_vdp_busy
 register_lazy "_vdrive.tcl" vdrive
 register_lazy "_vgmrecorder.tcl" {vgm_rec vgm_rec_next vgm_rec_end}
 register_lazy "_tcl_bridge.tcl" tcl_bridge
+register_lazy "_profiler.tcl" symboltracer


### PR DESCRIPTION
* Lazy evaluation makes the interpreter autocomplete only what we want;
* Add `set_tabcompletion_proc` to evaluate subcommands;
* And now it works like `record_channels` (referencing #2075):
<img width="644" height="543" alt="image" src="https://github.com/user-attachments/assets/003f8d99-2e7c-4fd4-8584-6fb3cb941bfd" />
