### PR TITLE
Add ASCII8-R mapper for reversed ASCII 8kB bank registers

### DIFF
--- a/share/softwaredb.xml
+++ b/share/softwaredb.xml
@@ -13493,6 +13493,7 @@ The Database is located at https://romdb.vampier.net/
     <rom sha1="6ea5bb55d3f5c242d3cd1e8af74d2078b568f5b9" type="ASCII8" status="Author" remark="Portuguese" />
   </software>
   <software title="XeGrader" system="MSX2" company="Tokihiro Naito" year="2025" country="JP">
+    <rom sha1="5b95556923d4f564cbc51ceb7a544915f0b1331f" type="ASCII8-R" status="Verified" remark="Retail cartridge v2.0.3" />
     <rom sha1="29d2509404b009497a9043319fdd8616e63a3fd1" type="ASCII8" status="Author" remark="Trail Version 2025-03-19" />
     <rom sha1="049323a69dca3af9019b4afeafbd4bf6c699065e" type="ASCII8" status="Author" remark="Trial Version - Initial Release" />
     <rom sha1="7507e08958a80f2fa58ccc46eb63d17f1618823a" type="ASCII8" status="Author" remark="Trail Version 2025-02-12" />

--- a/src/memory/RomAscii8kB.cc
+++ b/src/memory/RomAscii8kB.cc
@@ -8,6 +8,14 @@
 //  bank 2: 0x6800 - 0x6fff (0x6800 used)
 //  bank 3: 0x7000 - 0x77ff (0x7000 used)
 //  bank 4: 0x7800 - 0x7fff (0x7800 used)
+//
+// With 'reversedRegs' the same four registers exist, but they are wired to the
+// memory regions in the opposite order:
+//  0x4000 - 0x5fff: selected by 0x7800 - 0x7fff
+//  0x6000 - 0x7fff: selected by 0x7000 - 0x77ff
+//  0x8000 - 0x9fff: selected by 0x6800 - 0x6fff
+//  0xa000 - 0xbfff: selected by 0x6000 - 0x67ff
+// Used by the retail cartridge of XeGrader.
 
 #include "RomAscii8kB.hh"
 #include "serialize.hh"
@@ -15,8 +23,10 @@
 
 namespace openmsx {
 
-RomAscii8kB::RomAscii8kB(const DeviceConfig& config, Rom&& rom_)
+RomAscii8kB::RomAscii8kB(const DeviceConfig& config, Rom&& rom_,
+                         bool reversedRegs_)
 	: Rom8kBBlocks(config, std::move(rom_))
+	, reversedRegs(reversedRegs_)
 {
 	RomAscii8kB::reset(EmuTime::dummy());
 }
@@ -35,7 +45,8 @@ void RomAscii8kB::reset(EmuTime /*time*/)
 void RomAscii8kB::writeMem(uint16_t address, byte value, EmuTime /*time*/)
 {
 	if ((0x6000 <= address) && (address < 0x8000)) {
-		byte region = ((address >> 11) & 3) + 2;
+		auto reg = (address >> 11) & 3;
+		byte region = reversedRegs ? byte(5 - reg) : byte(reg + 2);
 		setRom(region, value);
 	}
 }

--- a/src/memory/RomAscii8kB.hh
+++ b/src/memory/RomAscii8kB.hh
@@ -8,11 +8,18 @@ namespace openmsx {
 class RomAscii8kB : public Rom8kBBlocks
 {
 public:
-	RomAscii8kB(const DeviceConfig& config, Rom&& rom);
+	/** @param reversedRegs when true the four bank registers map to the
+	  *   memory regions in the opposite order (see writeMem()).
+	  */
+	RomAscii8kB(const DeviceConfig& config, Rom&& rom,
+	            bool reversedRegs = false);
 
 	void reset(EmuTime time) override;
 	void writeMem(uint16_t address, byte value, EmuTime time) override;
 	[[nodiscard]] byte* getWriteCacheLine(uint16_t address) override;
+
+private:
+	const bool reversedRegs;
 };
 
 } // namespace openmsx

--- a/src/memory/RomFactory.cc
+++ b/src/memory/RomFactory.cc
@@ -257,6 +257,8 @@ std::unique_ptr<MSXDevice> create(DeviceConfig& config)
 		return std::make_unique<RomKonamiKeyboardMaster>(config, std::move(rom));
 	case ASCII8:
 		return std::make_unique<RomAscii8kB>(config, std::move(rom));
+	case ASCII8R:
+		return std::make_unique<RomAscii8kB>(config, std::move(rom), true);
 	case ASCII16:
 		return std::make_unique<RomAscii16kB>(config, std::move(rom));
 	case ASCII16X:

--- a/src/memory/RomInfo.cc
+++ b/src/memory/RomInfo.cc
@@ -24,6 +24,7 @@ static constexpr auto romTypeInfoArray = [] {
 	r[KONAMI_SCC]      = {0x2000, "KonamiSCC",       "Konami with SCC"};
 	r[KBDMASTER]       = {0x4000, "KeyboardMaster",  "Konami Keyboard Master with VLM5030"}; // officially plain 16K
 	r[ASCII8]          = {0x2000, "ASCII8",          "ASCII 8kB"};
+	r[ASCII8R]         = {0x2000, "ASCII8-R",        "ASCII 8kB with reversed bank registers"};
 	r[ASCII16]         = {0x4000, "ASCII16",         "ASCII 16kB"};
 	r[ASCII16X]        = {0x4000, "ASCII16-X",       "ASCII-X 16kB"};
 	r[R_TYPE]          = {0x4000, "R-Type",          "R-Type"};

--- a/src/memory/RomTypes.hh
+++ b/src/memory/RomTypes.hh
@@ -10,6 +10,7 @@ enum class RomType : uint8_t {
 	ARC,
 	ALALAMIAH30IN1,
 	ASCII8,
+	ASCII8R,
 	ASCII8_2,
 	ASCII8_32,
 	ASCII8_8,


### PR DESCRIPTION
The retail cartridge of XeGrader uses the regular ASCII 8kB scheme, but with the four bank registers wired to the memory regions in the opposite order:

  0x4000 - 0x5fff <- register at 0x7800 - 0x7fff
  0x6000 - 0x7fff <- register at 0x7000 - 0x77ff
  0x8000 - 0x9fff <- register at 0x6800 - 0x6fff
  0xa000 - 0xbfff <- register at 0x6000 - 0x67ff

Loading such a ROM as plain ASCII8 puts the banks in the wrong place, and no existing mapper covers this wiring, so add RomType::ASCII8R, named "ASCII8-R" in the database and the GUI.

It reuses RomAscii8kB with a new 'reversedRegs' constructor flag that mirrors the register-to-region mapping (5 - reg instead of reg + 2); reset, write cache lines and serialization are unaffected.

Also add the softwaredb entry for the dump of the retail cartridge (will also send the sha1 to the MSX ROM database)