### PR TITLE
Search for file with ROM extension in zip file 

### DIFF
--- a/src/file/File.cc
+++ b/src/file/File.cc
@@ -15,7 +15,7 @@ namespace openmsx {
 
 File::File() = default;
 
-[[nodiscard]] static std::unique_ptr<FileBase> init(zstring_view filename, File::OpenMode mode)
+[[nodiscard]] static std::unique_ptr<FileBase> init(zstring_view filename, File::OpenMode mode, zstring_view extension = {})
 {
 	static constexpr std::array<uint8_t, 3> GZ_HEADER  = {0x1F, 0x8B, 0x08};
 	static constexpr std::array<uint8_t, 4> ZIP_HEADER = {0x50, 0x4B, 0x03, 0x04};
@@ -28,7 +28,7 @@ File::File() = default;
 		if (std::ranges::equal(subspan<3>(buf), GZ_HEADER)) {
 			file = std::make_unique<GZFileAdapter>(std::move(file), filename);
 		} else if (std::ranges::equal(subspan<4>(buf), ZIP_HEADER)) {
-			file = std::make_unique<ZipFileAdapter>(std::move(file), filename);
+			file = std::make_unique<ZipFileAdapter>(std::move(file), filename, extension);
 		} else {
 			// only pre-cache non-compressed files
 			if (mode == File::OpenMode::PRE_CACHE) {
@@ -39,8 +39,8 @@ File::File() = default;
 	return file;
 }
 
-File::File(zstring_view filename, OpenMode mode)
-	: file(init(filename, mode))
+File::File(zstring_view filename, OpenMode mode, zstring_view extension)
+	: file(init(filename, mode, extension))
 {
 }
 

--- a/src/file/File.hh
+++ b/src/file/File.hh
@@ -37,7 +37,7 @@ public:
 	 * @throws FileNotFoundException if file not found
 	 * @throws FileException for other errors
 	 */
-	explicit File(zstring_view filename, OpenMode mode = OpenMode::NORMAL);
+	explicit File(zstring_view filename, OpenMode mode = OpenMode::NORMAL, zstring_view extension = {});
 
 	/** This constructor maps very closely on the fopen() libc function.
 	  * Compared to constructor above, it does not transparently

--- a/src/file/ZipFileAdapter.cc
+++ b/src/file/ZipFileAdapter.cc
@@ -2,12 +2,14 @@
 
 #include "FileException.hh"
 #include "MappedFile.hh"
+#include "StringOp.hh"
 #include "ZlibInflate.hh"
 
 namespace openmsx {
 
-ZipFileAdapter::ZipFileAdapter(std::unique_ptr<FileBase> file_, zstring_view filename_)
+ZipFileAdapter::ZipFileAdapter(std::unique_ptr<FileBase> file_, zstring_view filename_, zstring_view extension_)
 	: CompressedFileAdapter(std::move(file_), filename_)
+	, extension(extension_)
 {
 }
 
@@ -16,29 +18,36 @@ void ZipFileAdapter::decompress(FileBase& f, Decompressed& d)
 	auto mmap = MappedFile<const uint8_t>(f.mmap(0, true));
 	ZlibInflate zlib(mmap);
 
-	if (zlib.get32LE() != 0x04034B50) {
-		throw FileException("Invalid ZIP file");
+	while (true) {
+		if (zlib.get32LE() != 0x04034B50) {
+			throw FileException("Invalid ZIP file");
+		}
+
+		// skip "version needed to extract" and "general purpose bit flag"
+		zlib.skip(2 + 2);
+
+		// compression method
+		if (auto x = zlib.get16LE(); x != 0 && x != 0x0008) {
+			throw FileException("Unsupported zip compression method");
+		}
+
+		// skip "last mod file time", "last mod file data", "crc32"
+		zlib.skip(2 + 2 + 4);
+
+		unsigned compSize = zlib.get32LE(); // compressed size
+		unsigned origSize = zlib.get32LE(); // uncompressed size
+		unsigned filenameLen = zlib.get16LE(); // filename length
+		unsigned extraFieldLen = zlib.get16LE(); // extra field length
+		d.originalName = zlib.getString(filenameLen); // original filename
+		zlib.skip(extraFieldLen); // skip "extra field"
+
+		if (extension.empty() || StringOp::toLower(d.originalName).ends_with(extension)) {
+			d.buf = zlib.inflate(origSize);
+			return;
+		}
+
+		zlib.skip(compSize);
 	}
-
-	// skip "version needed to extract" and "general purpose bit flag"
-	zlib.skip(2 + 2);
-
-	// compression method
-	if (zlib.get16LE() != 0x0008) {
-		throw FileException("Unsupported zip compression method");
-	}
-
-	// skip "last mod file time", "last mod file data",
-	//      "crc32",              "compressed size"
-	zlib.skip(2 + 2 + 4 + 4);
-
-	unsigned origSize = zlib.get32LE(); // uncompressed size
-	unsigned filenameLen = zlib.get16LE(); // filename length
-	unsigned extraFieldLen = zlib.get16LE(); // extra field length
-	d.originalName = zlib.getString(filenameLen); // original filename
-	zlib.skip(extraFieldLen); // skip "extra field"
-
-	d.buf = zlib.inflate(origSize);
 }
 
 } // namespace openmsx

--- a/src/file/ZipFileAdapter.hh
+++ b/src/file/ZipFileAdapter.hh
@@ -8,10 +8,11 @@ namespace openmsx {
 class ZipFileAdapter final : public CompressedFileAdapter
 {
 public:
-	explicit ZipFileAdapter(std::unique_ptr<FileBase> file, zstring_view filename);
+	explicit ZipFileAdapter(std::unique_ptr<FileBase> file, zstring_view filename, zstring_view extension);
 
 private:
 	void decompress(FileBase& file, Decompressed& decompressed) override;
+	std::string extension;
 };
 
 } // namespace openmsx

--- a/src/memory/Rom.cc
+++ b/src/memory/Rom.cc
@@ -121,7 +121,7 @@ void Rom::init(MSXMotherBoard& motherBoard, XMLElement& config,
 		if (resolvedFilenameElem) {
 			try {
 				auto fname = resolvedFilenameElem->getData();
-				file = File(fname);
+				file = File(fname, File::OpenMode::NORMAL, ".rom");
 				filename = fname;
 			} catch (FileException&) {
 				// ignore


### PR DESCRIPTION
When loading a ROM file as a cartridge, the contents of a supplied zip file are checked until a .ROM extension is found. The matching file is then deflated.