### PR TITLE
Adds missing #include <climits>

### DIFF
--- a/src/commands/TclObject.hh
+++ b/src/commands/TclObject.hh
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <climits>
 #include <cstdint>
 #include <initializer_list>
 #include <iterator>


### PR DESCRIPTION
There was a compilation error, caused by a missing header in the TCLObject source code:

```sh
src/commands/TclObject.cc: In member function ‘void openmsx::TclObject::addListElementsImpl(int, Tcl_Obj* const*)’:
src/commands/TclObject.cc:51:45: error: ‘INT_MAX’ was not declared in this scope
   51 |         if (Tcl_ListObjReplace(interp, obj, INT_MAX, 0, objc, objv) != TCL_OK) {
      |                                             ^~~~~~~
src/commands/TclObject.cc:5:1: note: ‘INT_MAX’ is defined in header ‘<climits>’; this is probably fixable by adding ‘#include <climits>’
    4 | #include "Interpreter.hh"
  +++ |+#include <climits>
    5 | 
```

System info:

```sh
$ g++ --version
g++ (GCC) 16.1.1 20260501 (Red Hat 16.1.1-1)
Copyright (C) 2026 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

Info after `make` command:

```sh
Using Python: python3
Build configuration:
Up to date: derived/x86_64-linux-opt/config/Version.ii
  Platform: x86_64-linux
  Flavour:  opt
  Compiler: g++
  Subset:   full build
```

Adding the missing import fixed the problem.