### PR TITLE
Use only the config specified by the TCL_CONFIG env var

### DIFF
--- a/build/libraries.py
+++ b/build/libraries.py
@@ -352,11 +352,12 @@ class TCL(Library):
 			return cls.tclConfig
 
 		def iterLocations():
-			# Allow the user to specify the location we should search first,
+			# Allow the user to specify the location of the config script,
 			# by setting an environment variable.
 			tclpath = environ.get('TCL_CONFIG')
 			if tclpath is not None:
 				yield tclpath
+				return
 
 			if distroRoot is None or cls.isSystemLibrary(platform):
 				if msysActive():


### PR DESCRIPTION
If Tcl 8.5 and 8.6 are installed, and the 8.6 config script location is specified using the TCL_CONFIG env var, then other dirs will still be searched and 8.5 will be chosen, rendering the env var useless in this case.
This change causes the search to be skipped if the env var is set, allowing the user to select the one specific Tcl version of their choice.
I don't know what is the intention here, but this make sense/works better for me.