### PR TITLE
Proposal: a second debuggable for ROMs with 16-bit segment indexes

### DIFF
--- a/src/imgui/ImGuiDebugger.cc
+++ b/src/imgui/ImGuiDebugger.cc
@@ -461,12 +461,12 @@ ImGuiDebugger::SlotInfo ImGuiDebugger::getSlotInfo(MSXCPUInterface& cpuInterface
 		const auto* device = cpuInterface.getVisibleMSXDevice(page);
 		if (const auto* mapper = dynamic_cast<const MSXMemoryMapperBase*>(device)) {
 			r.segment = strCat(mapper->getSelectedSegment(page));
-		} else if (auto [rom, romBlocks] = ImGuiDisassembly::getRomBlocks(debugger, device); romBlocks) {
+		} else if (auto [rom, debuggable] = ImGuiDisassembly::getDebuggable(debugger, device); debuggable) {
 			if (unsigned blockSize = RomInfo::getBlockSize(rom->getRomType())) {
 				auto addr = 0x4000 * page;
 				char separator = 'R';
 				for (int offset = 0; offset < 0x4000; offset += blockSize) {
-					auto seg = romBlocks->readExt(addr + offset);
+					auto seg = debuggable->readExt(addr + offset);
 					strAppend(r.segment, separator, strCat_if(seg != unsigned(-1), seg).else_('-'));
 					separator = '/';
 				}

--- a/src/imgui/ImGuiDisassembly.cc
+++ b/src/imgui/ImGuiDisassembly.cc
@@ -66,14 +66,14 @@ void ImGuiDisassembly::setGotoTarget(uint16_t target)
 	setDisassemblyScrollY.reset(); // don't restore initial scroll position
 }
 
-std::pair<const MSXRom*, RomBlockDebuggableBase*>
-	ImGuiDisassembly::getRomBlocks(Debugger& debugger, const MSXDevice* device)
+std::pair<const MSXRom*, RomBlockDebuggableBase::Debuggable16*>
+	ImGuiDisassembly::getDebuggable(Debugger& debugger, const MSXDevice* device)
 {
-	RomBlockDebuggableBase* debuggable = nullptr;
+	RomBlockDebuggableBase::Debuggable16* debuggable = nullptr;
 	const auto* rom = dynamic_cast<const MSXRom*>(device);
 	if (rom && !dynamic_cast<const RomPlain*>(rom)) {
-		debuggable = dynamic_cast<RomBlockDebuggableBase*>(
-			debugger.findDebuggable(tmpStrCat(rom->getName(), " romblocks")));
+		debuggable = dynamic_cast<RomBlockDebuggableBase::Debuggable16*>(
+			debugger.findDebuggable(tmpStrCat(rom->getName(), " romblocks16")));
 	}
 	return {rom, debuggable};
 }
@@ -98,8 +98,8 @@ struct CurrentSlot {
 		const auto* device = cpuInterface.getVisibleMSXDevice(page);
 		if (const auto* mapper = dynamic_cast<const MSXMemoryMapperBase*>(device)) {
 			result.seg = mapper->getSelectedSegment(narrow<uint8_t>(page));
-		} else if (auto [_, romBlocks] = ImGuiDisassembly::getRomBlocks(debugger, device); romBlocks) {
-			result.seg = romBlocks->readExt(addr);
+		} else if (auto [_, debuggable] = ImGuiDisassembly::getDebuggable(debugger, device); debuggable) {
+			result.seg = debuggable->readExt(addr);
 		}
 	}
 	return result;

--- a/src/imgui/ImGuiDisassembly.hh
+++ b/src/imgui/ImGuiDisassembly.hh
@@ -2,6 +2,7 @@
 #define IMGUI_DISASSEMBLY_HH
 
 #include "ImGuiPart.hh"
+#include "RomBlockDebuggable.hh"
 
 #include <optional>
 #include <span>
@@ -11,6 +12,7 @@
 namespace openmsx {
 
 class Debugger;
+class Debuggable;
 class MSXDevice;
 class MSXCPUInterface;
 class MSXRom;
@@ -35,8 +37,8 @@ public:
 
 public:
 	void actionToggleBp(MSXMotherBoard& motherBoard);
-	[[nodiscard]] static std::pair<const MSXRom*, RomBlockDebuggableBase*>
-		getRomBlocks(Debugger& debugger, const MSXDevice* device);
+	[[nodiscard]] static std::pair<const MSXRom*, RomBlockDebuggableBase::Debuggable16*>
+		getDebuggable(Debugger& debugger, const MSXDevice* device);
 
 private:
 	unsigned disassemble(

--- a/src/memory/RomAscii16X.cc
+++ b/src/memory/RomAscii16X.cc
@@ -22,6 +22,7 @@ namespace openmsx {
 RomAscii16X::RomAscii16X(DeviceConfig& config, Rom&& rom_)
 	: MSXRom(config, std::move(rom_))
 	, debuggable(*this)
+	, debuggableExt(*this, getName() + " romblocks ext")
 	, flash(rom, AmdFlashChip::S29GL064S70TFI040, {}, config)
 {
 	reset(EmuTime::dummy());
@@ -29,7 +30,8 @@ RomAscii16X::RomAscii16X(DeviceConfig& config, Rom&& rom_)
 
 void RomAscii16X::reset(EmuTime /*time*/)
 {
-	ranges::iota(bankRegs, uint16_t(0));
+	std::ranges::fill(mappedHigh, 0);
+	ranges::iota(mappedLow, uint8_t(0));
 
 	flash.reset();
 
@@ -38,7 +40,8 @@ void RomAscii16X::reset(EmuTime /*time*/)
 
 unsigned RomAscii16X::getFlashAddr(uint16_t addr) const
 {
-	uint16_t bank = bankRegs[((addr >> 14) & 1) ^ 1];
+	const uint16_t index = ((addr >> 14) & 1) ^ 1;
+	uint16_t bank = (mappedHigh[index] << 8) | mappedLow[index];
 	return (bank << 14) | (addr & 0x3FFF);
 }
 
@@ -63,7 +66,8 @@ void RomAscii16X::writeMem(uint16_t addr, byte value, EmuTime time)
 
 	if ((addr & 0x3FFF) >= 0x2000) {
 		const uint16_t index = (addr >> 12) & 1;
-		bankRegs[index] = (addr & 0x0F00) | value;
+		mappedLow[index] = value;
+		mappedHigh[index] = (addr >> 8) & 0x0F;
 		invalidateDeviceRCache(0x4000 ^ (index << 14), 0x4000);
 		invalidateDeviceRCache(0xC000 ^ (index << 14), 0x4000);
 	}
@@ -77,7 +81,8 @@ byte* RomAscii16X::getWriteCacheLine(uint16_t /* addr */)
 unsigned RomAscii16X::Debuggable::readExt(unsigned address)
 {
 	auto& outer = OUTER(RomAscii16X, debuggable);
-	return outer.bankRegs[((address >> 14) & 1) ^ 1];
+	uint8_t index = ((address >> 14) & 1) ^ 1;
+	return (outer.mappedHigh[index] << 8) | outer.mappedLow[index];
 }
 
 template<typename Archive>
@@ -87,7 +92,8 @@ void RomAscii16X::serialize(Archive& ar, unsigned /*version*/)
 	ar.template serializeBase<MSXDevice>(*this);
 
 	ar.serialize("flash",       flash,
-	             "bankRegs",    bankRegs);
+	             "mappedLow",   mappedLow,
+	             "mappedHigh",  mappedHigh);
 }
 INSTANTIATE_SERIALIZE_METHODS(RomAscii16X);
 REGISTER_MSXDEVICE(RomAscii16X, "RomAscii16X");

--- a/src/memory/RomAscii16X.cc
+++ b/src/memory/RomAscii16X.cc
@@ -21,8 +21,7 @@ namespace openmsx {
 
 RomAscii16X::RomAscii16X(DeviceConfig& config, Rom&& rom_)
 	: MSXRom(config, std::move(rom_))
-	, debuggable(*this)
-	, debuggableExt(*this, getName() + " romblocks ext")
+	, romBlockDebug(*this)
 	, flash(rom, AmdFlashChip::S29GL064S70TFI040, {}, config)
 {
 	reset(EmuTime::dummy());
@@ -30,8 +29,7 @@ RomAscii16X::RomAscii16X(DeviceConfig& config, Rom&& rom_)
 
 void RomAscii16X::reset(EmuTime /*time*/)
 {
-	std::ranges::fill(mappedHigh, 0);
-	ranges::iota(mappedLow, uint8_t(0));
+	ranges::iota(romBlockDebug.bankRegs, uint16_t(0));
 
 	flash.reset();
 
@@ -40,8 +38,7 @@ void RomAscii16X::reset(EmuTime /*time*/)
 
 unsigned RomAscii16X::getFlashAddr(uint16_t addr) const
 {
-	const uint16_t index = ((addr >> 14) & 1) ^ 1;
-	uint16_t bank = (mappedHigh[index] << 8) | mappedLow[index];
+	uint16_t bank = romBlockDebug.bankRegs[((addr >> 14) & 1) ^ 1];
 	return (bank << 14) | (addr & 0x3FFF);
 }
 
@@ -66,8 +63,7 @@ void RomAscii16X::writeMem(uint16_t addr, byte value, EmuTime time)
 
 	if ((addr & 0x3FFF) >= 0x2000) {
 		const uint16_t index = (addr >> 12) & 1;
-		mappedLow[index] = value;
-		mappedHigh[index] = (addr >> 8) & 0x0F;
+		romBlockDebug.bankRegs[index] = (addr & 0x0F00) | value;
 		invalidateDeviceRCache(0x4000 ^ (index << 14), 0x4000);
 		invalidateDeviceRCache(0xC000 ^ (index << 14), 0x4000);
 	}
@@ -78,11 +74,10 @@ byte* RomAscii16X::getWriteCacheLine(uint16_t /* addr */)
 	return nullptr; // not cacheable
 }
 
-unsigned RomAscii16X::Debuggable::readExt(unsigned address)
+unsigned RomAscii16X::Blocks::readExt(unsigned address)
 {
-	auto& outer = OUTER(RomAscii16X, debuggable);
 	uint8_t index = ((address >> 14) & 1) ^ 1;
-	return (outer.mappedHigh[index] << 8) | outer.mappedLow[index];
+	return bankRegs[index];
 }
 
 template<typename Archive>
@@ -92,8 +87,7 @@ void RomAscii16X::serialize(Archive& ar, unsigned /*version*/)
 	ar.template serializeBase<MSXDevice>(*this);
 
 	ar.serialize("flash",       flash,
-	             "mappedLow",   mappedLow,
-	             "mappedHigh",  mappedHigh);
+	             "bankRegs",    romBlockDebug.bankRegs);
 }
 INSTANTIATE_SERIALIZE_METHODS(RomAscii16X);
 REGISTER_MSXDEVICE(RomAscii16X, "RomAscii16X");

--- a/src/memory/RomAscii16X.hh
+++ b/src/memory/RomAscii16X.hh
@@ -27,18 +27,15 @@ public:
 private:
 	[[nodiscard]] unsigned getFlashAddr(uint16_t addr) const;
 
-	struct Debuggable final : RomBlockDebuggableBase {
-		explicit Debuggable(const RomAscii16X& device)
+	struct Blocks final : RomBlockDebuggableBase {
+		explicit Blocks(const RomAscii16X& device)
 			: RomBlockDebuggableBase(device) {}
-		explicit Debuggable(const RomAscii16X& device, std::string name_)
-			: RomBlockDebuggableBase(device, name_) {}
 		[[nodiscard]] unsigned readExt(unsigned address) override;
-	} debuggable, debuggableExt;
+
+		std::array<uint16_t, 2> bankRegs = {0, 0};
+	} romBlockDebug;
 
 	AmdFlash flash;
-
-	std::array<uint8_t, 2> mappedLow = {0, 0};
-	std::array<uint8_t, 2> mappedHigh = {0, 0};
 };
 
 } // namespace openmsx

--- a/src/memory/RomAscii16X.hh
+++ b/src/memory/RomAscii16X.hh
@@ -30,12 +30,15 @@ private:
 	struct Debuggable final : RomBlockDebuggableBase {
 		explicit Debuggable(const RomAscii16X& device)
 			: RomBlockDebuggableBase(device) {}
+		explicit Debuggable(const RomAscii16X& device, std::string name_)
+			: RomBlockDebuggableBase(device, name_) {}
 		[[nodiscard]] unsigned readExt(unsigned address) override;
-	} debuggable;
+	} debuggable, debuggableExt;
 
 	AmdFlash flash;
 
-	std::array<uint16_t, 2> bankRegs = {0, 0};
+	std::array<uint8_t, 2> mappedLow = {0, 0};
+	std::array<uint8_t, 2> mappedHigh = {0, 0};
 };
 
 } // namespace openmsx

--- a/src/memory/RomBlockDebuggable.hh
+++ b/src/memory/RomBlockDebuggable.hh
@@ -3,39 +3,61 @@
 
 #include "MSXDevice.hh"
 #include "SimpleDebuggable.hh"
+#include "outer.hh"
 
 #include <span>
 #include <string>
 
 namespace openmsx {
 
-class RomBlockDebuggableBase : public SimpleDebuggable
+class RomBlockDebuggableBase
 {
 public:
-	explicit RomBlockDebuggableBase(const MSXDevice& device, std::string name_)
-		: SimpleDebuggable(
-			device.getMotherBoard(),
-			name_,
-		        "Shows for each byte of the mapper which memory block is selected.",
-		        0x10000)
-	{
-	}
 	explicit RomBlockDebuggableBase(const MSXDevice& device)
-		: SimpleDebuggable(
+		: debuggable8(
 			device.getMotherBoard(),
 			device.getName() + " romblocks",
-		        "Shows for each byte of the mapper which memory block is selected.",
-		        0x10000)
+			"Shows for each byte of the mapper which memory block is selected.")
+		, debuggable16(
+			device.getMotherBoard(),
+			device.getName() + " romblocks16",
+			"Shows for each byte of the mapper which memory block is selected (16-bit version).")
 	{
-	}
-
-	// For the 'Debuggable' interface we need to have an 8-bit read(). For most mappers that's sufficient.
-	[[nodiscard]] byte read(unsigned address) override {
-		return narrow_cast<byte>(readExt(address));
 	}
 
 	// To support larger than 8 bit segment numbers.
 	[[nodiscard]] virtual unsigned readExt(unsigned address) = 0;
+
+	struct Debuggable8 final : SimpleDebuggable {
+		explicit Debuggable8(MSXMotherBoard& motherBoard_, const std::string name_, static_string_view description_)
+			: SimpleDebuggable(motherBoard_, name_, description_, 0x10000)
+		{
+		}
+		[[nodiscard]] byte read(unsigned address) override
+		{
+			auto& outer = OUTER(RomBlockDebuggableBase, debuggable8);
+			return narrow_cast<byte>(outer.readExt(address));
+		}
+	} debuggable8;
+
+	struct Debuggable16 final : SimpleDebuggable {
+		explicit Debuggable16(MSXMotherBoard& motherBoard_, const std::string name_, static_string_view description_)
+			: SimpleDebuggable(motherBoard_, name_, description_, 0x10000)
+		{
+		}
+		[[nodiscard]] byte read(unsigned address) override
+		{
+			auto& outer = OUTER(RomBlockDebuggableBase, debuggable16);
+			// extend read to return LSB or MSB according to even/odd address
+			return narrow_cast<byte>(address & 1 ? outer.readExt(address) >> 8 : outer.readExt(address));
+		}
+		// extend Debuggable16 interface to access outer function from debuggable
+		[[nodiscard]] unsigned readExt(unsigned address)
+		{
+			auto& outer = OUTER(RomBlockDebuggableBase, debuggable16);
+			return outer.readExt(address);
+		}
+	} debuggable16;
 
 protected:
 	~RomBlockDebuggableBase() = default;

--- a/src/memory/RomBlockDebuggable.hh
+++ b/src/memory/RomBlockDebuggable.hh
@@ -12,6 +12,14 @@ namespace openmsx {
 class RomBlockDebuggableBase : public SimpleDebuggable
 {
 public:
+	explicit RomBlockDebuggableBase(const MSXDevice& device, std::string name_)
+		: SimpleDebuggable(
+			device.getMotherBoard(),
+			name_,
+		        "Shows for each byte of the mapper which memory block is selected.",
+		        0x10000)
+	{
+	}
 	explicit RomBlockDebuggableBase(const MSXDevice& device)
 		: SimpleDebuggable(
 			device.getMotherBoard(),


### PR DESCRIPTION
This proof of concept changes RomAscii16X ROM device to add a second debuggable to allow Tcl scripts to access the remaining bits of a 16 bit segment index in a compatible manner.

The low 8-bit segment index is still accessible through:
```debug read {MSXdev25_ASTEROIDS_v1.0.rom romblocks} <address>```

but the remaining bits of the segment index are accessible through: 
```debug read {MSXdev25_ASTEROIDS_v1.0.rom romblocks16} <address>```

Since this is a proposal, I have set to draft, but if this is accepted as the right approach, I intend to do the same to other ROM like Yamanooto in the same PR.