### PR TITLE
TC8566AF: don't fast-fail RECALIBRATE on a missing drive

### DIFF
--- a/src/fdc/TC8566AF.cc
+++ b/src/fdc/TC8566AF.cc
@@ -731,9 +731,16 @@ void TC8566AF::doSeek(int n)
 	};
 
 	if (currentDrive.isDummyDrive()) {
+		// No drive connected. Do NOT take a fast-fail shortcut here:
+		// real hardware keeps stepping until the 255 step-pulse limit
+		// is exhausted, with the drive-busy bit held high the whole
+		// time. Probes like FastCopy 3.0 only consult ST0 (via SENSE
+		// INTERRUPT STATUS) after observing the busy bit, so an
+		// instant completion would hide the error from them. Mark the
+		// drive as Not Ready and fall through; the regular
+		// SEEK/RECALIBRATE logic below will step the (no-op) DummyDrive
+		// and eventually set Equipment Check on RECALIBRATE.
 		status0 |= ST0_NR;
-		endSeek();
-		return;
 	}
 
 	bool direction = false; // initialize to avoid warning


### PR DESCRIPTION
  The dummy-drive shortcut in doSeek() set ST0_NR and immediately
  called endSeek(), which clears the drive-busy bit in the main
  status register. That hid the failure from any disk driver that
  follows the textbook probe pattern:

    1. write RECALIBRATE
    2. poll the main status register for a drive-busy bit
    3. if busy, issue SENSE INTERRUPT STATUS and inspect ST0

  Because the shortcut completed in zero emulated time, the busy
  bit was already cleared by the time step 2 ran. The driver never
  reached step 3, never read ST0, and never saw the NR or any
  error indication. RECALIBRATE on a non-existent drive therefore
  looked indistinguishable from success.

  FastCopy 3.0 on a single-drive Turbo-R (FS-A1GT) hit this and
  reported "Number of drives: 2", because its drive-B detection
  relies entirely on the EC bit observed via SENSE INTERRUPT
  STATUS after RECALIBRATE.

  Drop the early-return. Mark the drive Not Ready, then fall
  through into the regular RECALIBRATE path. On a DummyDrive,
  isTrack00() always returns false and step() is a no-op, so the
  loop walks down its 255-step budget, holding the drive-busy bit
  high the whole time while emulated time advances. When the
  budget is exhausted, the existing code sets ST0_EC and ends the
  seek -- the same observable behavior real hardware produces for
  an absent drive, and the sequence drivers are written to detect.

  SEEK on a dummy drive still "completes" silently (no EC), which
  matches what the TC8566AF datasheet allows when the drive does
  not acknowledge -- and drivers that care about presence use
  RECALIBRATE for that check, not SEEK.