### PR TITLE
I/O port Kanji behavior of Sony HB-11 confirmed by hw test 

### DIFF
--- a/share/machines/Sony_HB-11.xml
+++ b/share/machines/Sony_HB-11.xml
@@ -31,8 +31,7 @@ VDP: TMS9118NL
       </rom>
       <io base="0xD8" num="2" type="O"/>
       <io base="0xD9" num="1" type="I"/>
-      <level_2_via>only_level_1</level_2_via> <!-- confirmed by a Hit Bit U owner with test v3.1 on 2026-07-06 -->
-
+      <level_2_via>only_level_1</level_2_via> <!-- confirmed by theNestruo with test v3.1 -->
     </Kanji>
 
     <PPI id="ppi">

--- a/share/machines/Sony_HB-11.xml
+++ b/share/machines/Sony_HB-11.xml
@@ -31,6 +31,8 @@ VDP: TMS9118NL
       </rom>
       <io base="0xD8" num="2" type="O"/>
       <io base="0xD9" num="1" type="I"/>
+      <level_2_via>only_level_1</level_2_via> <!-- confirmed by a Hit Bit U owner with test v3.1 on 2026-07-06 -->
+
     </Kanji>
 
     <PPI id="ppi">


### PR DESCRIPTION
A Sony Hit Bit U owner (theNestruo) has run v3.1 of the I/O Port Kanji/Hanja/Hangul tests on their MSX and confirms that this computer has Level 1 Kanji, completely ignores writes to the Level 2 ports, returns 0xFF on reads of the Level 2 ports without disturbing the Level 1 counter, only responds to reads on port 0xD9 (with 0xD8 returning 0xFF and not disturbing the counter), and ignores the upper two bits in writes to ports 0xD8/0xD9.

This PR tells OpenMSX explicitly to match the hardware behavior. Due to the already present kanji I/O port configuration, this was already how OpenMSX emulated this machine - but now it's explicitly described as a single-level kanji implementation and the comment mentions the owner of the machine the results are from, in case further testing/validation is needed in the future.

This is related to https://github.com/openMSX/openMSX/issues/2138