### PR TITLE
Fix Tcl 9.0 issues with ByteArray conversion

### DIFF
--- a/src/commands/TclObject.cc
+++ b/src/commands/TclObject.cc
@@ -166,10 +166,18 @@ zstring_view TclObject::getString() const
 	return {buf, size_t(length)};
 }
 
-std::span<const uint8_t> TclObject::getBinary() const
+std::span<const uint8_t> TclObject::getBinary(Interpreter& interp_) const
 {
+	auto* interp = interp_.interp;
 	Tcl_Size length;
+#if TCL_MAJOR_VERSION >= 9
+	const auto* buf = Tcl_GetBytesFromObj(interp, obj, &length);
+	if (buf == nullptr) {
+		throwException(interp);
+	}
+#else
 	const auto* buf = Tcl_GetByteArrayFromObj(obj, &length);
+#endif
 	return {buf, size_t(length)};
 }
 

--- a/src/commands/TclObject.hh
+++ b/src/commands/TclObject.hh
@@ -162,7 +162,7 @@ public:
 	[[nodiscard]] bool getBoolean (Interpreter& interp) const;
 	[[nodiscard]] float  getFloat (Interpreter& interp) const;
 	[[nodiscard]] double getDouble(Interpreter& interp) const;
-	[[nodiscard]] std::span<const uint8_t> getBinary() const;
+	[[nodiscard]] std::span<const uint8_t> getBinary(Interpreter& interp) const;
 	[[nodiscard]] size_t getListLength(Interpreter& interp) const;
 	[[nodiscard]] TclObject getListIndex(Interpreter& interp, size_t index) const;
 	[[nodiscard]] TclObject getListIndexUnchecked(size_t index) const;

--- a/src/debugger/Debugger.cc
+++ b/src/debugger/Debugger.cc
@@ -334,7 +334,7 @@ void Debugger::Cmd::writeBlock(std::span<const TclObject> tokens, TclObject& /*r
 	if (addr >= devSize) {
 		throw CommandException("Invalid address");
 	}
-	auto buf = tokens[4].getBinary();
+	auto buf = tokens[4].getBinary(getInterpreter());
 	if ((buf.size() + addr) > devSize) {
 		throw CommandException("Invalid size");
 	}
@@ -373,7 +373,7 @@ void Debugger::Cmd::disasm(std::span<const TclObject> tokens, TclObject& result,
 void Debugger::Cmd::disasmBlob(std::span<const TclObject> tokens, TclObject& result) const
 {
 	checkNumArgs(tokens, Between{4, 5}, Prefix{2}, "value addr ?function?");
-	std::span<const uint8_t> bin = tokens[2].getBinary();
+	std::span<const uint8_t> bin = tokens[2].getBinary(getInterpreter());
 	auto len = instructionLength(bin);
 	if (!len || *len > bin.size()) {
 		throw CommandException("Blob does not contain a complete Z80 instruction");

--- a/src/input/Keyboard.cc
+++ b/src/input/Keyboard.cc
@@ -1776,7 +1776,7 @@ void Keyboard::Msxcode2UnicodeCmd::execute(std::span<const TclObject> tokens, Tc
 	const auto& keyboard = OUTER(Keyboard, msxcode2UnicodeCmd);
 	const auto& msxChars = keyboard.unicodeKeymap.getMsxChars();
 
-	auto msx = tokens[1].getBinary();
+	auto msx = tokens[1].getBinary(getInterpreter());
 	auto fallback = [&] -> std::function<uint32_t(uint8_t)> {
 		if (tokens.size() < 3) {
 			// If no fallback is given use space as replacement character

--- a/src/unittest/TclObject_test.cc
+++ b/src/unittest/TclObject_test.cc
@@ -149,13 +149,17 @@ TEST_CASE("TclObject, operator=")
 	SECTION("binary") {
 		std::array<uint8_t, 3> buf = {1, 2, 3};
 		t = std::span{buf};
-		auto result = t.getBinary();
+		auto result = t.getBinary(interp);
 		CHECK(std::ranges::equal(buf, result));
 		// 'buf' was copied into 't'
 		CHECK(result.data() != &buf[0]);
 		CHECK(result[0] == 1);
 		buf[0] = 99;
 		CHECK(result[0] == 1);
+#if TCL_MAJOR_VERSION >= 9
+		TclObject t2("␢");
+		CHECK_THROWS(t2.getBinary(interp));
+#endif
 	}
 	SECTION("copy") {
 		TclObject t2(true);


### PR DESCRIPTION
Issue #2115 is now fixed on Tcl 9.0:
<img width="861" height="589" alt="image" src="https://github.com/user-attachments/assets/c3883212-abad-4730-a851-dd7edc12980b" />
No more SIGABRT, just a simple error message