### PR TITLE
Add Namco mapper for A13-not-connected 16kB cartridges

### DIFF
--- a/build/msvc/openmsx.vcxproj
+++ b/build/msvc/openmsx.vcxproj
@@ -618,6 +618,7 @@
     <ClCompile Include="$(OpenMSXSrcDir)\memory\RomMatraCompilation.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\memory\RomMatraInk.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\memory\RomMSXDOS2.cc" />
+    <ClCompile Include="$(OpenMSXSrcDir)\memory\RomNamco.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\memory\RomNational.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\memory\RomNeo8.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\memory\RomNeo16.cc" />
@@ -1216,6 +1217,7 @@
     <None Include="$(OpenMSXSrcDir)\memory\RomMatraCompilation.hh" />
     <None Include="$(OpenMSXSrcDir)\memory\RomMatraInk.hh" />
     <None Include="$(OpenMSXSrcDir)\memory\RomMSXDOS2.hh" />
+    <None Include="$(OpenMSXSrcDir)\memory\RomNamco.hh" />
     <None Include="$(OpenMSXSrcDir)\memory\RomNational.hh" />
     <None Include="$(OpenMSXSrcDir)\memory\RomNeo8.hh" />
     <None Include="$(OpenMSXSrcDir)\memory\RomNeo16.hh" />

--- a/build/msvc/openmsx.vcxproj.filters
+++ b/build/msvc/openmsx.vcxproj.filters
@@ -885,6 +885,9 @@
     <ClCompile Include="$(OpenMSXSrcDir)\memory\RomMSXDOS2.cc">
       <Filter>memory</Filter>
     </ClCompile>
+    <ClCompile Include="$(OpenMSXSrcDir)\memory\RomNamco.cc">
+      <Filter>memory</Filter>
+    </ClCompile>
     <ClCompile Include="$(OpenMSXSrcDir)\memory\RomNational.cc">
       <Filter>memory</Filter>
     </ClCompile>
@@ -2422,6 +2425,9 @@
       <Filter>memory</Filter>
     </None>
     <None Include="$(OpenMSXSrcDir)\memory\RomMSXDOS2.hh">
+      <Filter>memory</Filter>
+    </None>
+    <None Include="$(OpenMSXSrcDir)\memory\RomNamco.hh">
       <Filter>memory</Filter>
     </None>
     <None Include="$(OpenMSXSrcDir)\memory\RomNational.hh">

--- a/share/softwaredb.xml
+++ b/share/softwaredb.xml
@@ -1241,6 +1241,7 @@ The Database is located at https://romdb.vampier.net/
   </software>
   <software title="Bosconian" system="MSX" company="NAMCO" year="1984" country="JP" genmsxid="321">
     <rom sha1="451cbb072011b26a7e0bc9931e67995a71f5fd6f" type="Mirrored" status="GoodMSX" />
+    <rom sha1="9ccb422713a1128586047f8e67c4133df072d094" type="Namco" />
     <rom sha1="a7b94a1b56ea642a6fc101cd653403f9322409b8" type="KonamiSCC" status="Hack" remark="In game SCC music" />
     <rom sha1="0bf7b432dc132f9a7bc74106261bca07d5f99690" type="Mirrored" />
     <rom sha1="33ad6d1bf1fb816b232ea706d149327e363c7b21" type="Mirrored" />
@@ -2506,6 +2507,7 @@ The Database is located at https://romdb.vampier.net/
   </software>
   <software title="Dig Dug" system="MSX" company="NAMCO" year="1984" country="JP" genmsxid="221">
     <rom sha1="6e2e5cff4ee4dd935fbe6684f2c54b39eca06092" type="Mirrored" status="GoodMSX" />
+    <rom sha1="2c16a5aa2b45358a7d53e8ea672fddec1757d907" type="Namco" />
     <rom sha1="54052caab2d3d145fd456eb5f0160d508532a26b" type="KonamiSCC" status="Hack" remark="SCC Version" />
     <rom sha1="e3391daab17710b3f34c70f60ac6c8bfea15b6cc" type="Mirrored" />
     <rom sha1="c1376facb3db0124f0557a95684d3059a3043fec" type="Mirrored" status="Bad" />
@@ -3531,6 +3533,7 @@ The Database is located at https://romdb.vampier.net/
   </software>
   <software title="Galaga" system="MSX" company="NAMCO" year="1984" country="JP" genmsxid="141">
     <rom sha1="faa5aef23febc61a875e28eebe3aadf83e1f5ba7" type="Mirrored" status="GoodMSX" />
+    <rom sha1="9d425f222d9c3c25fe7b25fbcca6d47dffffc570" type="Namco" />
     <rom sha1="90f3696fe96e720a9309cab8b981b6f84744b60e" type="KonamiSCC" status="Hack" remark="GDX SCC Version" />
     <rom sha1="c81a30eca8cc5226855ea752a9d83181247329ea" type="Mirrored" status="Hack" />
     <rom sha1="25308ebb33fd87a7f6a8e61868d3dcde3bd622c5" type="Mirrored" />
@@ -5060,6 +5063,7 @@ The Database is located at https://romdb.vampier.net/
   </software>
   <software title="King &amp; Balloon" system="MSX" company="NAMCO" year="1984" country="JP" genmsxid="147">
     <rom sha1="ed15174dec31a29f9d41a06de3008db04af11a25" type="Mirrored" status="GoodMSX" />
+    <rom sha1="e073f6378fe5803d3ce81e55f963e5f9a7078b08" type="Namco" />
     <rom sha1="bec70fbf9b1384b6a8adc45226689f02d996b6a7" type="Mirrored" status="GoodMSX" />
     <rom sha1="d2c5497a52f5b8ababfc24fff1573622f86a69c6" />
     <rom sha1="15c82849dfc691a9cc39f874ab48243523ea6b9c" type="Mirrored" />
@@ -5965,6 +5969,7 @@ The Database is located at https://romdb.vampier.net/
     <rom sha1="e7d06c0a5c7f256c061e5b8173fdcc145d2fc4d6" type="Mirrored" status="GoodMSX" />
     <rom sha1="20ce82112ba0c50063667d61e43979ac464a3bb4" type="Mirrored" status="Bad" remark="one byte is corrupted, 06h instead of 87h at 03C5h" />
     <rom sha1="a8313b0dce35faa80b399a220f19b04333fdec1d" type="Mirrored" status="GoodMSX" />
+    <rom sha1="7a909f04458f96a5fc6463ec918621e163b5874b" type="Namco" />
     <rom sha1="43ec23bbdb3af0f5dbc6d17ea0b8d745e8833c86" type="Mirrored" />
     <rom sha1="028eb65719ea49cc97ceb6bc3143df87c10078e4" type="Mirrored" />
     <rom sha1="7df9d6786925a7218fd6808b1cad5e21f3a5a2af" type="KonamiSCC" status="Hack" remark="GDX SCC Version" />
@@ -7181,6 +7186,7 @@ The Database is located at https://romdb.vampier.net/
     <rom sha1="dfca4d006ecd1ce0164a96da79264896679159ae" type="KonamiSCC" status="Hack" remark="SCC Version" />
     <rom sha1="56febd50be4accb3eb8c73ff4ff641ea767108b3" type="Mirrored" />
     <rom sha1="a72724a79c2c50ec66046c0828934b5cad11b7c9" type="Mirrored" status="GoodMSX" />
+    <rom sha1="88b7fc4a07b5c216a418b56735d12ad989700c76" type="Namco" />
     <rom sha1="fdb9d995ecdd2eacf369c11b8833d08559957695" type="KonamiSCC" status="Hack" remark="GDX SCC Version" />
     <rom sha1="8435d825a47afabcd50e5295c36eefd5d5a421cb" type="Mirrored" status="Hack" remark="Clover Hack - MSX1 Only" />
     <rom sha1="04084dbc6cbb9f674ebbd9f07900deab995a1d97" type="Mirrored" status="Hack" remark="Clover Hack" />

--- a/src/memory/RomFactory.cc
+++ b/src/memory/RomFactory.cc
@@ -39,6 +39,7 @@
 #include "RomMatraInk.hh"
 #include "RomMitsubishiMLTS2.hh"
 #include "RomMultiRom.hh"
+#include "RomNamco.hh"
 #include "RomNational.hh"
 #include "RomNeo16.hh"
 #include "RomNeo8.hh"
@@ -308,6 +309,8 @@ std::unique_ptr<MSXDevice> create(DeviceConfig& config)
 		return std::make_unique<RomPanasonic>(config, std::move(rom));
 	case NATIONAL:
 		return std::make_unique<RomNational>(config, std::move(rom));
+	case NAMCO:
+		return std::make_unique<RomNamco>(config, std::move(rom));
 	case NEO8:
 		return std::make_unique<RomNeo8>(config, std::move(rom));
 	case NEO16:

--- a/src/memory/RomInfo.cc
+++ b/src/memory/RomInfo.cc
@@ -81,6 +81,7 @@ static constexpr auto romTypeInfoArray = [] {
 	r[NEO16]           = {0x4000, "NEO-16",          "NEO-16 mapper"};
 	r[WONDERKID]       = {0x4000, "WonderKid",       "Wonder Kid"};
 	r[KOREAN128IN1]    = {0x2000, "Korean128in1",    "Korean 128 in 1"};
+	r[NAMCO]           = {0,      "Namco",           "Namco 16kB"};
 
 	// ROM mapper types used for system ROMs in machines
 	r[PANASONIC]       = {0x2000, "Panasonic",       "Panasonic internal mapper"};

--- a/src/memory/RomNamco.cc
+++ b/src/memory/RomNamco.cc
@@ -1,0 +1,38 @@
+#include "RomNamco.hh"
+
+#include "MSXException.hh"
+
+#include "xrange.hh"
+
+namespace openmsx {
+
+RomNamco::RomNamco(const DeviceConfig& config, Rom&& rom_)
+	: Rom8kBBlocks(config, std::move(rom_))
+{
+	// Namco's MSX arcade ports (Galaga, Dig Dug, Bosconian, King &
+	// Balloon) use a 16kB ROM chip on a cartridge that ties the chip's A13
+	// line to the MSX A15 line and leaves the MSX A13/A14 lines
+	// unconnected. So MSX A15 selects which 8kB half of the chip is
+	// visible, and that half is mirrored across the whole 32kB region:
+	//   0x0000-0x7FFF -> first  8kB block
+	//   0x8000-0xFFFF -> second 8kB block
+	// As a regular cartridge this is active in pages 1+2, giving:
+	//   0x4000-0x7FFF -> block 0 (mirrored at 0x6000-0x7FFF)
+	//   0x8000-0xBFFF -> block 1 (mirrored at 0xA000-0xBFFF)
+	//
+	// Note: dumping such a cartridge through the MSX address space yields a
+	// 32kB image with each 8kB block doubled ([b0,b0,b1,b1]). Those (more
+	// common) overdumps already load correctly as the plain 'Mirrored'
+	// type; this mapper exists for the trimmed 16kB originals.
+	if (rom.size() != 0x4000) {
+		throw MSXException(rom.getName(),
+			": Namco ROM must be exactly 16kB.");
+	}
+	for (auto page : xrange(8)) {
+		setRom(page, (page < 4) ? 0 : 1);
+	}
+}
+
+REGISTER_MSXDEVICE(RomNamco, "RomNamco");
+
+} // namespace openmsx

--- a/src/memory/RomNamco.hh
+++ b/src/memory/RomNamco.hh
@@ -1,0 +1,16 @@
+#ifndef ROMNAMCO_HH
+#define ROMNAMCO_HH
+
+#include "RomBlocks.hh"
+
+namespace openmsx {
+
+class RomNamco final : public Rom8kBBlocks
+{
+public:
+	RomNamco(const DeviceConfig& config, Rom&& rom);
+};
+
+} // namespace openmsx
+
+#endif

--- a/src/memory/RomTypes.hh
+++ b/src/memory/RomTypes.hh
@@ -58,6 +58,7 @@ enum class RomType : uint8_t {
 	MSXTRA,
 	MSXWRITE,
 	MULTIROM,
+	NAMCO,
 	NATIONAL,
 	NEO8,
 	NEO16,


### PR DESCRIPTION
Several Namco MSX arcade ports (Galaga, Dig Dug, Bosconian, King & Balloon, Mappy, Pac-Man) use a 16kB ROM chip wired with the chip's A13 line tied to MSX A15 and MSX A13/A14 left unconnected, so A15 selects which 8kB block is visible and that block mirrors within each 32kB half. These carts are normally distributed as 32kB [b0,b0,b1,b1] overdumps (which happen to load correctly as 'Mirrored'); the de-overdumped 16kB original needs block 1 at 0x8000, which no existing mapper provides.

Add RomType::NAMCO and the RomNamco mapper (block 0 -> pages 0-3, block 1 -> pages 4-7), register it in RomFactory/RomInfo and the MSVC project, and add softwaredb 'Namco' entries for the six boot-verified titles.

Curiously, some overdumps are of common Mirrored type. I verified that some games have two versions, recompiled to each mirror type.