### PR TITLE
Update Yamaha_YIS-503.xml to allow things to use the module slot

### DIFF
--- a/share/machines/Yamaha_YIS-503.xml
+++ b/share/machines/Yamaha_YIS-503.xml
@@ -72,7 +72,7 @@
     this slot to have this adapter connected... -->
     <primary external="true" slot="2"/>
 
-    <primary slot="3"/> <!-- module slot -->
+    <primary slot="3" external="true" /> <!-- module slot -->
 
   </devices>
 


### PR DESCRIPTION
The module slot was empty but since it was missing external="true" I also couldn't plug anything into it. In real life I own this machine, and frequently use it with various Yamaha modules including two different SFG-05 revisions and also SFG-01. I also use a cartridge adapter on the rear expansion port, but happily that is already implemented!