### PR TITLE
hw test confirms National FS-4000 I/O port kanji behavior

### DIFF
--- a/share/machines/National_FS-4000.xml
+++ b/share/machines/National_FS-4000.xml
@@ -22,6 +22,7 @@
       </rom>
       <io base="0xD8" num="2" type="O"/>
       <io base="0xD9" num="1" type="I"/>
+      <level_2_via>only_level_1</level_2_via> <!-- checked on hardware by Jun Nishikawa using kanjitest v3.1 -->
     </Kanji>
 
     <PPI id="ppi">


### PR DESCRIPTION
National FS-4000 I/O port kanji behavior is confirmed by Jun Nishikawa using kanji test v3.1

see https://github.com/openMSX/openMSX/issues/2138#issuecomment-4997438711

this already happened to be how openMSX emulated this machine, but this makes it explicit and documents the behavior as matching test results