### PR TITLE
feat(wavegame): add Wave Game audio cartridge support

### DIFF
--- a/build/msvc/openmsx.vcxproj
+++ b/build/msvc/openmsx.vcxproj
@@ -697,6 +697,8 @@
     <ClCompile Include="$(OpenMSXSrcDir)\sound\VLM5030.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\sound\WavAudioInput.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\sound\WavWriter.cc" />
+    <ClCompile Include="$(OpenMSXSrcDir)\sound\WaveGame.cc" />
+    <ClCompile Include="$(OpenMSXSrcDir)\sound\WaveGameCommand.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\sound\Y8950.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\sound\Y8950Adpcm.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\sound\Y8950KeyboardConnector.cc" />
@@ -1305,6 +1307,8 @@
     <None Include="$(OpenMSXSrcDir)\sound\WavAudioInput.hh" />
     <None Include="$(OpenMSXSrcDir)\sound\WavData.hh" />
     <None Include="$(OpenMSXSrcDir)\sound\WavWriter.hh" />
+    <None Include="$(OpenMSXSrcDir)\sound\WaveGame.hh" />
+    <None Include="$(OpenMSXSrcDir)\sound\WaveGameCommand.hh" />
     <None Include="$(OpenMSXSrcDir)\sound\Y8950.hh" />
     <None Include="$(OpenMSXSrcDir)\sound\Y8950Adpcm.hh" />
     <None Include="$(OpenMSXSrcDir)\sound\Y8950KeyboardConnector.hh" />

--- a/build/msvc/openmsx.vcxproj.filters
+++ b/build/msvc/openmsx.vcxproj.filters
@@ -1086,6 +1086,12 @@
     <ClCompile Include="$(OpenMSXSrcDir)\sound\WavWriter.cc">
       <Filter>sound</Filter>
     </ClCompile>
+    <ClCompile Include="$(OpenMSXSrcDir)\sound\WaveGame.cc">
+      <Filter>sound</Filter>
+    </ClCompile>
+    <ClCompile Include="$(OpenMSXSrcDir)\sound\WaveGameCommand.cc">
+      <Filter>sound</Filter>
+    </ClCompile>
     <ClCompile Include="$(OpenMSXSrcDir)\sound\Y8950.cc">
       <Filter>sound</Filter>
     </ClCompile>
@@ -2644,6 +2650,12 @@
       <Filter>sound</Filter>
     </None>
     <None Include="$(OpenMSXSrcDir)\sound\WavWriter.hh">
+      <Filter>sound</Filter>
+    </None>
+    <None Include="$(OpenMSXSrcDir)\sound\WaveGame.hh">
+      <Filter>sound</Filter>
+    </None>
+    <None Include="$(OpenMSXSrcDir)\sound\WaveGameCommand.hh">
       <Filter>sound</Filter>
     </None>
     <None Include="$(OpenMSXSrcDir)\sound\Y8950.hh">

--- a/share/extensions/WaveGame.xml
+++ b/share/extensions/WaveGame.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<!DOCTYPE msxconfig SYSTEM 'msxconfig2.dtd'>
+<msxconfig>
+  <info>
+    <manufacturer>MSX Pico</manufacturer>
+    <code>WaveGame</code>
+    <release_year>2025</release_year>
+    <description>MSX Pico Wave Game audio cartridge. Streams WAV music files on I/O port 0x92. Use Media &gt; Wave Game to point it at a directory of NN.wav / NN.cfg files. Note: port 0x92 is unofficial, avoid combining with any device that also writes 0x92.</description>
+    <type>Cartridge</type>
+  </info>
+  <devices>
+    <WaveGame id="Wave Game">
+      <io base="0x92" num="1" type="O"/>
+      <firmware>1</firmware>
+      <sound>
+        <volume>15000</volume>
+      </sound>
+    </WaveGame>
+  </devices>
+</msxconfig>

--- a/src/DeviceFactory.cc
+++ b/src/DeviceFactory.cc
@@ -90,6 +90,7 @@
 #include "VDPIODelay.hh"
 #include "VictorFDC.hh"
 #include "Video9000.hh"
+#include "WaveGame.hh"
 #include "XMLElement.hh"
 #include "YamahaFDC.hh"
 #include "YamahaSKW01.hh"
@@ -322,6 +323,8 @@ std::unique_ptr<MSXDevice> DeviceFactory::create(DeviceConfig& conf)
 		// Ignore for now. We might want to create a real device for it later.
 	} else if (type == "MSXPiDevice") {
 		result = std::make_unique<MSXPiDevice>(conf);
+	} else if (type == "WaveGame") {
+		result = std::make_unique<WaveGame>(conf);
 	} else {
 		throw MSXException("Unknown device \"", type,
 		                   "\" specified in configuration");

--- a/src/imgui/ImGuiMedia.cc
+++ b/src/imgui/ImGuiMedia.cc
@@ -43,6 +43,8 @@ namespace openmsx {
 
 using namespace std::literals;
 
+static constexpr zstring_view WAVEGAME_MEDIA = "wavegame";
+
 void ImGuiMedia::save(ImGuiTextBuffer& buf)
 {
 	savePersistent(buf, *this, persistentElements);
@@ -101,6 +103,9 @@ void ImGuiMedia::save(ImGuiTextBuffer& buf)
 
 	if (cassetteMediaInfo.show) buf.append("cassette.show=1\n");
 	saveGroup(cassetteMediaInfo.group, "cassette");
+
+	if (wavegameMediaInfo.show) buf.append("wavegame.show=1\n");
+	saveGroup(wavegameMediaInfo.group, "wavegame");
 
 	saveGroup(extensionMediaInfo, "extension");
 	saveGroup(laserdiscMediaInfo, "laserdisc");
@@ -186,6 +191,13 @@ void ImGuiMedia::loadLine(std::string_view name, zstring_view value)
 		} else {
 			loadGroup(cassetteMediaInfo.group, suffix);
 		}
+	} else if (name.starts_with("wavegame.")) {
+		auto suffix = name.substr(9);
+		if (suffix == "show") {
+			wavegameMediaInfo.show = StringOp::stringToBool(value);
+		} else {
+			loadGroup(wavegameMediaInfo.group, suffix);
+		}
 	} else if (name.starts_with("extension.")) {
 		loadGroup(extensionMediaInfo, name.substr(10));
 	} else if (name.starts_with("laserdisc.")) {
@@ -211,6 +223,8 @@ void ImGuiMedia::showMediaWindow(std::string_view mediaName)
 	//	} else if (auto index = getIndex("cd")) {
 		} else if (mediaName.starts_with("cassette")) {
 			cassetteMediaInfo.show = true;
+		} else if (mediaName == WAVEGAME_MEDIA) {
+			wavegameMediaInfo.show = true;
 	//	} else if (mediaName.starts_with("laserdisc")) {
 		}
 }
@@ -704,6 +718,19 @@ void ImGuiMedia::showMenu(MSXMotherBoard* motherBoard)
 			});
 		}
 		endGroup();
+
+		// Wave Game
+		if (motherBoard->findMediaProvider(WAVEGAME_MEDIA)) {
+			elementInGroup();
+			ImGui::MenuItem("Wave Game", nullptr, &wavegameMediaInfo.show);
+			simpleToolTip([&] -> std::string {
+				auto cmdResult = manager.execute(TclObject(WAVEGAME_MEDIA));
+				if (!cmdResult) return "Empty";
+				auto s = cmdResult->getString();
+				return s.empty() || s == "empty" ? "Empty" : std::string(s);
+			});
+		}
+		endGroup();
 	});
 
 	if (switchHdAction) {
@@ -829,6 +856,12 @@ void ImGuiMedia::paint(MSXMotherBoard* motherBoard)
 	if (cassetteMediaInfo.show) {
 		if (auto* player = motherBoard->getCassettePort().getCassettePlayer()) {
 			cassetteMenu(*player);
+		}
+	}
+
+	if (wavegameMediaInfo.show) {
+		if (motherBoard->findMediaProvider(WAVEGAME_MEDIA)) {
+			wavegameMenu();
 		}
 	}
 }
@@ -1623,6 +1656,45 @@ void ImGuiMedia::cassetteMenu(CassettePlayer& cassettePlayer)
 	});
 }
 
+void ImGuiMedia::wavegameMenu()
+{
+	ImGui::SetNextWindowSize(gl::vec2{40, 14} * ImGui::GetFontSize(), ImGuiCond_FirstUseEver);
+	auto& info = wavegameMediaInfo;
+	auto& group = info.group;
+	im::Window("Wave Game", &info.show, [&]{
+		auto cmdResult = manager.execute(TclObject(WAVEGAME_MEDIA));
+		std::string current;
+		if (cmdResult) {
+			auto s = cmdResult->getString();
+			if (!s.empty() && s != "empty") current = std::string(s);
+		}
+
+		ImGui::TextUnformatted("Current samples directory"sv);
+		im::Indent([&]{
+			if (current.empty()) {
+				ImGui::TextUnformatted("No directory selected"sv);
+			} else {
+				ImGui::TextUnformatted("Directory:"sv);
+				ImGui::SameLine();
+				ImGui::TextUnformatted(ImGui::leftClip(current, ImGui::GetContentRegionAvail().x));
+			}
+			im::Disabled(current.empty(), [&]{
+				if (ImGui::Button("Eject")) {
+					manager.executeDelayed(makeTclList(WAVEGAME_MEDIA, "eject"));
+				}
+			});
+		});
+
+		im::Child("select", {0, -ImGui::GetFrameHeightWithSpacing()}, [&]{
+			ImGui::SeparatorText("Select new samples directory");
+			im::Indent([&]{
+				selectDirectory(group, "Select Wave Game samples folder", current, {});
+			});
+		});
+		insertMediaButton(WAVEGAME_MEDIA, group, &info.show);
+	});
+}
+
 void ImGuiMedia::insertMedia(std::string_view mediaName, const MediaItem& item, bool delayed)
 {
 	TclObject cmd = makeTclList(mediaName);
@@ -1676,6 +1748,8 @@ void ImGuiMedia::addRecent(const TclObject& cmd)
 			}
 		} else if (mediaName == "cassetteplayer") {
 			return &cassetteMediaInfo.group;
+		} else if (mediaName == WAVEGAME_MEDIA) {
+			return &wavegameMediaInfo.group;
 		} else if (mediaName == "laserdiscplayer") {
 			return &laserdiscMediaInfo;
 		} else if (mediaName == "ext") {

--- a/src/imgui/ImGuiMedia.hh
+++ b/src/imgui/ImGuiMedia.hh
@@ -117,6 +117,10 @@ public:
 		ItemGroup group;
 		bool show = false;
 	};
+	struct WaveGameMediaInfo {
+		ItemGroup group;
+		bool show = false;
+	};
 
 public:
 	bool resetOnCartChanges = true;
@@ -145,6 +149,7 @@ private:
 	void diskMenu(int i);
 	void cartridgeMenu(int cartNum);
 	void cassetteMenu(CassettePlayer& cassettePlayer);
+	void wavegameMenu();
 	void insertMedia(std::string_view mediaName, const MediaItem& item, bool delayed = true);
 	void paintCurrent(const TclObject& current, std::string_view type);
 	void paintRecent(std::string_view mediaName, ItemGroup& group,
@@ -160,6 +165,7 @@ private:
 	std::array<CartridgeMediaInfo, CartridgeSlotManager::MAX_SLOTS> cartridgeMediaInfo;
 	ItemGroup extensionMediaInfo;
 	CassetteMediaInfo cassetteMediaInfo;
+	WaveGameMediaInfo wavegameMediaInfo;
 	std::array<ItemGroup, HD::MAX_HD> hdMediaInfo;
 	std::array<ItemGroup, IDECDROM::MAX_CD> cdMediaInfo;
 	ItemGroup laserdiscMediaInfo;

--- a/src/meson.build
+++ b/src/meson.build
@@ -405,6 +405,8 @@ sources = files(
     'sound/VLM5030.cc',
     'sound/WavAudioInput.cc',
     'sound/WavWriter.cc',
+    'sound/WaveGame.cc',
+    'sound/WaveGameCommand.cc',
     'sound/Y8950.cc',
     'sound/Y8950Adpcm.cc',
     'sound/Y8950KeyboardConnector.cc',

--- a/src/sound/WavData.hh
+++ b/src/sound/WavData.hh
@@ -36,6 +36,8 @@ public:
 	explicit WavData(File file, Filter filter = {});
 
 	[[nodiscard]] unsigned getFreq() const { return freq; }
+	[[nodiscard]] unsigned getChannels() const { return channels; }
+	[[nodiscard]] unsigned getBits() const { return bits; }
 	[[nodiscard]] size_t getSize() const { return buffer.size(); }
 	[[nodiscard]] int16_t getSample(size_t pos) const {
 		return (pos < buffer.size()) ? buffer[pos] : int16_t(0);
@@ -48,6 +50,8 @@ private:
 private:
 	MemBuffer<int16_t> buffer;
 	unsigned freq = 0;
+	unsigned channels = 0;
+	unsigned bits = 0;
 };
 
 ////
@@ -85,12 +89,15 @@ inline WavData::WavData(File file, Filter filter)
 	    (std::string_view{header->fmtID.data(),    4} != "fmt ")) {
 		throw MSXException("Invalid WAV file.");
 	}
-	unsigned bits = header->wBitsPerSample;
+	bits = header->wBitsPerSample;
 	if ((header->wFormatTag != 1) || (bits != one_of(8u, 16u))) {
 		throw MSXException("WAV format unsupported, must be 8 or 16 bit PCM.");
 	}
 	freq = header->dwSamplesPerSec;
-	unsigned channels = header->wChannels;
+	channels = header->wChannels;
+	if (channels == 0) {
+		throw MSXException("Invalid WAV file.");
+	}
 
 	// Skip any extra format bytes
 	size_t pos = 20 + header->fmtSize;

--- a/src/sound/WaveGame.cc
+++ b/src/sound/WaveGame.cc
@@ -1,0 +1,604 @@
+#include "WaveGame.hh"
+
+#include "WaveGameCommand.hh"
+
+#include "DeviceConfig.hh"
+#include "EmuDuration.hh"
+#include "EmuTime.hh"
+#include "FileOperations.hh"
+#include "MSXCliComm.hh"
+#include "MSXCPUInterface.hh"
+#include "MSXException.hh"
+#include "TclObject.hh"
+#include "XMLElement.hh"
+#include "serialize.hh"
+#include "serialize_stl.hh"
+
+#include "narrow.hh"
+#include "strCat.hh"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <fstream>
+#include <optional>
+
+namespace openmsx {
+
+static constexpr uint16_t FIRMWARE_BYTE_ADDR = 0xF91E;
+
+// The Pico hardware runs at 48 kHz mono 16-bit PCM. Non-conforming
+// files are rejected at load.
+static constexpr unsigned INPUT_RATE = 48'000;
+static constexpr unsigned INPUT_CHANNELS = 1;
+static constexpr unsigned INPUT_BITS = 16;
+
+// Delay before (re-)writing the BIOS work-RAM firmware byte. We must
+// wait until the MSX BIOS has finished initialising its work-RAM
+// (otherwise BIOS will clobber our value). One second is a comfortable
+// margin on all supported machines.
+static constexpr auto FIRMWARE_BYTE_DELAY = EmuDuration::sec(1);
+
+// 1 second fade-in used by the v2.07+ "continue previous" command and
+// the implicit fade applied to the bare "stop" opcode on new firmware.
+static constexpr double CONTINUE_FADE_SECONDS = 1.0;
+
+// Firmware revision values written into 0xF91E.
+static constexpr byte FW_V207_PLUS = 1;
+
+static constexpr static_string_view DESCRIPTION =
+	"MSX Pico Wave Game audio cartridge, plays WAV files on I/O port 0x92.";
+
+static constexpr std::string_view MEDIA_PROVIDER_NAME = "wavegame";
+
+// NN.wav / NN.cfg filename for song index [0, 64).
+[[nodiscard]] static std::string songFilename(unsigned idx, std::string_view ext)
+{
+	return strCat((idx < 10) ? "0" : "", idx, ext);
+}
+
+[[nodiscard]] static byte getFirmwareValue(const DeviceConfig& config)
+{
+	auto firmware = config.getChildDataAsInt("firmware", FW_V207_PLUS);
+	if (firmware != 0 && firmware != FW_V207_PLUS) {
+		throw MSXException("Wave Game firmware value must be 0 or 1.");
+	}
+	return byte(firmware);
+}
+
+WaveGame::WaveGame(const DeviceConfig& config)
+	: MSXDevice(config)
+	, ResampledSoundDevice(
+		config.getMotherBoard(), MEDIA_PROVIDER_NAME, DESCRIPTION,
+		/*numChannels=*/1, INPUT_RATE, /*stereo=*/false)
+	, syncFirmwareByte(config.getMotherBoard().getScheduler())
+	, motherBoard(config.getMotherBoard())
+	, firmwareValue(getFirmwareValue(config))
+{
+	registerSound(config);
+
+	motherBoard.registerMediaProvider(MEDIA_PROVIDER_NAME, *this);
+	motherBoard.getMSXCliComm().update(
+		CliComm::UpdateType::HARDWARE, MEDIA_PROVIDER_NAME, "add");
+
+	command = std::make_unique<WaveGameCommand>(
+		*this,
+		motherBoard.getCommandController(),
+		motherBoard.getStateChangeDistributor(),
+		motherBoard.getScheduler());
+}
+
+WaveGame::~WaveGame()
+{
+	syncFirmwareByte.removeSyncPoints();
+	motherBoard.unregisterMediaProvider(*this);
+	motherBoard.getMSXCliComm().update(
+		CliComm::UpdateType::HARDWARE, MEDIA_PROVIDER_NAME, "remove");
+	unregisterSound();
+}
+
+void WaveGame::reset(EmuTime time)
+{
+	stopPlayback();
+	expectQueueByte = false;
+	hasQueued = false;
+	queuedCmd = 0;
+	paused = false;
+	lastSong = NO_SONG;
+	lastPos = 0;
+	lastLooping = false;
+	scheduleFirmwareByte(time);
+}
+
+void WaveGame::powerUp(EmuTime time)
+{
+	reset(time);
+}
+
+void WaveGame::writeIO(uint16_t /*port*/, byte value, EmuTime /*time*/)
+{
+	// 0xD0 (v2.07+) stashes the *next* write for deferred execution. The
+	// latched byte is not itself interpreted further - it just arms the
+	// latch.
+	if (expectQueueByte) {
+		expectQueueByte = false;
+		if (current == NO_SONG) {
+			handleCommand(value);
+		} else {
+			queuedCmd = value;
+			hasQueued = true;
+		}
+		return;
+	}
+	handleCommand(value);
+}
+
+void WaveGame::handleCommand(byte value)
+{
+	const bool v207plus = firmwareValue >= FW_V207_PLUS;
+
+	// 00000000 - stop music
+	if (value == 0x00) {
+		if (v207plus) {
+			startFadeOut(CONTINUE_FADE_SECONDS);
+		} else {
+			stopPlayback();
+		}
+		return;
+	}
+	// 0000xxxx - fade out in xxxx seconds
+	if ((value & 0xF0) == 0x00) {
+		startFadeOut(double(value & 0x0F));
+		return;
+	}
+	// 01xxxxxx - play song xxxxxx once
+	if ((value & 0xC0) == 0x40) {
+		rememberLastPlayback();
+		playSong(value & 0x3F, /*loop=*/false);
+		return;
+	}
+	// 10xxxxxx - play song xxxxxx in a loop
+	if ((value & 0xC0) == 0x80) {
+		rememberLastPlayback();
+		playSong(value & 0x3F, /*loop=*/true);
+		return;
+	}
+	// 11xxxxxx - firmware-specific
+	if (!v207plus) {
+		// v1.49 .. v2.06: any 11xxxxxx toggles pause
+		paused = !paused;
+		return;
+	}
+	switch (value) {
+	case 0xC0: // toggle pause
+		paused = !paused;
+		break;
+	case 0xD0: // queue next command
+		expectQueueByte = true;
+		break;
+	case 0xE0: // continue previous song with 1s fade-in
+		continuePreviousSong();
+		break;
+	case 0xF0: // play pause.wav once
+		playPauseWav();
+		break;
+	default:
+		// Unknown 11xxxxxx opcode on new firmware: ignore, just as the
+		// real Pico does.
+		break;
+	}
+}
+
+void WaveGame::scheduleFirmwareByte(EmuTime time)
+{
+	syncFirmwareByte.removeSyncPoints();
+	syncFirmwareByte.setSyncPoint(time + FIRMWARE_BYTE_DELAY);
+}
+
+void WaveGame::writeFirmwareByte(EmuTime time)
+{
+	// BIOS work RAM is in page 3, which is normally mapped to main RAM.
+	// If that happens not to be the case at this instant, the write is
+	// silently absorbed by whatever device is mapped there, which is
+	// also what a real Pico cart would experience.
+	getCPUInterface().writeMem(FIRMWARE_BYTE_ADDR, firmwareValue, time);
+}
+
+const WaveGame::Song* WaveGame::currentSong() const
+{
+	if (current == PAUSE_WAV_SONG) {
+		return pauseWavSong.valid ? &pauseWavSong : nullptr;
+	}
+	if (current < songs.size() && songs[current].valid) {
+		return &songs[current];
+	}
+	return nullptr;
+}
+
+float WaveGame::getAmplificationFactorImpl() const
+{
+	// The default amp factor (1/32768) scales an int16 sample to [-1, 1].
+	// The PSG uses amp = 1.0 on already-normalized floats, which is why at
+	// matching XML volumes the PSG is noticeably louder. Pre-multiplying
+	// by 3 gives WAV playback comparable headroom without forcing users
+	// to crank master + device sliders all the way up; the slider range
+	// then stays useful (full-scale music stops clipping below ~70%).
+	return 3.0f / 32768.0f;
+}
+
+void WaveGame::generateChannels(std::span<float*> bufs, unsigned num)
+{
+	assert(bufs.size() == 1);
+	const auto* song = currentSong();
+	if (!song || paused) {
+		bufs[0] = nullptr;
+		return;
+	}
+	const auto& wav = wavs[song->wavIdx];
+	for (unsigned i = 0; i < num; ++i) {
+		if (playPos >= song->endSample) {
+			if (looping && song->hasLoop) {
+				playPos = song->loopSample;
+			} else {
+				// Reached natural end of this song.
+				current = NO_SONG;
+				fadeGain = 1.0f;
+				fadeStep = 0.0f;
+				if (hasQueued) {
+					byte cmd = queuedCmd;
+					hasQueued = false;
+					queuedCmd = 0;
+					handleCommand(cmd);
+				}
+				// The queued command (if any) will start from the next
+				// buffer. This introduces at most one buffer of silence,
+				// which is below audible threshold.
+				while (i < num) bufs[0][i++] = 0.0f;
+				return;
+			}
+		}
+		auto sample = narrow<float>(wav.getSample(playPos++)) * fadeGain;
+		bufs[0][i] = sample;
+
+		if (fadeStep != 0.0f) {
+			fadeGain += fadeStep;
+			if (fadeStep < 0.0f && fadeGain <= 0.0f) {
+				// Fade-out complete.
+				fadeGain = 1.0f;
+				fadeStep = 0.0f;
+				current = NO_SONG;
+				// Also check the queue here - some titles fade-then-queue.
+				if (hasQueued) {
+					byte cmd = queuedCmd;
+					hasQueued = false;
+					queuedCmd = 0;
+					handleCommand(cmd);
+				}
+				while (++i < num) bufs[0][i] = 0.0f;
+				return;
+			}
+			if (fadeStep > 0.0f && fadeGain >= 1.0f) {
+				// Fade-in complete.
+				fadeGain = 1.0f;
+				fadeStep = 0.0f;
+			}
+		}
+	}
+}
+
+void WaveGame::resetSongs()
+{
+	wavs.clear();
+	for (auto& s : songs) s = Song{};
+	pauseWavSong = Song{};
+}
+
+void WaveGame::rememberLastPlayback()
+{
+	// Only regular songs are eligible for "continue previous" - the
+	// pause.wav jingle is explicitly excluded.
+	if (current < songs.size() && songs[current].valid) {
+		lastSong = current;
+		lastPos = playPos;
+		lastLooping = looping;
+	}
+}
+
+void WaveGame::playSong(unsigned idx, bool loop)
+{
+	if (idx >= songs.size() || !songs[idx].valid) {
+		// Real cart is silent for missing slots.
+		current = NO_SONG;
+		playPos = 0;
+		looping = false;
+		fadeGain = 1.0f;
+		fadeStep = 0.0f;
+		return;
+	}
+	current = idx;
+	playPos = songs[idx].startSample;
+	looping = loop;
+	paused = false;
+	fadeGain = 1.0f;
+	fadeStep = 0.0f;
+}
+
+void WaveGame::playPauseWav()
+{
+	if (!pauseWavSong.valid) return;
+	rememberLastPlayback();
+	current = PAUSE_WAV_SONG;
+	playPos = pauseWavSong.startSample;
+	looping = false;
+	paused = false;
+	fadeGain = 1.0f;
+	fadeStep = 0.0f;
+}
+
+void WaveGame::continuePreviousSong()
+{
+	if (lastSong >= songs.size() || !songs[lastSong].valid) return;
+	current = lastSong;
+	playPos = lastPos;
+	looping = lastLooping;
+	paused = false;
+	fadeGain = 0.0f;
+	fadeStep = 1.0f / float(CONTINUE_FADE_SECONDS * INPUT_RATE);
+}
+
+void WaveGame::stopPlayback()
+{
+	current = NO_SONG;
+	playPos = 0;
+	looping = false;
+	paused = false;
+	fadeGain = 1.0f;
+	fadeStep = 0.0f;
+}
+
+void WaveGame::startFadeOut(double seconds)
+{
+	if (seconds <= 0.0 || current == NO_SONG) {
+		stopPlayback();
+		return;
+	}
+	// Preserve current playback state; the fade runs in generateChannels.
+	fadeGain = std::max(fadeGain, 0.0f);
+	fadeStep = -1.0f / float(seconds * INPUT_RATE);
+}
+
+// Parse a per-song NN.cfg. Format:
+//   line 1: loop offset     (sample count)
+//   line 2: start offset    (sample count, optional)
+// Returns true iff at least the loop offset was read. `startOff` is
+// left at 0 if only one line is present.
+[[nodiscard]] static bool parseCfg(const std::string& path,
+                                   size_t& loopOff, size_t& startOff)
+{
+	std::ifstream ifs(path);
+	if (!ifs) return false;
+	long long tmp = 0;
+	if (!(ifs >> tmp)) return false;
+	loopOff = (tmp < 0) ? 0 : size_t(tmp);
+	if (ifs >> tmp) {
+		startOff = (tmp < 0) ? 0 : size_t(tmp);
+	} else {
+		startOff = 0;
+	}
+	return true;
+}
+
+// Parse multi.cfg. Format:
+//   line 1: loop offset (sample count, absolute within multi.wav)
+//   line 2+: start offset for song 0, 1, 2, ...
+// Absent or unreadable files leave `loopOff` at 0 and `starts` empty,
+// which matches the Pico's behaviour for a multi.wav without cfg.
+static bool parseMultiCfg(const std::string& path,
+                          size_t& loopOff,
+                          std::vector<size_t>& starts)
+{
+	std::ifstream ifs(path);
+	if (!ifs) return false;
+	long long tmp = 0;
+	if (!(ifs >> tmp)) return false;
+	loopOff = (tmp < 0) ? 0 : size_t(tmp);
+	while (ifs >> tmp) {
+		starts.push_back((tmp < 0) ? 0 : size_t(tmp));
+	}
+	return true;
+}
+
+static bool isValidWaveGameWav(const WavData& wav)
+{
+	return (wav.getFreq() == INPUT_RATE) &&
+	       (wav.getChannels() == INPUT_CHANNELS) &&
+	       (wav.getBits() == INPUT_BITS);
+}
+
+static void printInvalidWavWarning(MSXCliComm& cli, std::string_view filename, const WavData& wav)
+{
+	cli.printWarning(
+		"Wave Game: ", filename, " is ",
+		wav.getFreq(), " Hz, ", wav.getChannels(), " channel(s), ",
+		wav.getBits(), "-bit; expected ",
+		INPUT_RATE, " Hz, mono, 16-bit, skipping.");
+}
+
+void WaveGame::loadSongsFrom(const std::string& dir)
+{
+	stopPlayback();
+	resetSongs();
+
+	auto& cli = motherBoard.getMSXCliComm();
+
+	// pause.wav (optional; v2.07+ plays it on 0xF0).
+	{
+		auto path = FileOperations::join(dir, "pause.wav");
+		if (FileOperations::isRegularFile(path)) {
+			try {
+				WavData w(path);
+				if (!isValidWaveGameWav(w)) {
+					printInvalidWavWarning(cli, "pause.wav", w);
+				} else {
+					size_t sz = w.getSize();
+					wavs.push_back(std::move(w));
+					pauseWavSong = Song{
+						.wavIdx      = wavs.size() - 1,
+						.startSample = 0,
+						.endSample   = sz,
+						.loopSample  = 0,
+						.hasLoop     = false,
+						.valid       = true,
+					};
+				}
+			} catch (const MSXException& e) {
+				cli.printWarning(
+					"Wave Game: pause.wav load failed: ",
+					e.getMessage());
+			}
+		}
+	}
+
+	// Try multi.wav + multi.cfg so its indices can fill gaps between
+	// individual NN.wav files.
+	std::optional<size_t> multiIdx;
+	size_t multiLoop = 0;
+	std::vector<size_t> multiStarts;
+	{
+		auto mwav = FileOperations::join(dir, "multi.wav");
+		if (FileOperations::isRegularFile(mwav)) {
+			try {
+				WavData w(mwav);
+				if (!isValidWaveGameWav(w)) {
+					printInvalidWavWarning(cli, "multi.wav", w);
+				} else {
+					auto mcfg = FileOperations::join(dir, "multi.cfg");
+					parseMultiCfg(mcfg, multiLoop, multiStarts);
+					wavs.push_back(std::move(w));
+					multiIdx = wavs.size() - 1;
+				}
+			} catch (const MSXException& e) {
+				cli.printWarning(
+					"Wave Game: multi.wav load failed: ",
+					e.getMessage());
+			}
+		}
+	}
+
+	// Individual NN.wav.
+	for (unsigned i = 0; i < NUM_SONGS; ++i) {
+		auto path = FileOperations::join(dir, songFilename(i, ".wav"));
+		if (!FileOperations::isRegularFile(path)) continue;
+		try {
+			WavData w(path);
+			auto filename = songFilename(i, ".wav");
+			if (!isValidWaveGameWav(w)) {
+				printInvalidWavWarning(cli, filename, w);
+				continue;
+			}
+			size_t sz = w.getSize();
+
+			auto cfgPath = FileOperations::join(dir, songFilename(i, ".cfg"));
+			size_t loopOff = 0;
+			size_t startOff = 0;
+			bool hasLoop = parseCfg(cfgPath, loopOff, startOff);
+			loopOff  = std::min(loopOff,  sz);
+			startOff = std::min(startOff, sz);
+
+			wavs.push_back(std::move(w));
+			songs[i] = Song{
+				.wavIdx      = wavs.size() - 1,
+				.startSample = startOff,
+				.endSample   = sz,
+				.loopSample  = loopOff,
+				.hasLoop     = hasLoop,
+				.valid       = true,
+			};
+		} catch (const MSXException& e) {
+			cli.printWarning(
+				"Wave Game: ", songFilename(i, ".wav"),
+				" load failed: ", e.getMessage());
+		}
+	}
+
+	// Fill remaining slots from multi.wav using multi.cfg offsets.
+	if (multiIdx) {
+		const size_t mSize = wavs[*multiIdx].getSize();
+		for (unsigned i = 0; i < NUM_SONGS; ++i) {
+			if (songs[i].valid) continue;
+			if (i >= multiStarts.size()) break;
+			size_t start = std::min(multiStarts[i], mSize);
+			size_t end   = (i + 1 < multiStarts.size())
+			             ? std::min(multiStarts[i + 1], mSize)
+			             : mSize;
+			if (start >= end) continue;
+			songs[i] = Song{
+				.wavIdx      = *multiIdx,
+				.startSample = start,
+				.endSample   = end,
+				.loopSample  = std::min(multiLoop, mSize),
+				.hasLoop     = multiLoop != 0,
+				.valid       = true,
+			};
+		}
+	}
+}
+
+void WaveGame::getMediaInfo(TclObject& result)
+{
+	result.addDictKeyValues("target", currentDir,
+	                        "type", "directory");
+}
+
+void WaveGame::setMedia(const TclObject& info, EmuTime /*time*/)
+{
+	auto target = info.getOptionalDictValue(TclObject("target"));
+	if (!target) return;
+	auto trgt = target->getString();
+	if (trgt.empty()) {
+		eject();
+	} else {
+		setSamplesDir(std::string(trgt));
+	}
+}
+
+void WaveGame::setSamplesDir(const std::string& dir)
+{
+	currentDir = dir;
+	loadSongsFrom(dir);
+}
+
+void WaveGame::eject()
+{
+	currentDir.clear();
+	stopPlayback();
+	resetSongs();
+}
+
+template<typename Archive>
+void WaveGame::serialize(Archive& ar, unsigned /*version*/)
+{
+	ar.template serializeBase<MSXDevice>(*this);
+	ar.serialize("currentDir", currentDir);
+	if constexpr (Archive::IS_LOADER) {
+		if (!currentDir.empty()) {
+			loadSongsFrom(currentDir);
+		}
+	}
+	ar.serialize("current",         current,
+	             "playPos",         playPos,
+	             "looping",         looping,
+	             "paused",          paused,
+	             "fadeGain",        fadeGain,
+	             "fadeStep",        fadeStep,
+	             "expectQueueByte", expectQueueByte,
+	             "hasQueued",       hasQueued,
+	             "queuedCmd",       queuedCmd,
+	             "lastSong",        lastSong,
+	             "lastPos",         lastPos,
+	             "lastLooping",     lastLooping);
+}
+INSTANTIATE_SERIALIZE_METHODS(WaveGame);
+REGISTER_MSXDEVICE(WaveGame, "WaveGame");
+
+} // namespace openmsx

--- a/src/sound/WaveGame.hh
+++ b/src/sound/WaveGame.hh
@@ -1,0 +1,151 @@
+#ifndef WAVEGAME_HH
+#define WAVEGAME_HH
+
+#include "MSXDevice.hh"
+#include "MSXMotherBoard.hh"
+#include "ResampledSoundDevice.hh"
+#include "Schedulable.hh"
+#include "WavData.hh"
+
+#include "outer.hh"
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace openmsx {
+
+class WaveGameCommand;
+
+// Emulation of the MSX Pico "Wave Game" audio cartridge.
+//
+// The real cartridge plays 48 kHz mono 16-bit PCM WAV files from an SD
+// card in response to byte commands written to I/O port 0x92. Songs are
+// named NN.wav (two-digit decimal, 00..63), with optional NN.cfg files
+// giving loop and start offsets in sample counts. A 'multi.wav' +
+// 'multi.cfg' pair is consulted as a fallback for song slots not backed
+// by an individual NN.wav. A firmware byte at BIOS work-RAM address
+// 0xF91E lets games probe the cartridge revision
+// (0 = v1.49 .. v2.06, 1 = v2.07+).
+//
+// Port 0x92 protocol, as documented by the Pico firmware README:
+//   00000000       stop music (instant on v1.49-2.06; 1s fade on v2.07+)
+//   0000xxxx       fade out over xxxx seconds
+//   01xxxxxx       play song xxxxxx once
+//   10xxxxxx       play song xxxxxx in a loop
+//   11xxxxxx       (v1.49-2.06) toggle pause, low bits ignored
+//   11000000       (v2.07+)     toggle pause
+//   11010000       (v2.07+)     store next command, execute after current
+//                                song ends
+//   11100000       (v2.07+)     continue previous song with 1s fade-in
+//   11110000       (v2.07+)     play pause.wav once
+class WaveGame final : public MSXDevice
+                     , public ResampledSoundDevice
+                     , public MediaProvider
+{
+public:
+	static constexpr unsigned NUM_SONGS = 64; // 6-bit song index
+	static constexpr unsigned NO_SONG = unsigned(-1);
+	// Reserved index used internally for the pause.wav slot.
+	static constexpr unsigned PAUSE_WAV_SONG = NUM_SONGS;
+
+	explicit WaveGame(const DeviceConfig& config);
+	~WaveGame() override;
+
+	// MSXDevice
+	void reset(EmuTime time) override;
+	void powerUp(EmuTime time) override;
+	void writeIO(uint16_t port, byte value, EmuTime time) override;
+
+	// MediaProvider
+	void getMediaInfo(TclObject& result) override;
+	void setMedia(const TclObject& info, EmuTime time) override;
+
+	// Used by WaveGameCommand.
+	void setSamplesDir(const std::string& dir);
+	void eject();
+	[[nodiscard]] const std::string& getSamplesDir() const { return currentDir; }
+
+	template<typename Archive>
+	void serialize(Archive& ar, unsigned version);
+
+private:
+	struct Song {
+		size_t wavIdx     = 0;    // index into `wavs`
+		size_t startSample = 0;   // first sample of this song in the WAV
+		size_t endSample   = 0;   // one past last sample (exclusive)
+		size_t loopSample  = 0;   // absolute position within the WAV to loop back to
+		bool   hasLoop     = false;
+		bool   valid       = false;
+	};
+
+	// SoundDevice
+	void generateChannels(std::span<float*> bufs, unsigned num) override;
+	[[nodiscard]] float getAmplificationFactorImpl() const override;
+
+	void loadSongsFrom(const std::string& dir);
+	void resetSongs();
+
+	void handleCommand(byte value);
+	void playSong(unsigned idx, bool loop);
+	void playPauseWav();
+	void continuePreviousSong();
+	void stopPlayback();
+	void startFadeOut(double seconds);
+	void rememberLastPlayback();
+
+	[[nodiscard]] const Song* currentSong() const;
+
+	void writeFirmwareByte(EmuTime time);
+	void scheduleFirmwareByte(EmuTime time);
+
+	struct SyncFirmwareByte final : Schedulable {
+		friend class WaveGame;
+		explicit SyncFirmwareByte(Scheduler& s) : Schedulable(s) {}
+		void executeUntil(EmuTime time) override {
+			auto& wg = OUTER(WaveGame, syncFirmwareByte);
+			wg.writeFirmwareByte(time);
+		}
+	} syncFirmwareByte;
+
+	MSXMotherBoard& motherBoard;
+	std::string currentDir; // "" == ejected
+	const byte firmwareValue; // written to BIOS work RAM 0xF91E
+
+	std::vector<WavData> wavs;        // backing WAV buffers
+	std::array<Song, NUM_SONGS> songs{};
+
+	// pause.wav is stored outside the regular song table; see
+	// PAUSE_WAV_SONG.
+	Song pauseWavSong{};
+
+	// Playback state.
+	unsigned current = NO_SONG;   // song index (or PAUSE_WAV_SONG, or NO_SONG)
+	size_t   playPos = 0;         // absolute position inside the song's WAV
+	bool     looping = false;
+	bool     paused  = false;
+
+	// Fade. `fadeStep == 0` means no fade in progress.
+	float fadeGain = 1.0f;
+	float fadeStep = 0.0f;
+
+	// Queue. 0xD0 sets `expectQueueByte`; the next write fills `queuedCmd`
+	// and sets `hasQueued`. When the current song ends naturally, the
+	// queued byte is executed and the queue cleared.
+	bool expectQueueByte = false;
+	bool hasQueued       = false;
+	byte queuedCmd       = 0;
+
+	// Remembered state for the "continue previous" command.
+	unsigned lastSong    = NO_SONG;
+	size_t   lastPos     = 0;
+	bool     lastLooping = false;
+
+	std::unique_ptr<WaveGameCommand> command;
+};
+
+} // namespace openmsx
+
+#endif

--- a/src/sound/WaveGameCommand.cc
+++ b/src/sound/WaveGameCommand.cc
@@ -1,0 +1,83 @@
+#include "WaveGameCommand.hh"
+
+#include "WaveGame.hh"
+
+#include "CommandException.hh"
+#include "FileContext.hh"
+#include "FileOperations.hh"
+#include "Filename.hh"
+#include "TclObject.hh"
+
+#include <array>
+#include <string_view>
+
+namespace openmsx {
+
+using namespace std::literals;
+
+WaveGameCommand::WaveGameCommand(
+		WaveGame& waveGame_,
+		CommandController& commandController_,
+		StateChangeDistributor& stateChangeDistributor_,
+		Scheduler& scheduler_)
+	: RecordedCommand(commandController_, stateChangeDistributor_,
+	                  scheduler_, "wavegame")
+	, waveGame(waveGame_)
+{
+}
+
+void WaveGameCommand::execute(
+	std::span<const TclObject> tokens, TclObject& result, EmuTime /*time*/)
+{
+	if (tokens.size() == 1) {
+		const auto& dir = waveGame.getSamplesDir();
+		result = dir.empty() ? std::string_view{"empty"} : std::string_view{dir};
+
+	} else if (tokens.size() == 2 && tokens[1] == "eject") {
+		waveGame.eject();
+		result = "Wave Game directory ejected";
+
+	} else if (tokens.size() == 3 && tokens[1] == "insert") {
+		std::string dir(tokens[2].getString());
+		try {
+			dir = Filename(std::move(dir), userFileContext()).getResolved();
+			if (!FileOperations::isDirectory(dir)) {
+				throw CommandException(
+					"Wave Game expects a directory, not a file: ", dir);
+			}
+			waveGame.setSamplesDir(dir);
+			result = "Wave Game samples directory set to: ";
+			result.addListElement(dir);
+		} catch (MSXException& e) {
+			throw CommandException(std::move(e).getMessage());
+		}
+
+	} else {
+		throw SyntaxError();
+	}
+}
+
+std::string WaveGameCommand::help(std::span<const TclObject> /*tokens*/) const
+{
+	return "wavegame                : show current samples directory (or 'empty')\n"
+	       "wavegame insert <path>  : point Wave Game at a directory of NN.wav / NN.cfg files\n"
+	       "wavegame eject          : clear the samples directory\n";
+}
+
+void WaveGameCommand::tabCompletion(std::vector<std::string>& tokens) const
+{
+	if (tokens.size() == 2) {
+		static constexpr std::array cmds = {"insert"sv, "eject"sv};
+		completeFileName(tokens, userFileContext(), cmds);
+	} else if (tokens.size() == 3 && tokens[1] == "insert") {
+		completeFileName(tokens, userFileContext());
+	}
+}
+
+bool WaveGameCommand::needRecord(std::span<const TclObject> tokens) const
+{
+	// Only state-changing forms need to be recorded for replay.
+	return tokens.size() > 1;
+}
+
+} // namespace openmsx

--- a/src/sound/WaveGameCommand.hh
+++ b/src/sound/WaveGameCommand.hh
@@ -1,0 +1,33 @@
+#ifndef WAVEGAMECOMMAND_HH
+#define WAVEGAMECOMMAND_HH
+
+#include "RecordedCommand.hh"
+
+namespace openmsx {
+
+class WaveGame;
+class CommandController;
+class StateChangeDistributor;
+class Scheduler;
+
+class WaveGameCommand final : public RecordedCommand
+{
+public:
+	WaveGameCommand(WaveGame& waveGame,
+	                CommandController& commandController,
+	                StateChangeDistributor& stateChangeDistributor,
+	                Scheduler& scheduler);
+
+	void execute(std::span<const TclObject> tokens, TclObject& result,
+	             EmuTime time) override;
+	[[nodiscard]] std::string help(std::span<const TclObject> tokens) const override;
+	void tabCompletion(std::vector<std::string>& tokens) const override;
+	[[nodiscard]] bool needRecord(std::span<const TclObject> tokens) const override;
+
+private:
+	WaveGame& waveGame;
+};
+
+} // namespace openmsx
+
+#endif

--- a/src/unittest/WavData_test.cc
+++ b/src/unittest/WavData_test.cc
@@ -13,6 +13,8 @@ TEST_CASE("WavData, default constructor")
 	WavData wav;
 	CHECK(wav.getSize() == 0);
 	CHECK(wav.getFreq() == 0);
+	CHECK(wav.getChannels() == 0);
+	CHECK(wav.getBits() == 0);
 	for (auto i : xrange(10)) {
 		CHECK(wav.getSample(i) == 0);
 	}
@@ -96,6 +98,8 @@ TEST_CASE("WavData, parser")
 		WavData wav(memory_buffer_file(buffer));
 		CHECK(wav.getSize() == 0);
 		CHECK(wav.getFreq() == 44100);
+		CHECK(wav.getChannels() == 1);
+		CHECK(wav.getBits() == 16);
 	}
 }
 
@@ -113,6 +117,8 @@ TEST_CASE("WavData, content")
 		WavData wav(memory_buffer_file(buffer));
 		CHECK(wav.getSize() == 5);
 		CHECK(wav.getFreq() == 44100);
+		CHECK(wav.getChannels() == 1);
+		CHECK(wav.getBits() == 8);
 		CHECK(wav.getSample(0) == -0x8000);
 		CHECK(wav.getSample(1) == -0x3b00);
 		CHECK(wav.getSample(2) ==  0x0000);
@@ -132,6 +138,8 @@ TEST_CASE("WavData, content")
 		WavData wav(memory_buffer_file(buffer));
 		CHECK(wav.getSize() == 4);
 		CHECK(wav.getFreq() == 44100);
+		CHECK(wav.getChannels() == 1);
+		CHECK(wav.getBits() == 16);
 		CHECK(wav.getSample(0) ==  0x4523);
 		CHECK(wav.getSample(1) ==  0x7e00);
 		CHECK(wav.getSample(2) == -0x0001);
@@ -151,6 +159,8 @@ TEST_CASE("WavData, content")
 		WavData wav(memory_buffer_file(buffer));
 		CHECK(wav.getSize() == 4);
 		CHECK(wav.getFreq() == 44100);
+		CHECK(wav.getChannels() == 2);
+		CHECK(wav.getBits() == 8);
 		CHECK(wav.getSample(0) == -0x8000);
 		CHECK(wav.getSample(1) == -0x4000);
 		CHECK(wav.getSample(2) ==  0x0000);
@@ -169,6 +179,8 @@ TEST_CASE("WavData, content")
 		WavData wav(memory_buffer_file(buffer));
 		CHECK(wav.getSize() == 4);
 		CHECK(wav.getFreq() == 44100);
+		CHECK(wav.getChannels() == 2);
+		CHECK(wav.getBits() == 16);
 		CHECK(wav.getSample(0) ==  0x3412);
 		CHECK(wav.getSample(1) ==  0x7856);
 		CHECK(wav.getSample(2) == -0x4366);


### PR DESCRIPTION
- Introduce WaveGame class for MSX Pico audio cartridge emulation
- Implement command handling for audio playback via WaveGameCommand
- Add XML configuration support for loading WAV files and settings
- Register Wave Game as a media provider in the system
- Update project files to include new source files

Implements #1975 
