### PR TITLE
fix(plotter): set default size for plotter viewer window

### DIFF
--- a/src/imgui/ImGuiPlotterViewer.cc
+++ b/src/imgui/ImGuiPlotterViewer.cc
@@ -33,6 +33,7 @@ void ImGuiPlotterViewer::paint(MSXMotherBoard* motherBoard)
 {
 	if (!show) return;
 
+	ImGui::SetNextWindowSize({480, 720}, ImGuiCond_FirstUseEver);
 	im::Window("Plotter viewer", &show, [&]{
 		if (!motherBoard) {
 			ImGui::TextUnformatted("No machine present.");


### PR DESCRIPTION
- Add initial window size of 480x720 for the plotter viewer
- Ensure size is applied on first use to enhance user experience