### PR TITLE
Add 'Recent machines' submenu to the Machine menu 

### DIFF
--- a/src/imgui/ImGuiMachine.cc
+++ b/src/imgui/ImGuiMachine.cc
@@ -152,6 +152,7 @@ void ImGuiMachine::showMenu(MSXMotherBoard* motherBoard)
 		const auto& hotKey = reactor.getHotKey();
 
 		ImGui::MenuItem("Select MSX machine...", nullptr, &showSelectMachine);
+		showRecentMachinesMenu();
 
 		auto showSetupDepthLevelSelector = [&](const std::string& displayText, const bool includeNone, SetupDepth currentDepth) {
 			static constexpr array_with_enum_index<SetupDepth, zstring_view> helpText = {
@@ -404,6 +405,34 @@ void ImGuiMachine::showMenu(MSXMotherBoard* motherBoard)
 			previewSetup.motherBoard.reset();
 		});
 	}
+}
+
+void ImGuiMachine::showRecentMachinesMenu()
+{
+	// grayed-out as long as no machine has been selected via the GUI
+	im::Menu("Recent machines", !recentMachines.empty(), [&]{
+		// don't switch machine (and thus modify 'recentMachines') while iterating over it
+		std::string selectedMachine;
+		for (auto [i, item] : enumerate(recentMachines)) {
+			auto* info = findMachineInfo(item);
+			if (!info) continue;
+			bool ok = getTestResult(*info).empty();
+			im::StyleColor(!ok, ImGuiCol_Text, getColor(imColor::ERROR), [&]{
+				if (ImGui::MenuItem(tmpStrCat(info->displayName, "##", i).c_str()) && ok) {
+					selectedMachine = info->configName;
+				}
+			});
+			if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal | ImGuiHoveredFlags_NoSharedDelay | ImGuiHoveredFlags_Stationary)) {
+				im::ItemTooltip([&]{
+					printConfigInfo(*info);
+				});
+			}
+		}
+		if (!selectedMachine.empty()) {
+			manager.executeDelayed(makeTclList("machine", selectedMachine));
+			addRecentItem(recentMachines, selectedMachine);
+		}
+	});
 }
 
 void ImGuiMachine::signalQuit()

--- a/src/imgui/ImGuiMachine.cc
+++ b/src/imgui/ImGuiMachine.cc
@@ -409,8 +409,12 @@ void ImGuiMachine::showMenu(MSXMotherBoard* motherBoard)
 
 void ImGuiMachine::showRecentMachinesMenu()
 {
-	// grayed-out as long as no machine has been selected via the GUI
-	im::Menu("Recent machines", !recentMachines.empty(), [&]{
+	// grayed-out as long as no machine has been selected via the GUI, and also
+	// when none of the remembered machines exists (anymore)
+	bool anyMachine = std::ranges::any_of(recentMachines, [&](const auto& item) {
+		return findMachineInfo(item) != nullptr;
+	});
+	im::Menu("Recent machines", anyMachine, [&]{
 		// don't switch machine (and thus modify 'recentMachines') while iterating over it
 		std::string selectedMachine;
 		for (auto [i, item] : enumerate(recentMachines)) {

--- a/src/imgui/ImGuiMachine.cc
+++ b/src/imgui/ImGuiMachine.cc
@@ -417,7 +417,7 @@ void ImGuiMachine::showRecentMachinesMenu()
 	im::Menu("Recent machines", anyMachine, [&]{
 		// don't switch machine (and thus modify 'recentMachines') while iterating over it
 		std::string selectedMachine;
-		for (auto [i, item] : enumerate(recentMachines)) {
+		for (const auto& [i, item] : enumerate(recentMachines)) {
 			auto* info = findMachineInfo(item);
 			if (!info) continue;
 			bool ok = getTestResult(*info).empty();

--- a/src/imgui/ImGuiMachine.cc
+++ b/src/imgui/ImGuiMachine.cc
@@ -1074,7 +1074,7 @@ void ImGuiMachine::paintTestHardware()
 		im::Disabled(!allMachinesTested || !allExtensionsTested, [&]{
 			if (ImGui::Button("Rerun test")) {
 				manager.media->resetExtensionInfo();
-				machineInfo.clear();
+				resetMachineInfo();
 			}
 		});
 		ImGui::Separator();
@@ -1097,6 +1097,12 @@ std::vector<ImGuiMachine::MachineInfo>& ImGuiMachine::getAllMachines()
 		machineInfo = parseAllConfigFiles<MachineInfo>(manager, "machines", {"Manufacturer"sv, "Product code"sv});
 	}
 	return machineInfo;
+}
+
+void ImGuiMachine::resetMachineInfo()
+{
+	machineInfo.clear();
+	unknownMachines.clear();
 }
 
 static void amendConfigInfo(MSXMotherBoard& mb, ImGuiMachine::MachineInfo& info)
@@ -1195,15 +1201,22 @@ bool ImGuiMachine::printConfigInfo(MachineInfo& info)
 
 ImGuiMachine::MachineInfo* ImGuiMachine::findMachineInfo(std::string_view config)
 {
-	auto& allMachines = getAllMachines();
-	auto it = std::ranges::find(allMachines, config, &MachineInfo::configName);
-	if (it == allMachines.end()) {
-		// perhaps something changed, let's refresh the cache and try again
-		machineInfo.clear();
-		allMachines = getAllMachines();
-		it = std::ranges::find(allMachines, config, &MachineInfo::configName);
-	}
-	return (it != allMachines.end()) ? std::to_address(it) : nullptr;
+	auto search = [&]() -> MachineInfo* {
+		auto& allMachines = getAllMachines();
+		auto it = std::ranges::find(allMachines, config, &MachineInfo::configName);
+		return (it != allMachines.end()) ? std::to_address(it) : nullptr;
+	};
+	if (auto* info = search()) return info;
+
+	// Not found. Perhaps something changed on disk, e.g. the user added or
+	// renamed a machine config while openMSX was running. Refresh the cache
+	// and try again. But refreshing parses all (>200) machine config files,
+	// and we're called from painting code, so don't do that over and over for
+	// a config name that really doesn't exist (compare getTestResult()).
+	if (contains(unknownMachines, config)) return nullptr;
+	unknownMachines.emplace_back(config);
+	machineInfo.clear();
+	return search();
 }
 
 } // namespace openmsx

--- a/src/imgui/ImGuiMachine.cc
+++ b/src/imgui/ImGuiMachine.cc
@@ -1078,7 +1078,7 @@ void ImGuiMachine::paintTestHardware()
 		im::Disabled(!allMachinesTested || !allExtensionsTested, [&]{
 			if (ImGui::Button("Rerun test")) {
 				manager.media->resetExtensionInfo();
-				resetMachineInfo();
+				machineInfo.clear();
 			}
 		});
 		ImGui::Separator();
@@ -1101,12 +1101,6 @@ std::vector<ImGuiMachine::MachineInfo>& ImGuiMachine::getAllMachines()
 		machineInfo = parseAllConfigFiles<MachineInfo>(manager, "machines", {"Manufacturer"sv, "Product code"sv});
 	}
 	return machineInfo;
-}
-
-void ImGuiMachine::resetMachineInfo()
-{
-	machineInfo.clear();
-	unknownMachines.clear();
 }
 
 static void amendConfigInfo(MSXMotherBoard& mb, ImGuiMachine::MachineInfo& info)
@@ -1205,20 +1199,9 @@ bool ImGuiMachine::printConfigInfo(MachineInfo& info)
 
 ImGuiMachine::MachineInfo* ImGuiMachine::findMachineInfo(std::string_view config)
 {
-	auto search = [&]() -> MachineInfo* {
-		auto& allMachines = getAllMachines();
-		auto it = std::ranges::find(allMachines, config, &MachineInfo::configName);
-		return (it != allMachines.end()) ? std::to_address(it) : nullptr;
-	};
-	if (auto* info = search()) return info;
-
-	// Not found, maybe a config was added or renamed on disk. Refresh and retry,
-	// but only once per name: refreshing parses all (>200) config files and we're
-	// called while painting (compare getTestResult()).
-	if (contains(unknownMachines, config)) return nullptr;
-	unknownMachines.emplace_back(config);
-	machineInfo.clear();
-	return search();
+	auto& allMachines = getAllMachines();
+	auto it = std::ranges::find(allMachines, config, &MachineInfo::configName);
+	return (it != allMachines.end()) ? std::to_address(it) : nullptr;
 }
 
 } // namespace openmsx

--- a/src/imgui/ImGuiMachine.cc
+++ b/src/imgui/ImGuiMachine.cc
@@ -1212,11 +1212,9 @@ ImGuiMachine::MachineInfo* ImGuiMachine::findMachineInfo(std::string_view config
 	};
 	if (auto* info = search()) return info;
 
-	// Not found. Perhaps something changed on disk, e.g. the user added or
-	// renamed a machine config while openMSX was running. Refresh the cache
-	// and try again. But refreshing parses all (>200) machine config files,
-	// and we're called from painting code, so don't do that over and over for
-	// a config name that really doesn't exist (compare getTestResult()).
+	// Not found, maybe a config was added or renamed on disk. Refresh and retry,
+	// but only once per name: refreshing parses all (>200) config files and we're
+	// called while painting (compare getTestResult()).
 	if (contains(unknownMachines, config)) return nullptr;
 	unknownMachines.emplace_back(config);
 	machineInfo.clear();

--- a/src/imgui/ImGuiMachine.hh
+++ b/src/imgui/ImGuiMachine.hh
@@ -36,6 +36,7 @@ public:
 	void signalQuit();
 
 private:
+	void showRecentMachinesMenu();
 	void paintSelectMachine(const MSXMotherBoard* motherBoard);
 	void paintTestHardware();
 	[[nodiscard]] std::vector<MachineInfo>& getAllMachines();

--- a/src/imgui/ImGuiMachine.hh
+++ b/src/imgui/ImGuiMachine.hh
@@ -40,7 +40,6 @@ private:
 	void paintSelectMachine(const MSXMotherBoard* motherBoard);
 	void paintTestHardware();
 	[[nodiscard]] std::vector<MachineInfo>& getAllMachines();
-	void resetMachineInfo();
 	[[nodiscard]] MachineInfo* findMachineInfo(std::string_view config);
 	[[nodiscard]] const std::string& getTestResult(MachineInfo& info);
 	bool printConfigInfo(MachineInfo& info);
@@ -65,7 +64,6 @@ public:
 
 private:
 	std::vector<MachineInfo> machineInfo; // sorted on displayName
-	std::vector<std::string> unknownMachines;
 	std::string newMachineConfig;
 	std::string filterType;
 	std::string filterRegion;

--- a/src/imgui/ImGuiMachine.hh
+++ b/src/imgui/ImGuiMachine.hh
@@ -40,6 +40,10 @@ private:
 	void paintSelectMachine(const MSXMotherBoard* motherBoard);
 	void paintTestHardware();
 	[[nodiscard]] std::vector<MachineInfo>& getAllMachines();
+	void resetMachineInfo();
+	/** Search the MachineInfo for the given machine config name, or nullptr if
+	  * there is no such machine. The result is only valid until the next call
+	  * to getAllMachines() or resetMachineInfo(). */
 	[[nodiscard]] MachineInfo* findMachineInfo(std::string_view config);
 	[[nodiscard]] const std::string& getTestResult(MachineInfo& info);
 	bool printConfigInfo(MachineInfo& info);
@@ -64,6 +68,9 @@ public:
 
 private:
 	std::vector<MachineInfo> machineInfo; // sorted on displayName
+	// Config names for which we already refreshed 'machineInfo' once because
+	// they were not found. That refresh is expensive, don't repeat it.
+	std::vector<std::string> unknownMachines;
 	std::string newMachineConfig;
 	std::string filterType;
 	std::string filterRegion;

--- a/src/imgui/ImGuiMachine.hh
+++ b/src/imgui/ImGuiMachine.hh
@@ -41,9 +41,6 @@ private:
 	void paintTestHardware();
 	[[nodiscard]] std::vector<MachineInfo>& getAllMachines();
 	void resetMachineInfo();
-	/** Search the MachineInfo for the given machine config name, or nullptr if
-	  * there is no such machine. The result is only valid until the next call
-	  * to getAllMachines() or resetMachineInfo(). */
 	[[nodiscard]] MachineInfo* findMachineInfo(std::string_view config);
 	[[nodiscard]] const std::string& getTestResult(MachineInfo& info);
 	bool printConfigInfo(MachineInfo& info);
@@ -68,8 +65,6 @@ public:
 
 private:
 	std::vector<MachineInfo> machineInfo; // sorted on displayName
-	// Config names for which we already refreshed 'machineInfo' once because
-	// they were not found. That refresh is expensive, don't repeat it.
 	std::vector<std::string> unknownMachines;
 	std::string newMachineConfig;
 	std::string filterType;


### PR DESCRIPTION
Switching to a recently used machine required opening the 'Select MSX machine' window first. This adds a Recent machines submenu directly below Select MSX machine..., like most applications have. Entries show the machine's display name, carry the usual config tooltip on hover, and are drawn in the error color when the machine fails its hardware test (and are then not selectable).

The existing recent-machines list inside the 'Select MSX machine' window is kept as-is, because that window is also reachable via the Quick setup editor.

The submenu is grayed out when no machine has been selected via the GUI yet, and also when none of the remembered machines still exists — the names are remembered by config name in imgui.ini and never validated, so they can all point at machines that are no longer installed, which previously left the submenu enabled but empty.

Fixes #2137.

**How the machine info is cached**

ImGuiMachine keeps a machineInfo cache: one entry per installed machine config, filled by running openmsx_info machines <config> for every config found on disk. With 200+ configs that's about 13ms, so it's built once and reused. findMachineInfo() is a plain lookup in that cache.

Previously a lookup miss wiped and refilled the whole cache, so that configs added or renamed while openMSX was running were still picked up. Since findMachineInfo() is called from painting code, one stale name in the recent list was enough to trigger that rescan every frame. As discussed in review, openMSX now simply assumes machine config files don't change while it is running, and that refresh is gone.

**Trade-off**

Machine configs added, renamed or removed while openMSX is running are not picked up until you hit Machine → Test MSX hardware → Rerun test (or restart).
