### PR TITLE
Fix shift key behavior

### DIFF
--- a/src/input/Keyboard.cc
+++ b/src/input/Keyboard.cc
@@ -158,6 +158,24 @@ static constexpr auto extractScanCodeMapping(GetMapping getMapping)
 	std::ranges::sort(result, {}, &ScanCodeMsxMapping::hostScanCode);
 	return result;
 }
+template<typename GetMapping>
+static constexpr auto extractCombinedShiftFlag(GetMapping getMapping)
+{
+	constexpr auto mapping = getMapping();
+	constexpr size_t N = count(mapping, &MsxKeyScanMapping::hostKeyCodes);
+	std::array<KeyCodeMsxMapping, N> result;
+	size_t i = 0;
+	for (const auto& m : mapping) {
+		bool lshift = false;
+		bool rshift = false;
+		for (const auto& k : m.hostKeyCodes) {
+			if (k == SDLK_LSHIFT) lshift = true;
+			if (k == SDLK_RSHIFT) rshift = true;
+			if (lshift && rshift) return true;
+		}
+	}
+	return false;
+}
 
 static constexpr auto getMSXMapping()
 {
@@ -636,14 +654,18 @@ static constexpr auto getSegaMapping()
 //   x  , x  , x  , x  , x  , x  , x  , x  , x  , x  , x  , x  , x  , x  , x  , x  , //140
 }
 
-static constexpr auto msxKeyCodeMapping    = extractKeyCodeMapping ([] { return getMSXMapping(); });
-static constexpr auto msxScanCodeMapping   = extractScanCodeMapping([] { return getMSXMapping(); });
-static constexpr auto sviKeyCodeMapping    = extractKeyCodeMapping ([] { return getSVIMapping(); });
-static constexpr auto sviScanCodeMapping   = extractScanCodeMapping([] { return getSVIMapping(); });
-static constexpr auto cvJoyKeyCodeMapping  = extractKeyCodeMapping ([] { return getCvJoyMapping(); });
-static constexpr auto cvJoyScanCodeMapping = extractScanCodeMapping([] { return getCvJoyMapping(); });
-static constexpr auto segaKeyCodeMapping   = extractKeyCodeMapping ([] { return getSegaMapping(); });
-static constexpr auto segaScanCodeMapping  = extractScanCodeMapping([] { return getSegaMapping(); });
+static constexpr auto msxKeyCodeMapping      = extractKeyCodeMapping   ([] { return getMSXMapping(); });
+static constexpr auto msxScanCodeMapping     = extractScanCodeMapping  ([] { return getMSXMapping(); });
+static constexpr auto msxCombinedShiftFlag   = extractCombinedShiftFlag([] { return getMSXMapping(); });
+static constexpr auto sviKeyCodeMapping      = extractKeyCodeMapping   ([] { return getSVIMapping(); });
+static constexpr auto sviScanCodeMapping     = extractScanCodeMapping  ([] { return getSVIMapping(); });
+static constexpr auto sviCombinedShiftFlag   = extractCombinedShiftFlag([] { return getSVIMapping(); });
+static constexpr auto cvJoyKeyCodeMapping    = extractKeyCodeMapping   ([] { return getCvJoyMapping(); });
+static constexpr auto cvJoyScanCodeMapping   = extractScanCodeMapping  ([] { return getCvJoyMapping(); });
+static constexpr auto cvJoyCombinedShiftFlag = extractCombinedShiftFlag([] { return getCvJoyMapping(); });
+static constexpr auto segaKeyCodeMapping     = extractKeyCodeMapping   ([] { return getSegaMapping(); });
+static constexpr auto segaScanCodeMapping    = extractScanCodeMapping  ([] { return getSegaMapping(); });
+static constexpr auto segaCombinedShiftFlag  = extractCombinedShiftFlag([] { return getSegaMapping(); });
 
 static constexpr array_with_enum_index<Keyboard::Matrix, std::span<const KeyCodeMsxMapping>> defaultKeyCodeMappings = {
 	msxKeyCodeMapping,
@@ -656,6 +678,12 @@ static constexpr array_with_enum_index<Keyboard::Matrix, std::span<const ScanCod
 	sviScanCodeMapping,
 	cvJoyScanCodeMapping,
 	segaScanCodeMapping,
+};
+static constexpr array_with_enum_index<Keyboard::Matrix, bool> defaultCombinedShiftFlags = {
+	msxCombinedShiftFlag,
+	sviCombinedShiftFlag,
+	cvJoyCombinedShiftFlag,
+	segaCombinedShiftFlag,
 };
 
 Keyboard::Keyboard(MSXMotherBoard& motherBoard,
@@ -672,6 +700,7 @@ Keyboard::Keyboard(MSXMotherBoard& motherBoard,
 	, stateChangeDistributor(stateChangeDistributor_)
 	, keyCodeTab (defaultKeyCodeMappings [matrix])
 	, scanCodeTab(defaultScanCodeMappings[matrix])
+	, combinedShiftFlag(defaultCombinedShiftFlags[matrix])
 	, modifierPos(modifierPosForMatrix[matrix])
 	, keyMatrixUpCmd  (commandController, stateChangeDistributor, scheduler_)
 	, keyMatrixDownCmd(commandController, stateChangeDistributor, scheduler_)
@@ -998,6 +1027,15 @@ bool Keyboard::processQueuedEvent(const Event& event, EmuTime time)
 	// KEYPAD_RETURN and KEYPAD_COMMA exist at the same physical position on the host side.
 	} else if ((key.sym.sym == SDLK_KP_ENTER) || (key.sym.sym == SDLK_KP_COMMA)) {
 		processKeypadEnterKey(time, down);
+		return false;
+	} else if (combinedShiftFlag && ((key.sym.sym == SDLK_LSHIFT) || (key.sym.sym == SDLK_RSHIFT))) {
+		if (key.sym.sym == SDLK_LSHIFT) lshift_pressed = down;
+		if (key.sym.sym == SDLK_RSHIFT) rshift_pressed = down;
+		if (down && (lshift_pressed != rshift_pressed)) {
+			processSdlKey(time, SDLKey::create(SDLK_LSHIFT,SDL_SCANCODE_LSHIFT, down, key.sym.mod));
+		} else if (!down && (lshift_pressed == rshift_pressed)) {
+			processSdlKey(time, SDLKey::create(SDLK_LSHIFT,SDL_SCANCODE_LSHIFT, down, key.sym.mod));
+		}
 		return false;
 	} else {
 		// To work around a Japanese keyboard Kanji mode bug. (Multi-character

--- a/src/input/Keyboard.hh
+++ b/src/input/Keyboard.hh
@@ -125,6 +125,7 @@ private:
 
 	std::span<const KeyCodeMsxMapping> keyCodeTab;
 	std::span<const ScanCodeMsxMapping> scanCodeTab;
+	bool combinedShiftFlag;
 
 	const array_with_enum_index<UnicodeKeymap::KeyInfo::Modifier, KeyMatrixPosition>& modifierPos;
 
@@ -285,6 +286,10 @@ private:
 	uint8_t locksOn = 0;
 
 	bool focus = true;
+
+	/** Flag for tracking the combined state (OR) of left and right Shift keys */
+	bool lshift_pressed = false;
+	bool rshift_pressed = false;
 };
 SERIALIZE_CLASS_VERSION(Keyboard, 5);
 


### PR DESCRIPTION
Fix SHIFT behavior on machines treating LSHIFT and RSHIFT as the same key.

Since this behavior is limited to the SHIFT key, I have narrowed the scope of impact compared to the previous version, making it safer.

If L+R shift is defined in the key set obtained from get***Mapping() (... excluding CvJoy), apply special behavior:
- Ignore SHIFT Down events if LSHIFT or RSHIFT is already pressed.
- Ignore SHIFT Release events if LSHIFT or RSHIFT remains pressed.

Note: Assumes fix_KEYPAD_COMMA 11ca04f is already introduced.

