### PR TITLE
fix: implement the dipswitch 4 logic for carriage return

### DIFF
--- a/src/Plotter.cc
+++ b/src/Plotter.cc
@@ -300,8 +300,16 @@ void MSXPlotter::processTextMode(uint8_t data)
 		ensurePrintPage();
 		penPosition = {0.0f, 30.0f};
 		break;
-	case 0x0d: // CR - Carriage return
+	case 0x0d: // CR - Carriage return, if dipswitch 4 is set, also do a line feed
 		penPosition.x = 0.0f;
+		if (getDipSwitch4()) {
+			penPosition.y -= lineFeed;
+			if (penPosition.y < -1354.0f) { // Page end reached
+				flushEmulatedPrinter();
+				ensurePrintPage();
+				penPosition.y = 30.0f; // Reset to top of new page
+			}
+		}
 		break;
 	case 0x12: // DC2 - Scale set prefix (wait for next char)
 		escState = EscState::ESC_S;


### PR DESCRIPTION
This should fix the behaviour of the dip switch with the carriage return.

10 LPRINT "TEST";CHR$(&H0D);
20 LPRINT "JE"

When the switch is on, it prints:
TEST
JE

When the switch is off, it prints:
JEST

Because it only goes to the beginning of the line without the newline and then prints JE over the TEST.