### PR TITLE
Fix mouse speed scaling to resolve unnatural movement

### DIFF
--- a/src/PluggableFactory.cc
+++ b/src/PluggableFactory.cc
@@ -61,7 +61,7 @@ void PluggableFactory::createAll(PluggingController& controller,
 	controller.registerPluggable(std::make_unique<ArkanoidPad>(
 		msxEventDistributor, stateChangeDistributor));
 	controller.registerPluggable(std::make_unique<Mouse>(
-		msxEventDistributor, stateChangeDistributor));
+		msxEventDistributor, stateChangeDistributor, display));
 	controller.registerPluggable(std::make_unique<Paddle>(
 		msxEventDistributor, stateChangeDistributor));
 	controller.registerPluggable(std::make_unique<Trackball>(

--- a/src/input/Mouse.cc
+++ b/src/input/Mouse.cc
@@ -9,6 +9,9 @@
 #include "serialize.hh"
 #include "serialize_meta.hh"
 
+#include "Display.hh"
+#include "OutputSurface.hh"
+
 #include "Math.hh"
 #include "unreachable.hh"
 
@@ -19,7 +22,7 @@
 namespace openmsx {
 
 static constexpr int THRESHOLD = 2;
-static constexpr int SCALE = 2;
+static constexpr int SCALE = 2; // Magic number for old version archive, see StateChange.hh / serialize::serialize<MouseState>
 static constexpr int PHASE_XHIGH1 = 0;
 static constexpr int PHASE_XLOW1  = 1;
 static constexpr int PHASE_YHIGH1 = 2;
@@ -32,9 +35,11 @@ static constexpr int STROBE = 0x04;
 
 
 Mouse::Mouse(MSXEventDistributor& eventDistributor_,
-             StateChangeDistributor& stateChangeDistributor_)
+             StateChangeDistributor& stateChangeDistributor_,
+	         Display& display)
 	: eventDistributor(eventDistributor_)
 	, stateChangeDistributor(stateChangeDistributor_)
+	, display(display)
 	, phase(PHASE_YLOW2)
 {
 }
@@ -238,8 +243,12 @@ void Mouse::signalMSXEvent(const Event& event, EmuTime time) noexcept
 				// zero, so different direction for positive and
 				// negative values. But we get smoother output
 				// with a uniform rounding direction.
-				auto qrX = Math::div_mod_floor(e.getX() + fractionalX, SCALE);
-				auto qrY = Math::div_mod_floor(e.getY() + fractionalY, SCALE);
+				float scale= SCALE;
+				if (const auto* output = display.getOutputSurface()) {
+					scale = output->getPhysicalSize().y / 240;
+				}
+				auto qrX = Math::div_mod_floor(e.getX() + fractionalX, scale);
+				auto qrY = Math::div_mod_floor(e.getY() + fractionalY, scale);
 				fractionalX = qrX.remainder;
 				fractionalY = qrY.remainder;
 

--- a/src/input/Mouse.hh
+++ b/src/input/Mouse.hh
@@ -6,6 +6,8 @@
 #include "MSXEventListener.hh"
 #include "StateChangeListener.hh"
 #include "serialize_meta.hh"
+#include "VideoSystemChangeListener.hh"
+#include "Display.hh"
 
 namespace openmsx {
 
@@ -17,7 +19,8 @@ class Mouse final : public JoystickDevice, private MSXEventListener
 {
 public:
 	Mouse(MSXEventDistributor& eventDistributor,
-	      StateChangeDistributor& stateChangeDistributor);
+	      StateChangeDistributor& stateChangeDistributor,
+		  Display& display);
 	~Mouse() override;
 
 	template<typename Archive>
@@ -49,6 +52,8 @@ private:
 private:
 	MSXEventDistributor& eventDistributor;
 	StateChangeDistributor& stateChangeDistributor;
+	Display& display;   // Display object, used to get the display resolution
+
 	EmuTime lastTime = EmuTime::zero();
 	int phase;
 	int xRel = 0, yRel = 0;               // latched X/Y values, these are returned to the MSX


### PR DESCRIPTION
Changed the mouse speed correction from a fixed 1/2 multiplier to a ratio based on the display size and the MSX screen internal resolution (240).