### PR TITLE
Fixes library version probing

### DIFF
--- a/build/libraries.py
+++ b/build/libraries.py
@@ -189,7 +189,7 @@ class FreeType(Library):
 	@classmethod
 	def getVersion(cls, platform, linkStatic, distroRoot):
 		configScript = cls.getConfigScript(platform, linkStatic, distroRoot)
-		return '`%s --ftversion`' % configScript
+		return '`%s --version`' % configScript
 
 class GL(Library):
 	libName = 'GL'


### PR DESCRIPTION
When running ./configure, freetype was not returning its version number. The log file `derived/x86_64-linux-opt/config/probe.log` shows the following error:
```
FREETYPE: Found header
FREETYPE: Found lib
Error executing "pkg-config freetype2 --ftversion"
pkgconf: unknown option -- ftversion
Execution failed with exit code 1
```

After applying the fix, the library returns the version number, e.g.:
```
$ ./configure
...
Found libraries:
  ALSA:             version 1.2.15.3
  FreeType:         version 2.5.1
  GLEW:             version unknown
...
```