### PR TITLE
HD: register with DiskManipulator, so SD cards and SCSI disks are usable

### DIFF
--- a/doc/manual/diskmanipulator.html
+++ b/doc/manual/diskmanipulator.html
@@ -29,10 +29,21 @@
   of this document you will find some <a class="internal" href="#examples">examples of typical use</a>.</p>
 
   <div class="note">
-    Note: For now, this command does not work with SCSI/SD disks and drives!
-    So, you cannot create valid formatted SCSI hard disk images, SD card images
-    or manipulate files on hard disks formatted for use with a SCSI interface
-    or SD cards for an SD interface.
+    Note: hard disk like media (IDE and SCSI hard disks, SD cards) are only
+    understood when they have a Sunrise IDE, Beer IDE 1.9RC1 or Nextor
+    partition table, or no partition table at all (in which case the whole
+    image is treated as a single volume). Only FAT12 and FAT16 partitions can
+    be manipulated; FAT32 partitions are not supported. Images formatted by a
+    SCSI BIOS that uses yet another partition table layout will report
+    <code>No (or invalid) partition table.</code>
+  </div>
+
+  <div class="note">
+    Note: manipulating a hard disk, SD card or CompactFlash image while the
+    emulated MSX has it mounted can corrupt the image, because the MSX side
+    does not notice the change and keeps using its cached FAT information. Use
+    <code>set power off</code> first, or do the manipulation in a separate
+    openMSX instance.
   </div>
 
   <h2>General Syntax</h2>
@@ -44,7 +55,7 @@
 
   <p><code>&lt;command&gt;</code> specifies the action to be performed. The next section lists the commands available and explains them.</p>
 
-  <p><code>&lt;disk name&gt;</code> specifies the disk to operate on. Typical values are: <code><a class="external" href="commands.html#disk">diska</a></code>, <code>diskb</code>, <code><a class="external" href="commands.html#hd">hda</a></code> or the special <code><a class="external" href="commands.html#disk">virtual_drive</a></code> device. <code>disk&lt;x&gt;</code> and <code>hd&lt;x&gt;</code> are the drives available to the running emulated MSX machine. This allows interaction with the currently used disk images.<br />
+  <p><code>&lt;disk name&gt;</code> specifies the disk to operate on. Typical values are: <code><a class="external" href="commands.html#disk">diska</a></code>, <code>diskb</code>, <code><a class="external" href="commands.html#hd">hda</a></code> or the special <code><a class="external" href="commands.html#disk">virtual_drive</a></code> device. <code>disk&lt;x&gt;</code> and <code>hd&lt;x&gt;</code> are the drives available to the running emulated MSX machine; <code>hd&lt;x&gt;</code> covers all hard disk like media, so IDE and SCSI hard disks as well as the SD cards of e.g. the MegaFlashROM SCC+ SD. This allows interaction with the currently used disk images.<br />
   In case the disk contains a Sunrise IDE, Beer IDE 1.9RC1 or Nextor compatible partition table you can add a partition number (starting at 1) to the disk name to specify on which partition the command will act. For example <code>hda2</code> is the second partition on the master IDE disk, <code>hdb3</code> is the third partition on the slave IDE disk.</p>
 
   <p><code>&lt;command arguments&gt;</code> depend upon the command involved, see the detailed descriptions of the commands below.</p>

--- a/src/ide/HD.cc
+++ b/src/ide/HD.cc
@@ -1,6 +1,7 @@
 #include "HD.hh"
 
 #include "DeviceConfig.hh"
+#include "DiskManipulator.hh"
 #include "Display.hh"
 #include "FileContext.hh"
 #include "FilePool.hh"
@@ -14,6 +15,7 @@
 
 #include "narrow.hh"
 #include "serialize.hh"
+#include "strCat.hh"
 #include "tiger.hh"
 
 #include <array>
@@ -75,11 +77,14 @@ HD::HD(const DeviceConfig& config)
 		motherBoard.getReactor().getGlobalSettings().getPowerSetting());
 
 	motherBoard.registerMediaProvider(name, *this);
+	motherBoard.getReactor().getDiskManipulator().registerDrive(
+		*this, tmpStrCat(motherBoard.getMachineID(), "::"));
 	motherBoard.getMSXCliComm().update(CliComm::UpdateType::HARDWARE, name, "add");
 }
 
 HD::~HD()
 {
+	motherBoard.getReactor().getDiskManipulator().unregisterDrive(*this);
 	motherBoard.unregisterMediaProvider(*this);
 	motherBoard.getMSXCliComm().update(CliComm::UpdateType::HARDWARE, name, "remove");
 

--- a/src/ide/IDEHD.cc
+++ b/src/ide/IDEHD.cc
@@ -1,15 +1,12 @@
 #include "IDEHD.hh"
 
 #include "DeviceConfig.hh"
-#include "DiskManipulator.hh"
 #include "MSXException.hh"
 #include "MSXMotherBoard.hh"
-#include "Reactor.hh"
 #include "serialize.hh"
 
 #include "endian.hh"
 #include "narrow.hh"
-#include "strCat.hh"
 #include "xrange.hh"
 
 #include <cassert>
@@ -19,16 +16,9 @@ namespace openmsx {
 IDEHD::IDEHD(const DeviceConfig& config)
 	: HD(config)
 	, AbstractIDEDevice(config.getMotherBoard())
-	, diskManipulator(config.getReactor().getDiskManipulator())
 	, devName(config.getChildData("name", "openMSX hard disk"))
 {
-	diskManipulator.registerDrive(
-		*this, tmpStrCat(config.getMotherBoard().getMachineID(), "::"));
-}
-
-IDEHD::~IDEHD()
-{
-	diskManipulator.unregisterDrive(*this);
+	// registration with the DiskManipulator is done in the HD base class
 }
 
 bool IDEHD::isPacketDevice()

--- a/src/ide/IDEHD.hh
+++ b/src/ide/IDEHD.hh
@@ -7,7 +7,6 @@
 namespace openmsx {
 
 class DeviceConfig;
-class DiskManipulator;
 
 class IDEHD final : public HD, public AbstractIDEDevice
 {
@@ -17,7 +16,7 @@ public:
 	IDEHD(IDEHD&&) = delete;
 	IDEHD& operator=(const IDEHD&) = delete;
 	IDEHD& operator=(IDEHD&&) = delete;
-	~IDEHD() override;
+	~IDEHD() override = default;
 
 	template<typename Archive>
 	void serialize(Archive& ar, unsigned version);
@@ -32,7 +31,6 @@ private:
 	void executeCommand(uint8_t cmd) override;
 
 private:
-	DiskManipulator& diskManipulator;
 	unsigned transferSectorNumber = 0; // avoid UMR in serialize()
 	const std::string devName;
 };


### PR DESCRIPTION
Registration lived in IDEHD, so only IDE hard disks showed up in the 'diskmanipulator' command and in the Disk Manipulator window. The SD cards of the MegaFlashROM SCC+ SD and SCSI hard disks are plain HD objects and were therefore invisible, even though HD already implements DiskContainer and the partition-table code understands Nextor. Move register/unregisterDrive() to HD and update the (now stale) note in the manual.

Fixes #1795

<img width="461" height="188" alt="image" src="https://github.com/user-attachments/assets/474bb10f-81be-4fd7-99ec-8d128b6e4ae4" />
