### PR TITLE
fix: updated ST3 encoding and Turbo-R drive style so FastCopy 3.0 probes pass

### DIFF
--- a/share/machines/Boosted_MSXturboR_with_IDE.xml
+++ b/share/machines/Boosted_MSXturboR_with_IDE.xml
@@ -153,6 +153,7 @@
       <secondary slot="2">
         <TC8566AF id="Memory Mapped FDC">
           <io_regs>7FF2</io_regs>
+          <connectionstyle>National</connectionstyle>
           <mem base="0x4000" size="0x8000"/>
           <rom>
             <firstblock>48</firstblock>

--- a/share/machines/Panasonic_FS-A1GT.xml
+++ b/share/machines/Panasonic_FS-A1GT.xml
@@ -104,6 +104,7 @@
       <secondary slot="2">
         <TC8566AF id="Memory Mapped FDC">
           <io_regs>7FF2</io_regs>
+          <connectionstyle>National</connectionstyle>
           <mem base="0x4000" size="0x8000"/>
           <rom>
             <firstblock>48</firstblock>

--- a/share/machines/Panasonic_FS-A1ST.xml
+++ b/share/machines/Panasonic_FS-A1ST.xml
@@ -185,6 +185,7 @@
       <secondary slot="2">
         <TC8566AF id="Memory Mapped FDC">
           <io_regs>7FF2</io_regs>
+          <connectionstyle>National</connectionstyle>
           <rom>
             <firstblock>48</firstblock>
             <lastblock>55</lastblock>

--- a/share/machines/Sanyo_PHC-70FD.xml
+++ b/share/machines/Sanyo_PHC-70FD.xml
@@ -142,6 +142,7 @@
       <secondary slot="2">
         <TC8566AF id="Memory Mapped FDC">
           <io_regs>7FF8</io_regs>
+          <connectionstyle>National</connectionstyle>
           <drives>1</drives>
           <rom>
             <filename>Sanyo_PHC-70FD.rom</filename>

--- a/share/machines/Sanyo_PHC-70FD2.xml
+++ b/share/machines/Sanyo_PHC-70FD2.xml
@@ -123,6 +123,7 @@
       <secondary slot="2">
         <TC8566AF id="Memory Mapped FDC">
           <io_regs>7FF8</io_regs>
+          <connectionstyle>National</connectionstyle>
           <drives>2</drives>
           <rom>
             <filename>phc-70fd2_disk.rom</filename>

--- a/src/fdc/TC8566AF.cc
+++ b/src/fdc/TC8566AF.cc
@@ -423,9 +423,9 @@ void TC8566AF::commandPhase1(uint8_t value)
 		   //(drive[driveSelect]->isDiskInserted() ? 0 : ST0_DS0) |
 	           (value & (ST0_DS0 | ST0_DS1)) |
 	           (drive[driveSelect]->isDummyDrive() ? ST0_IC1 : 0));
-	status3  = (value & (ST3_DS0 | ST3_DS1)) |
+	status3  = (value & (ST3_DS0 | ST3_DS1 | ST3_HD)) |
 	           (drive[driveSelect]->isTrack00()        ? ST3_TK0 : 0) |
-	           (drive[driveSelect]->isDoubleSided()    ? ST3_HD  : 0) |
+	           (drive[driveSelect]->isDoubleSided()    ? ST3_2S  : 0) |
 	           (drive[driveSelect]->isWriteProtected() ? ST3_WP  : 0) |
 	           (drive[driveSelect]->isDiskInserted()   ? ST3_RDY : 0);
 }


### PR DESCRIPTION
Hi, this is an fix for issue https://github.com/openMSX/openMSX/issues/2025, the fix has been made by AI but the explanation it gives looks good and the software works correct after testing it.
----
Two related issues prevented FastCopy 3.0 (with the dr-bio4.gen driver) from running on the Panasonic FS-A1ST/FS-A1GT Turbo-R in openMSX. Real hardware runs it fine. FastCopy aborts with:

    "Sorry, but this program won't run on your computer."

FastCopy performs a strict TC8566AF authenticity probe before it does anything else. The probe issues SENSE DEVICE STATUS followed by RECALIBRATE, both with the drive motor OFF, and is picky about the exact bits returned. Two openMSX bugs combined to make this probe fail:

1. Wrong bit assigned to "two-sided disk" in ST3 
-------------------------------------------------- 
commandPhase1() was mapping DiskDrive::isDoubleSided() to ST3_HD (bit 2, "head select"), but per the TC8566AF / uPD765A datasheet the two-sided indicator lives in bit 3 (TS / ST3_2S). Bit 2 should echo the HD field of the preceding command byte.

FastCopy sends SENSE DEVICE STATUS with head=0/drive=0 and then checks `ST3 & 0x07 == 0`. With a double-sided 720KB DSK inserted, the wrong mapping set bit 2 spuriously, so the mask was non-zero and FastCopy concluded "no TC8566AF". 

Fix: map isDoubleSided() to ST3_2S, and include ST3_HD in the bits echoed from the command byte. This bug has been present since 2008 (commit da71d7900); it was dormant because typical disk drivers only inspect ST3 for RDY/WP/T0.

2. Panasonic Turbo-R drive connection style defaulted to Philips 
---------------------------------------------------------------- 
After the ST3 check, FastCopy issues RECALIBRATE with the motor still off and expects it to reach track 0. RealDrive::isTrack00() returns false while the motor is off when signalsNeedMotorOn is true, which is the default (Philips). The Panasonic/National Turbo-R internal drive behaves like the National FS-5500F2 documented in RealDrive.cc: the track 0 signal is valid regardless of motor state. Because the config defaulted to Philips, recalibrate stepped the head 255 times, gave up, set ST0 bit 4 (Equipment Check), and FastCopy read that as "drive not present".

Fix: add <connectionstyle>National</connectionstyle> to the TC8566AF element in Panasonic_FS-A1ST.xml and Panasonic_FS-A1GT.xml so the internal drive reports track 0 with motor off, matching real hardware.

Verified by booting Fastcopy30.dsk on Panasonic_FS-A1ST and confirming the main menu now appears; no regressions observed on the normal disk ROM boot path.