### PR TITLE
fix(plotter): implement pen down state management

### DIFF
--- a/src/Plotter.cc
+++ b/src/Plotter.cc
@@ -437,18 +437,22 @@ void MSXPlotter::executeGraphicCommand()
 	case 'D': // Draw (absolute) - D x,y[,x,y,...]
 		// The D command draws a series of absolute line segments
 		printDebug("Plotter: D - Draw absolute, ", coords.size() / 2, " segments, penDown=", penDown);
+		setPenDown(true);
 		for (size_t i = 0; i + 1 < coords.size(); i += 2) {
 			gl::vec2 target{coords[i], coords[i + 1]};
 			lineTo(target);
 		}
+		setPenDown(false);
 		break;
 
 	case 'J': // Draw relative - J dx,dy[,dx,dy,...]
 		// The J command draws a series of relative line segments
 		printDebug("Plotter: J - Draw relative, ", coords.size() / 2, " segments, penDown=", penDown);
+		setPenDown(true);
 		for (size_t i = 0; i + 1 < coords.size(); i += 2) {
 			lineTo(penPosition + gl::vec2{coords[i], coords[i + 1]});
 		}
+		setPenDown(false);
 		break;
 
 	case 'S': // Scale set - S n (0-15)
@@ -621,9 +625,23 @@ void MSXPlotter::drawDot(gl::vec2 pos)
 	paper->draw_dot(toPaperPos(pos), penRadius(), penColor());
 }
 
+void MSXPlotter::setPenDown(bool newState)
+{
+	if (newState == penDown) return;
+	if (newState) {
+		// Pen touches down: deposit a dwell dot (extra ink while stationary).
+		penDown = true;
+		drawDot(penPosition);
+	} else {
+		// Pen about to lift: deposit a dwell dot, then raise.
+		drawDot(penPosition);
+		penDown = false;
+	}
+}
+
 void MSXPlotter::drawLine(gl::vec2 from, gl::vec2 to)
 {
-	if (!penDown) return; // TODO increase dashDistance?
+	assert(penDown);
 
 	ensurePrintPage();
 	// TODO handle begin/end point with draw_dot() ??
@@ -723,7 +741,7 @@ void MSXPlotter::resetSettings()
 	mode = Mode::TEXT;
 	escState = EscState::NONE;
 	selectedPen = 0;
-	penDown = true;
+	penDown = false;
 	penPosition = gl::vec2{0.0f, 30.0f};
 	origin = gl::vec2{0.0f, 1354.0f};
 	lineType = 0;
@@ -748,7 +766,6 @@ void MSXPlotter::moveTo(gl::vec2 pos)
 
 void MSXPlotter::lineTo(gl::vec2 pos)
 {
-	// lineTo calls drawLine, which now handles addMoveDelay
 	drawLine(penPosition, pos);
 	penPosition = pos;
 }
@@ -757,6 +774,10 @@ void MSXPlotter::drawCharacter(uint8_t c)
 {
 	ScopedAssign savedLineType(lineType, 0);
 	ScopedAssign savedDashDistance(dashDistance, dashDistance); // value doesn't matter, just restore at the end
+	// Character glyphs are drawn as short strokes from the glyph grid; the pen is
+	// logically down during the call. Skip dwell dots (setPenDown) because the
+	// cursor/baseline position is not where the pen physically touches paper.
+	ScopedAssign savedPenDown(penDown, true);
 
 	// Select font based on character set setting
 	auto font = [&] {

--- a/src/Plotter.cc
+++ b/src/Plotter.cc
@@ -465,7 +465,7 @@ void MSXPlotter::executeGraphicCommand()
 
 	case 'L': // Line type - L n (0-15)
 		if (!coords.empty()) {
-			lineType = std::clamp(int(coords[0]), 0, 15);
+			lineType = uint8_t(std::clamp(int(coords[0]), 0, 15));
 			dashDistance = 0.0f; // Reset pattern phase
 			printDebug("Plotter: L - Line type set to ", lineType);
 		}
@@ -572,7 +572,7 @@ void MSXPlotter::executeGraphicCommand()
 			auto newPen = unsigned(coords[0]);
 			if (newPen != selectedPen) {
 				printDebug("Plotter: C - Select color ", newPen, " (Pen change delay applied)");
-				selectedPen = newPen;
+				selectedPen = uint8_t(newPen);
 			}
 		}
 		break;

--- a/src/Plotter.hh
+++ b/src/Plotter.hh
@@ -89,6 +89,7 @@ private:
 	void drawLine(gl::vec2 from, gl::vec2 to);
 	void drawCharacter(uint8_t c);
 	void drawDot(gl::vec2 pos);
+	void setPenDown(bool newState);
 	void drawDashedLine(gl::vec2 A, gl::vec2 B, float halfPeriod);
 	void drawSolidLine(gl::vec2 A, gl::vec2 B);
 	[[nodiscard]] gl::vec2 toPaperPos(gl::vec2 plotterPos) const;
@@ -120,7 +121,7 @@ private:
 
 	// Pen/color state
 	uint8_t selectedPen = 0; // 0=black, 1=blue, 2=green, 3=red
-	bool penDown = true; // pen starts down for drawing   TODO this isn't used ??
+	bool penDown = false; // true while executing a drawing command (D/J/P or text-mode printable)
 
 	// Plotter head position (logical steps, relative to origin)
 	gl::vec2 penPosition{0.0f, 0.0f};

--- a/src/Plotter.hh
+++ b/src/Plotter.hh
@@ -162,10 +162,10 @@ public:
 
 	// Pen colors: 0=no ink, 1=full ink for subtractive model
 	static constexpr std::array<gl::vec3, 4> inkColors = {{
-		{0.80f, 0.80f, 0.80f}, // black
-		{0.80f, 0.80f, 0.00f}, // blue
-		{0.65f, 0.32f, 0.52f}, // green
-		{0.00f, 0.80f, 0.80f}, // red
+		{0.48f, 0.48f, 0.48f}, // black
+		{0.48f, 0.48f, 0.00f}, // blue
+		{0.39f, 0.192f, 0.312f}, // green
+		{0.00f, 0.48f, 0.48f}, // red
 	}};
 };
 

--- a/src/imgui/ImGuiPlotterViewer.cc
+++ b/src/imgui/ImGuiPlotterViewer.cc
@@ -103,7 +103,7 @@ void ImGuiPlotterViewer::paint(MSXMotherBoard* motherBoard)
 		ImGui::ColorButton("##pencolor", c, ImGuiColorEditFlags_NoTooltip,
 		                   gl::vec2{ImGui::GetFontSize()});
 		ImGui::SameLine();
-		ImGui::Text("  Pos: (%.1f, %.1f)", plotPos.x, plotPos.y);
+		ImGui::Text("  Pos: (%.1f, %.1f)", double(plotPos.x), double(plotPos.y));
 		ImGui::SameLine();
 		ImGui::StrCat("  Mode: ", plotter->isGraphicMode() ? "Graphic"sv : "Text"sv);
 


### PR DESCRIPTION
- Add setPenDown method to manage pen state.
- Update draw commands to set pen down before drawing.
- Ensure pen state is correctly handled during drawing operations.

Although the plotter now plots extra dots, I don't really see a difference in the generated PNG.