### PR TITLE
Fix OpenMSX crash when compiled against SDL2-compat

### DIFF
--- a/src/events/InputEventGenerator.cc
+++ b/src/events/InputEventGenerator.cc
@@ -26,7 +26,6 @@ InputEventGenerator::InputEventGenerator(CommandController& commandController,
 		false, Setting::Save::NO)
 	, escapeGrabCmd(commandController)
 {
-	setGrabInput(grabInput.getBoolean());
 	eventDistributor.registerEventListener(EventType::WINDOW, *this);
 }
 
@@ -486,6 +485,11 @@ bool InputEventGenerator::signalEvent(const Event& event)
 		}
 	}, event);
 	return false;
+}
+
+void InputEventGenerator::initializeGrab(void) const
+{
+	SDL_SetWindowGrab(SDL_GL_GetCurrentWindow(), grabInput.getBoolean() ? SDL_TRUE : SDL_FALSE);
 }
 
 void InputEventGenerator::setGrabInput(bool grab) const

--- a/src/events/InputEventGenerator.hh
+++ b/src/events/InputEventGenerator.hh
@@ -48,6 +48,8 @@ public:
 
 	[[nodiscard]] JoystickManager& getJoystickManager() { return joystickManager; }
 
+	void initializeGrab(void) const;
+
 private:
 	void handle(SDL_Event& evt);
 	void handleKeyDown(const SDL_KeyboardEvent& key, uint32_t unicode);

--- a/src/video/VisibleSurface.cc
+++ b/src/video/VisibleSurface.cc
@@ -155,6 +155,7 @@ VisibleSurface::VisibleSurface(
 	glGenVertexArrays(1, &vao);
 	glBindVertexArray(vao);
 #endif
+	inputEventGenerator.initializeGrab();
 }
 
 VisibleSurface::~VisibleSurface()


### PR DESCRIPTION
OpenMSX calls `SDL_SetWindowGrab` before the video subsystem is initialised, which when compiled against the sdl2-compat compatibility layer causes a segfault. That didn't happen before because SDL2 has a macro called `CHECK_WINDOW_MAGIC` that initialised video subsystem before any attempt to reference it. But SDL2-compat doesn't use that macro and calls SDL3 functions directly, so `_this` in SDL3 is not initialised before `_this->grabbed_window` is referenced in `SDL_GetGrabbedWindow`, causing OpenMSX to abort.

This fixes issue #2092 