### PR TITLE
feat(imgui): add Slot map window to Tools

### DIFF
--- a/build/msvc/openmsx.vcxproj
+++ b/build/msvc/openmsx.vcxproj
@@ -519,6 +519,7 @@
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiRasterViewer.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiReverseBar.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiSettings.cc" />
+    <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiSlotMap.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiSoundChip.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiSpriteViewer.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiSymbols.cc" />
@@ -1122,6 +1123,7 @@
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiRasterViewer.hh" />
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiReverseBar.hh" />
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiSettings.hh" />
+    <None Include="$(OpenMSXSrcDir)\imgui\ImGuiSlotMap.hh" />
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiSoundChip.hh" />
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiSpriteViewer.hh" />
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiSymbols.hh" />

--- a/build/msvc/openmsx.vcxproj.filters
+++ b/build/msvc/openmsx.vcxproj.filters
@@ -618,6 +618,9 @@
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiSettings.cc">
       <Filter>imgui</Filter>
     </ClCompile>
+    <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiSlotMap.cc">
+      <Filter>imgui</Filter>
+    </ClCompile>
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiSoundChip.cc">
       <Filter>imgui</Filter>
     </ClCompile>
@@ -2155,6 +2158,9 @@
       <Filter>imgui</Filter>
     </None>
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiSettings.hh">
+      <Filter>imgui</Filter>
+    </None>
+    <None Include="$(OpenMSXSrcDir)\imgui\ImGuiSlotMap.hh">
       <Filter>imgui</Filter>
     </None>
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiSoundChip.hh">

--- a/src/CartridgeSlotManager.cc
+++ b/src/CartridgeSlotManager.cc
@@ -193,13 +193,9 @@ void CartridgeSlotManager::createExternalSlot(int ps, int ss)
 
 unsigned CartridgeSlotManager::getSlot(int ps, int ss) const
 {
-	for (auto slot : xrange(MAX_SLOTS)) {
-		if (slots[slot].exists() &&
-		    (slots[slot].ps == ps) && (slots[slot].ss == ss)) {
-			return slot;
-		}
-	}
-	UNREACHABLE; // was not an external slot
+	auto slot = findSlot(ps, ss, false);
+	if (!slot) UNREACHABLE; // was not an external slot
+	return *slot;
 }
 
 void CartridgeSlotManager::testRemoveExternalSlot(
@@ -351,10 +347,7 @@ void CartridgeSlotManager::freeSlot(
 
 bool CartridgeSlotManager::isExternalSlot(int ps, int ss, bool convert) const
 {
-	return std::ranges::any_of(xrange(MAX_SLOTS), [&](auto slot) {
-		int tmp = (convert && (slots[slot].ss == -1)) ? 0 : slots[slot].ss;
-		return slots[slot].exists() && (slots[slot].ps == ps) && (tmp == ss);
-	});
+	return findSlot(ps, ss, convert).has_value();
 }
 
 std::string CartridgeSlotManager::insertCartridge(

--- a/src/CartridgeSlotManager.cc
+++ b/src/CartridgeSlotManager.cc
@@ -194,7 +194,7 @@ void CartridgeSlotManager::createExternalSlot(int ps, int ss)
 unsigned CartridgeSlotManager::getSlot(int ps, int ss) const
 {
 	auto slot = findSlot(ps, ss, false);
-	if (!slot) UNREACHABLE; // was not an external slot
+	assert(slot); // was an external slot
 	return *slot;
 }
 

--- a/src/CartridgeSlotManager.hh
+++ b/src/CartridgeSlotManager.hh
@@ -76,6 +76,16 @@ public:
 		}
 		return {};
 	}
+	/** The external slot at (ps, ss), if there is one. With 'convert' a
+	  * primary slot that isn't expanded (ss == -1) also matches ss == 0. */
+	[[nodiscard]] std::optional<unsigned> findSlot(int ps, int ss, bool convert) const {
+		for (auto slot : xrange(MAX_SLOTS)) {
+			if (!slots[slot].exists()) continue;
+			int slotSs = (convert && (slots[slot].ss == -1)) ? 0 : slots[slot].ss;
+			if ((slots[slot].ps == ps) && (slotSs == ss)) return slot;
+		}
+		return {};
+	}
 
 private:
 	[[nodiscard]] const HardwareConfig* getExtensionConfig(std::string_view cartName) const;

--- a/src/cpu/MSXCPUInterface.hh
+++ b/src/cpu/MSXCPUInterface.hh
@@ -324,6 +324,8 @@ public:
 	void setFastForward(bool fastForward_) { fastForward = fastForward_; }
 	[[nodiscard]] bool isFastForward() const { return fastForward; }
 
+	/** The device in this slot and page. Never returns nullptr: a slot
+	  * without a device has the DummyDevice. */
 	[[nodiscard]] MSXDevice* getMSXDevice(int ps, int ss, int page);
 	[[nodiscard]] MSXDevice* getVisibleMSXDevice(int page) { return visibleDevices[page]; }
 

--- a/src/cpu/MSXMultiMemDevice.hh
+++ b/src/cpu/MSXMultiMemDevice.hh
@@ -30,7 +30,7 @@ public:
 	[[nodiscard]] std::vector<MSXDevice*> getDevices() const;
 
 	/** The address ranges actually in use, in no particular order.
-	  * The sentinel at the back is not included. */
+	  * The sentinel is not included. */
 	[[nodiscard]] std::span<const Range> getRanges() const {
 		return {ranges.data(), ranges.size() - 1};
 	}
@@ -48,7 +48,10 @@ private:
 	[[nodiscard]] const Range& searchRange(unsigned address) const;
 	[[nodiscard]] MSXDevice* searchDevice(unsigned address) const;
 
-	std::vector<Range> ranges; // ordered (sentinel at the back)
+	// In no particular order, except that the sentinel is at the back: it
+	// covers the whole address space, so searching front-to-back finds the
+	// real ranges first and always finds something.
+	std::vector<Range> ranges;
 };
 
 } // namespace openmsx

--- a/src/cpu/MSXMultiMemDevice.hh
+++ b/src/cpu/MSXMultiMemDevice.hh
@@ -2,12 +2,23 @@
 #define MSXMULTIMEMDEVICE_HH
 
 #include "MSXMultiDevice.hh"
+#include <span>
 #include <vector>
 
 namespace openmsx {
 
 class MSXMultiMemDevice final : public MSXMultiDevice
 {
+public:
+	struct Range {
+		Range(unsigned base_, unsigned size_, MSXDevice& device_);
+		[[nodiscard]] constexpr bool operator==(const Range&) const = default;
+
+		unsigned base;
+		unsigned size;
+		MSXDevice* device;
+	};
+
 public:
 	explicit MSXMultiMemDevice(HardwareConfig& hwConf);
 	~MSXMultiMemDevice() override;
@@ -17,6 +28,12 @@ public:
 	void remove(MSXDevice& device, unsigned base, unsigned size);
 	[[nodiscard]] bool empty() const { return ranges.size() == 1; }
 	[[nodiscard]] std::vector<MSXDevice*> getDevices() const;
+
+	/** The address ranges actually in use, in no particular order.
+	  * The sentinel at the back is not included. */
+	[[nodiscard]] std::span<const Range> getRanges() const {
+		return {ranges.data(), ranges.size() - 1};
+	}
 
 	// MSXDevice
 	[[nodiscard]] const std::string& getName() const override;
@@ -28,15 +45,6 @@ public:
 	[[nodiscard]] uint8_t* getWriteCacheLine(uint16_t start) override;
 
 private:
-	struct Range {
-		Range(unsigned base_, unsigned size_, MSXDevice& device_);
-		[[nodiscard]] constexpr bool operator==(const Range&) const = default;
-
-		unsigned base;
-		unsigned size;
-		MSXDevice* device;
-	};
-
 	[[nodiscard]] const Range& searchRange(unsigned address) const;
 	[[nodiscard]] MSXDevice* searchDevice(unsigned address) const;
 

--- a/src/imgui/ImGuiManager.cc
+++ b/src/imgui/ImGuiManager.cc
@@ -21,6 +21,7 @@
 #include "ImGuiReverseBar.hh"
 #include "ImGuiSCCViewer.hh"
 #include "ImGuiSettings.hh"
+#include "ImGuiSlotMap.hh"
 #include "ImGuiSoundChip.hh"
 #include "ImGuiSymbols.hh"
 #include "ImGuiTools.hh"
@@ -181,6 +182,7 @@ ImGuiManager::ImGuiManager(Reactor& reactor_)
 	openFile = std::make_unique<ImGuiOpenFile>(*this);
 	trainer = std::make_unique<ImGuiTrainer>(*this);
 	cheatFinder = std::make_unique<ImGuiCheatFinder>(*this);
+	slotMap = std::make_unique<ImGuiSlotMap>(*this);
 	sccViewer = std::make_unique<ImGuiSCCViewer>(*this);
 	msxMusicViewer = std::make_unique<ImGuiMsxMusicViewer>(*this);
 	waveViewer = std::make_unique<ImGuiWaveViewer>(*this);

--- a/src/imgui/ImGuiManager.hh
+++ b/src/imgui/ImGuiManager.hh
@@ -50,6 +50,7 @@ class ImGuiRasterViewer;
 class ImGuiReverseBar;
 class ImGuiSCCViewer;
 class ImGuiSettings;
+class ImGuiSlotMap;
 class ImGuiSoundChip;
 class ImGuiSymbols;
 class ImGuiTools;
@@ -175,6 +176,7 @@ public:
 	std::unique_ptr<ImGuiMsxMusicViewer> msxMusicViewer;
 	std::unique_ptr<ImGuiWaveViewer> waveViewer;
 	std::unique_ptr<ImGuiCheatFinder> cheatFinder;
+	std::unique_ptr<ImGuiSlotMap> slotMap;
 	std::unique_ptr<ImGuiDiskManipulator> diskManipulator;
 	std::unique_ptr<ImGuiSettings> settings;
 	std::unique_ptr<ImGuiSoundChip> soundChip;

--- a/src/imgui/ImGuiSlotMap.cc
+++ b/src/imgui/ImGuiSlotMap.cc
@@ -2,6 +2,7 @@
 
 #include "ImGuiCpp.hh"
 #include "ImGuiManager.hh"
+#include "ImGuiMedia.hh"
 #include "ImGuiUtils.hh"
 
 #include "CartridgeSlotManager.hh"
@@ -42,9 +43,9 @@ void ImGuiSlotMap::loadLine(std::string_view name, zstring_view value)
 	loadOnePersistent(name, value, *this, persistentElements);
 }
 
-// The letter of the external cartridge slot at (ps, ss), if any.
+// The external cartridge slot at (ps, ss), if any.
 // 'ss' must already be normalized: 0 for a non-expanded primary slot.
-[[nodiscard]] static std::optional<char> getCartridgeLetter(
+[[nodiscard]] static std::optional<unsigned> findCartridgeSlot(
 	const CartridgeSlotManager& slotManager, int ps, int ss)
 {
 	for (auto slot : xrange(CartridgeSlotManager::MAX_SLOTS)) {
@@ -52,7 +53,7 @@ void ImGuiSlotMap::loadLine(std::string_view name, zstring_view value)
 		auto [slotPs, slotSs] = slotManager.getPsSs(slot);
 		if (slotSs == -1) slotSs = 0; // not expanded
 		if ((slotPs == ps) && (slotSs == ss)) {
-			return char('A' + slot);
+			return slot;
 		}
 	}
 	return {};
@@ -109,22 +110,6 @@ static void getBlocks(std::vector<Block>& result, std::vector<Block>& scratch,
 	if (pos < ADDRESS_SPACE) result.emplace_back(pos, ADDRESS_SPACE, nullptr);
 }
 
-// Mirror of ImGuiUtils' leftClip(): keep the start of the string and replace
-// the part that doesn't fit with an ellipsis.
-[[nodiscard]] static std::string rightClip(std::string_view s, float maxWidth)
-{
-	maxWidth -= ImGui::CalcTextSize("..."sv).x;
-	if (maxWidth <= 0.0f) return "...";
-
-	// The first length that is too wide, minus one, is the longest prefix that
-	// still fits. Length 0 always fits, so that first length is never 0.
-	auto lengths = std::views::iota(0uz, s.size() + 1);
-	auto it = std::ranges::upper_bound(lengths, maxWidth, {},
-		[&](size_t n) { return ImGui::CalcTextSize(s.substr(0, n)).x; });
-	auto num = (it == lengths.end()) ? s.size() : (*it - 1);
-	return strCat(s.substr(0, num), "...");
-}
-
 // Draw 'text' centered in the rectangle, wrapped over as many lines as fit.
 // Falls back to a single clipped line, and to nothing at all when even that
 // doesn't fit - the tooltip is what makes those cells readable.
@@ -168,7 +153,7 @@ static void drawText(ImDrawList* drawList, std::string_view text,
 			y += lineHeight;
 		}
 	} else {
-		draw(rightClip(text, width), min.y + 0.5f * ((max.y - min.y) - lineHeight));
+		draw(ImGui::rightClip(text, width), min.y + 0.5f * ((max.y - min.y) - lineHeight));
 	}
 }
 
@@ -177,6 +162,7 @@ namespace {
 // overlap after being enlarged to a hoverable size.
 struct HoveredBlock {
 	Block block{0, 0, nullptr};
+	std::optional<unsigned> cartridgeSlot; // when it's in an external slot
 	float height = 0.0f;
 	bool valid = false;
 };
@@ -219,12 +205,12 @@ static constexpr float MIN_BLOCK_HEIGHT = 4.0f;
 static void drawSlot(DrawContext& ctx, int ps, int ss, bool expanded,
                      float x0, float x1, float headerTop, float top, float bottom)
 {
-	auto cartridge = getCartridgeLetter(ctx.slotManager, ps, ss);
+	auto cartridge = findCartridgeSlot(ctx.slotManager, ps, ss);
 	auto labelHeight = 0.5f * (top - headerTop);
 	drawText(ctx.drawList, expanded ? strCat(ps, '-', ss) : strCat(ps),
 	         gl::vec2(x0, headerTop), gl::vec2(x1, headerTop + labelHeight), ctx.textColor);
 	if (cartridge) {
-		drawText(ctx.drawList, tmpStrCat("Slot ", *cartridge),
+		drawText(ctx.drawList, tmpStrCat("Slot ", char('A' + *cartridge)),
 		         gl::vec2(x0, headerTop + labelHeight), gl::vec2(x1, top), ctx.dimTextColor);
 	}
 
@@ -273,20 +259,35 @@ static void drawSlot(DrawContext& ctx, int ps, int ss, bool expanded,
 		if ((x0 <= ctx.mouse.x) && (ctx.mouse.x < x1) &&
 		    (blockTop <= ctx.mouse.y) && (ctx.mouse.y < blockBottom) &&
 		    (!ctx.hovered.valid || (blockHeight < ctx.hovered.height))) {
-			ctx.hovered = HoveredBlock{block, blockHeight, true};
+			ctx.hovered = HoveredBlock{block, cartridge, blockHeight, true};
 		}
 	}
 }
 
 static void drawDeviceToolTip(DrawContext& ctx)
 {
-	const auto& [block, height_, valid_] = ctx.hovered;
+	const auto& block = ctx.hovered.block;
 	im::Tooltip([&]{
 		im::TextWrapPos(ImGui::GetFontSize() * 35.0f, [&]{
+			bool header = false;
+			// For an external slot, what is plugged into it. That's not the
+			// same thing as the device below, which is a part of it, though
+			// for a simple extension the two names are the same.
+			if (auto slot = ctx.hovered.cartridgeSlot) {
+				auto content = ctx.manager.media->displayNameForSlotContent(
+					ctx.slotManager, *slot);
+				if (block.device && (content == block.device->getName())) {
+					ImGui::StrCat("Slot ", char('A' + *slot));
+				} else {
+					ImGui::StrCat("Slot ", char('A' + *slot), ": ", content);
+				}
+				header = true;
+			}
 			if (block.device) {
 				ImGui::TextUnformatted(block.device->getName());
-				ImGui::Separator();
+				header = true;
 			}
+			if (header) ImGui::Separator();
 			auto size = block.end - block.begin;
 			ImGui::StrCat("address: 0x", hex_string<4, HexCase::upper>(block.begin),
 			              " - 0x", hex_string<4, HexCase::upper>(block.end - 1));

--- a/src/imgui/ImGuiSlotMap.cc
+++ b/src/imgui/ImGuiSlotMap.cc
@@ -53,8 +53,10 @@ struct Block {
 };
 
 // Draw 'text' centered in the rectangle, wrapped over as many lines as fit.
-// Falls back to a single clipped line, and to nothing at all when even that
-// doesn't fit - the tooltip is what makes those cells readable.
+// The last line ends in an ellipsis if the text needs more lines than that.
+// Falls back to a single clipped line when a word doesn't fit on a line of its
+// own, and to nothing at all when even that doesn't fit - the tooltip is what
+// makes those cells readable.
 static void drawText(ImDrawList* drawList, std::string_view text,
                      gl::vec2 min, gl::vec2 max, ImU32 color)
 {
@@ -76,26 +78,35 @@ static void drawText(ImDrawList* drawList, std::string_view text,
 	auto* font = ImGui::GetFont();
 	auto fontSize = ImGui::GetFontSize();
 	static_vector<std::string_view, 16> lines;
+	auto maxLines = std::min(size_t(height / lineHeight), lines.max_size());
+	std::string_view rest; // what didn't fit, goes on the last line
 	bool wrapped = true;
 	const char* pos = text.data();
 	const char* end = pos + text.size();
 	while (pos < end) {
-		if (lines.size() == lines.max_size()) { wrapped = false; break; }
+		if ((lines.size() + 1) == maxLines) {
+			// Nowhere left to wrap to, so the last line takes the remainder.
+			rest = std::string_view(pos, size_t(end - pos));
+			break;
+		}
 		const char* stop = font->CalcWordWrapPosition(fontSize, pos, end, width);
 		if ((stop == pos) || ((stop != end) && (*stop != ' '))) { wrapped = false; break; }
 		lines.push_back(std::string_view(pos, size_t(stop - pos)));
 		pos = stop;
 		while ((pos < end) && (*pos == ' ')) ++pos; // eat the wrap point
 	}
-	if (wrapped && !lines.empty() && (float(lines.size()) * lineHeight <= height)) {
-		auto y = min.y + 0.5f * ((max.y - min.y) - float(lines.size()) * lineHeight);
-		for (auto line : lines) {
-			draw(line, y);
-			y += lineHeight;
-		}
-	} else {
+	if (!wrapped) {
 		draw(ImGui::rightClip(text, width), min.y + 0.5f * ((max.y - min.y) - lineHeight));
+		return;
 	}
+	auto numLines = lines.size() + (rest.empty() ? 0 : 1);
+	auto y = min.y + 0.5f * ((max.y - min.y) - float(numLines) * lineHeight);
+	for (auto line : lines) {
+		draw(line, y);
+		y += lineHeight;
+	}
+	// rightClip() adds the ellipsis, and returns 'rest' unchanged when it fits.
+	if (!rest.empty()) draw(ImGui::rightClip(rest, width), y);
 }
 
 namespace {
@@ -187,6 +198,44 @@ static void getBlocks(DrawContext& ctx, int ps, int ss)
 	if (pos < ADDRESS_SPACE) result.emplace_back(pos, ADDRESS_SPACE, nullptr);
 }
 
+namespace {
+// Everything that only depends on the font and the style, shared by the layout
+// and by the default size of the window.
+struct Metrics {
+	float rowHeight;
+	float headerHeight;
+	float labelWidth;
+	float minSlotWidth;
+	float minMapHeight;
+	gl::vec2 gap;
+	float overhang;
+};
+}
+
+static Metrics getMetrics()
+{
+	const auto& style = ImGui::GetStyle();
+	auto lineHeight = ImGui::GetTextLineHeight();
+	auto rowHeight = lineHeight + 2.0f * style.CellPadding.y;
+	return {
+		.rowHeight = rowHeight,
+		.headerHeight = 2.0f * rowHeight, // external slot name, slot number
+		// Wide enough for every label on the address axis. Letters and digits
+		// don't have the same width, so check both kinds.
+		.labelWidth = 2.0f * style.CellPadding.x +
+		              std::max({ImGui::CalcTextSize("0000"sv).x,
+		                        ImGui::CalcTextSize("C000"sv).x,
+		                        ImGui::CalcTextSize("FFFF"sv).x}),
+		// A primary slot always gets the same width, expanded or not, so
+		// machines with a different slot layout still look alike.
+		.minSlotWidth = 4.0f * 3.0f * lineHeight,
+		.minMapHeight = 10.0f * rowHeight,
+		.gap = 2.0f * gl::vec2(style.ItemSpacing),
+		// The labels of the lowest and highest address stick out half a line.
+		.overhang = 0.5f * rowHeight,
+	};
+}
+
 // Below this a block can't be seen, let alone hovered. A single byte is a
 // hundredth of a pixel on a 64kB axis, so those are drawn out of scale.
 static constexpr float MIN_BLOCK_HEIGHT = 4.0f;
@@ -196,14 +245,17 @@ static constexpr float MIN_BLOCK_HEIGHT = 4.0f;
 static void drawSlot(DrawContext& ctx, int ps, int ss, bool expanded,
                      float x0, float x1, float headerTop, float top, float bottom)
 {
+	// The slot number goes directly above the map, there are four times as many
+	// of those as external slot names.
 	auto cartridge = ctx.slotManager.findSlot(ps, ss, true);
 	auto labelHeight = 0.5f * (top - headerTop);
-	drawText(ctx.drawList, expanded ? strCat(ps, '-', ss) : strCat(ps),
-	         gl::vec2(x0, headerTop), gl::vec2(x1, headerTop + labelHeight), ctx.textColor);
 	if (cartridge) {
 		drawText(ctx.drawList, tmpStrCat("Slot ", char('A' + *cartridge)),
-		         gl::vec2(x0, headerTop + labelHeight), gl::vec2(x1, top), ctx.dimTextColor);
+		         gl::vec2(x0, headerTop), gl::vec2(x1, headerTop + labelHeight),
+		         ctx.dimTextColor);
 	}
+	drawText(ctx.drawList, expanded ? strCat(ps, '-', ss) : strCat(ps),
+	         gl::vec2(x0, headerTop + labelHeight), gl::vec2(x1, top), ctx.textColor);
 
 	auto height = bottom - top;
 	auto addressToY = [&](unsigned address) {
@@ -319,30 +371,13 @@ static void drawDeviceToolTip(DrawContext& ctx)
 
 static void drawSlotMap(DrawContext& ctx)
 {
-	const auto& style = ImGui::GetStyle();
-	auto lineHeight = ImGui::GetTextLineHeight();
-	auto rowHeight = lineHeight + 2.0f * style.CellPadding.y;
-	auto headerHeight = 2.0f * rowHeight; // slot number, external slot name
-	auto gapX = 2.0f * style.ItemSpacing.x;
-	auto gapY = style.ItemSpacing.y;
-	// Wide enough for every label on the address axis. Letters and digits don't
-	// have the same width, so check both kinds.
-	auto labelWidth = 2.0f * style.CellPadding.x +
-		std::max({ImGui::CalcTextSize("0000"sv).x,
-		          ImGui::CalcTextSize("C000"sv).x,
-		          ImGui::CalcTextSize("FFFF"sv).x});
-	// A primary slot always gets the same width, expanded or not, so machines
-	// with a different slot layout still look alike.
-	auto minSlotWidth = 4.0f * 3.0f * lineHeight;
-	auto minMapHeight = 10.0f * rowHeight;
-
+	auto [rowHeight, headerHeight, labelWidth, minSlotWidth, minMapHeight, gap, overhang] =
+		getMetrics();
 	auto avail = gl::vec2(ImGui::GetContentRegionAvail());
-	// The labels of the lowest and highest address stick out half a line.
-	auto overhang = 0.5f * rowHeight;
 
 	// Reflow: put 4, 2 or 1 primary slots next to each other, whichever fits.
 	auto widthFor = [&](int perRow) {
-		return labelWidth + float(perRow) * minSlotWidth + float(perRow - 1) * gapX;
+		return labelWidth + float(perRow) * minSlotWidth + float(perRow - 1) * gap.x;
 	};
 	int perRow = 4;
 	if (widthFor(perRow) > avail.x) perRow = 2;
@@ -350,19 +385,19 @@ static void drawSlotMap(DrawContext& ctx)
 	int numRows = 4 / perRow;
 
 	auto slotWidth = std::max(minSlotWidth,
-		(avail.x - labelWidth - float(perRow - 1) * gapX) / float(perRow));
+		(avail.x - labelWidth - float(perRow - 1) * gap.x) / float(perRow));
 	auto mapHeight = std::max(minMapHeight,
-		(avail.y - overhang - float(numRows) * headerHeight - float(numRows - 1) * gapY) /
+		(avail.y - overhang - float(numRows) * headerHeight - float(numRows - 1) * gap.y) /
 		float(numRows));
 
 	auto origin = gl::vec2(ImGui::GetCursorScreenPos());
-	gl::vec2 size{labelWidth + float(perRow) * slotWidth + float(perRow - 1) * gapX,
-	              float(numRows) * (headerHeight + mapHeight) + float(numRows - 1) * gapY +
+	gl::vec2 size{labelWidth + float(perRow) * slotWidth + float(perRow - 1) * gap.x,
+	              float(numRows) * (headerHeight + mapHeight) + float(numRows - 1) * gap.y +
 	              overhang};
 	ImGui::Dummy(size); // reserve the space, the map itself is positioned absolutely
 
 	for (auto row : xrange(numRows)) {
-		auto headerTop = origin.y + float(row) * (headerHeight + mapHeight + gapY);
+		auto headerTop = origin.y + float(row) * (headerHeight + mapHeight + gap.y);
 		auto top = headerTop + headerHeight;
 		auto bottom = top + mapHeight;
 		auto addressToY = [&](unsigned address) {
@@ -402,7 +437,7 @@ static void drawSlotMap(DrawContext& ctx)
 				drawSlot(ctx, ps, 0, false, x, x + slotWidth, headerTop, top, bottom);
 			}
 			ctx.outlines.emplace_back(gl::vec2(x, top), gl::vec2(x + slotWidth, bottom));
-			x += slotWidth + gapX;
+			x += slotWidth + gap.x;
 		}
 	}
 
@@ -429,6 +464,18 @@ static void drawSlotMap(DrawContext& ctx)
 	ctx.tinyBlocks.clear();
 }
 
+// Big enough for a 2x2 layout: room for three primary slots next to each other,
+// while the reflow needs room for four before it puts them in a single row.
+static gl::vec2 defaultWindowSize()
+{
+	const auto& style = ImGui::GetStyle();
+	auto m = getMetrics();
+	gl::vec2 content{m.labelWidth + 3.0f * (m.minSlotWidth + m.gap.x),
+	                 2.0f * (m.headerHeight + m.minMapHeight) + m.gap.y + m.overhang};
+	return content + 2.0f * gl::vec2(style.WindowPadding) +
+	       gl::vec2(0.0f, ImGui::GetFrameHeight()); // title bar
+}
+
 void ImGuiSlotMap::paint(MSXMotherBoard* motherBoard)
 {
 	if (!show) return;
@@ -453,8 +500,7 @@ void ImGuiSlotMap::paint(MSXMotherBoard* motherBoard)
 	ctx.outlines.reserve(4);
 	ctx.separators.reserve(64);
 
-	auto fontSize = ImGui::GetFontSize();
-	ImGui::SetNextWindowSize(ImVec2(64.0f * fontSize, 26.0f * fontSize), ImGuiCond_FirstUseEver);
+	ImGui::SetNextWindowSize(defaultWindowSize(), ImGuiCond_FirstUseEver);
 	im::Window("Slot map", &show, [&]{
 		ctx.drawList = ImGui::GetWindowDrawList();
 		drawSlotMap(ctx);

--- a/src/imgui/ImGuiSlotMap.cc
+++ b/src/imgui/ImGuiSlotMap.cc
@@ -1,6 +1,7 @@
 #include "ImGuiSlotMap.hh"
 
 #include "ImGuiCpp.hh"
+#include "ImGuiManager.hh"
 #include "ImGuiUtils.hh"
 
 #include "CartridgeSlotManager.hh"
@@ -9,6 +10,7 @@
 #include "MSXDevice.hh"
 #include "MSXMotherBoard.hh"
 #include "MSXMultiMemDevice.hh"
+#include "TclObject.hh"
 
 #include "gl_vec.hh"
 #include "strCat.hh"
@@ -28,25 +30,16 @@
 namespace openmsx {
 
 static constexpr unsigned PAGE_SIZE = 0x4000;
+static constexpr unsigned ADDRESS_SPACE = 4 * PAGE_SIZE;
 
 void ImGuiSlotMap::save(ImGuiTextBuffer& buf)
 {
 	savePersistent(buf, *this, persistentElements);
-	buf.appendf("layout=%s\n", vertical ? "vertical" : "horizontal");
 }
 
 void ImGuiSlotMap::loadLine(std::string_view name, zstring_view value)
 {
-	if (loadOnePersistent(name, value, *this, persistentElements)) {
-		// already handled
-	} else if (name == "layout") {
-		// anything else keeps the default
-		if (value == "vertical") {
-			vertical = true;
-		} else if (value == "horizontal") {
-			vertical = false;
-		}
-	}
+	loadOnePersistent(name, value, *this, persistentElements);
 }
 
 // The letter of the external cartridge slot at (ps, ss), if any.
@@ -65,38 +58,55 @@ void ImGuiSlotMap::loadLine(std::string_view name, zstring_view value)
 	return {};
 }
 
-// The part of one 16kB page that is covered by a single device, as offsets
-// relative to the start of that page.
-struct Segment {
+// A continuous address range in one slot, covered by a single device.
+// 'device' is nullptr for the parts where nothing is mapped.
+struct Block {
 	unsigned begin;
 	unsigned end;
 	const MSXDevice* device;
 };
 
-// A device that covers a whole page is registered directly, a device that
-// covers less than a page is wrapped in an MSXMultiMemDevice, which knows the
-// exact address ranges. Result is sorted; gaps are left to the caller.
-static void getSegments(std::vector<Segment>& result, MSXCPUInterface& cpuInterface,
-                        const MSXDevice* dummyDevice, int ps, int ss, int page)
+// Split the address space of one slot into blocks. MSXCPUInterface stores a
+// device per 16kB page, and wraps devices that cover less than a page in an
+// MSXMultiMemDevice, which knows the exact address ranges. Recombining both
+// gives the real extent of every device, so that nothing here has to care
+// about page boundaries.
+static void getBlocks(std::vector<Block>& result, std::vector<Block>& scratch,
+                      MSXCPUInterface& cpuInterface, const MSXDevice* dummyDevice,
+                      int ps, int ss)
 {
-	result.clear();
-	const auto* device = cpuInterface.getMSXDevice(ps, ss, page);
-	if (!device || (device == dummyDevice)) return; // nothing in this page
-
-	const auto* multi = dynamic_cast<const MSXMultiMemDevice*>(device);
-	if (!multi) {
-		result.emplace_back(0u, PAGE_SIZE, device);
-		return;
-	}
-	auto pageBegin = PAGE_SIZE * unsigned(page);
-	for (const auto& range : multi->getRanges()) {
-		auto begin = std::max(range.base, pageBegin);
-		auto end = std::min(range.base + range.size, pageBegin + PAGE_SIZE);
-		if (begin < end) {
-			result.emplace_back(begin - pageBegin, end - pageBegin, range.device);
+	scratch.clear();
+	for (auto page : xrange(4)) {
+		auto pageBegin = PAGE_SIZE * unsigned(page);
+		const auto* device = cpuInterface.getMSXDevice(ps, ss, page);
+		if (!device || (device == dummyDevice)) continue;
+		if (const auto* multi = dynamic_cast<const MSXMultiMemDevice*>(device)) {
+			for (const auto& range : multi->getRanges()) {
+				auto begin = std::max(range.base, pageBegin);
+				auto end = std::min(range.base + range.size, pageBegin + PAGE_SIZE);
+				if (begin < end) scratch.emplace_back(begin, end, range.device);
+			}
+		} else {
+			scratch.emplace_back(pageBegin, pageBegin + PAGE_SIZE, device);
 		}
 	}
-	std::ranges::sort(result, {}, &Segment::begin);
+	std::ranges::sort(scratch, {}, &Block::begin);
+
+	// Glue the pieces of a device that spans page boundaries back together,
+	// and fill what's left with 'empty' blocks.
+	result.clear();
+	unsigned pos = 0;
+	for (const auto& block : scratch) {
+		if (!result.empty() && (result.back().device == block.device) &&
+		    (result.back().end == block.begin)) {
+			result.back().end = block.end;
+		} else {
+			if (pos < block.begin) result.emplace_back(pos, block.begin, nullptr);
+			result.emplace_back(block.begin, block.end, block.device);
+		}
+		pos = block.end;
+	}
+	if (pos < ADDRESS_SPACE) result.emplace_back(pos, ADDRESS_SPACE, nullptr);
 }
 
 // Mirror of ImGuiUtils' leftClip(): keep the start of the string and replace
@@ -115,72 +125,72 @@ static void getSegments(std::vector<Segment>& result, MSXCPUInterface& cpuInterf
 	return strCat(s.substr(0, num), "...");
 }
 
-// Try to draw 'text' as a block of centered lines, wrapped at word boundaries,
-// in the rectangle [min, max). Returns false when it doesn't fit; a tall cell
-// (a device covering several pages) can hold a lot more than a single line.
-[[nodiscard]] static bool drawWrapped(std::string_view text, gl::vec2 min, gl::vec2 max)
+// Draw 'text' centered in the rectangle, wrapped over as many lines as fit.
+// Falls back to a single clipped line, and to nothing at all when even that
+// doesn't fit - the tooltip is what makes those cells readable.
+static void drawText(ImDrawList* drawList, std::string_view text,
+                     gl::vec2 min, gl::vec2 max, ImU32 color)
 {
 	const auto& style = ImGui::GetStyle();
 	auto width = (max.x - min.x) - 2.0f * style.CellPadding.x;
 	auto height = (max.y - min.y) - 2.0f * style.CellPadding.y;
 	auto lineHeight = ImGui::GetTextLineHeight();
-	if ((width <= 0.0f) || (height < lineHeight)) return false;
+	if ((height < lineHeight) || (width < ImGui::CalcTextSize("..."sv).x)) return;
 
+	auto draw = [&](std::string_view line, float y) {
+		auto lineWidth = ImGui::CalcTextSize(line).x;
+		drawList->AddText(gl::vec2(min.x + 0.5f * ((max.x - min.x) - lineWidth), y),
+		                  color, line.data(), line.data() + line.size());
+	};
+
+	// Wrap at word boundaries. ImGui breaks mid-word when a word is wider than
+	// the cell, which reads as garbage in a diagram, so treat that as 'doesn't
+	// fit' and fall back to clipping.
 	auto* font = ImGui::GetFont();
 	auto fontSize = ImGui::GetFontSize();
-	std::array<std::string_view, 8> lines; // a cell is at most 8 lines high
+	std::array<std::string_view, 16> lines;
 	size_t numLines = 0;
-
+	bool wrapped = true;
 	const char* pos = text.data();
 	const char* end = pos + text.size();
 	while (pos < end) {
-		if (numLines == lines.size()) return false;
+		if (numLines == lines.size()) { wrapped = false; break; }
 		const char* stop = font->CalcWordWrapPosition(fontSize, pos, end, width);
-		// ImGui breaks mid-word when a word is wider than the cell; that reads
-		// as garbage in a diagram, so rather fall back to a clipped single line.
-		if ((stop == pos) || ((stop != end) && (*stop != ' '))) return false;
+		if ((stop == pos) || ((stop != end) && (*stop != ' '))) { wrapped = false; break; }
 		lines[numLines++] = std::string_view(pos, size_t(stop - pos));
 		pos = stop;
 		while ((pos < end) && (*pos == ' ')) ++pos; // eat the wrap point
 	}
-	if ((numLines == 0) || (float(numLines) * lineHeight > height)) return false;
-
-	auto y = min.y + 0.5f * ((max.y - min.y) - float(numLines) * lineHeight);
-	for (auto line : std::span(lines).first(numLines)) {
-		auto lineWidth = ImGui::CalcTextSize(line).x;
-		ImGui::SetCursorScreenPos(gl::vec2(min.x + 0.5f * ((max.x - min.x) - lineWidth), y));
-		ImGui::TextUnformatted(line);
-		y += lineHeight;
+	if (wrapped && (numLines != 0) && (float(numLines) * lineHeight <= height)) {
+		auto y = min.y + 0.5f * ((max.y - min.y) - float(numLines) * lineHeight);
+		for (auto line : std::span(lines).first(numLines)) {
+			draw(line, y);
+			y += lineHeight;
+		}
+	} else {
+		draw(rightClip(text, width), min.y + 0.5f * ((max.y - min.y) - lineHeight));
 	}
-	return true;
 }
 
-// Make a whole cell hoverable, so a short label can still explain itself.
-static void cellToolTip(const char* id, gl::vec2 min, gl::vec2 max, std::string_view text)
-{
-	ImGui::SetCursorScreenPos(min);
-	ImGui::InvisibleButton(id, max - min);
-	simpleToolTip(text);
-}
-
-static void drawCentered(std::string_view text, gl::vec2 min, gl::vec2 max)
-{
-	if (drawWrapped(text, min, max)) return;
-
-	// Doesn't fit, not even wrapped: clip to one line, full text on hover.
-	const auto& style = ImGui::GetStyle();
-	auto avail = (max.x - min.x) - 2.0f * style.CellPadding.x;
-	auto y = min.y + 0.5f * ((max.y - min.y) - ImGui::GetTextLineHeight());
-	ImGui::SetCursorScreenPos(gl::vec2(min.x + style.CellPadding.x, y));
-	ImGui::TextUnformatted(rightClip(text, avail));
-	simpleToolTip(text);
-}
-
-// Everything the grid needs. Cells are filled and outlined with the draw list
-// rather than with a table, because a device can cover several pages (one
-// merged cell) or just a part of one page.
 namespace {
+// What the mouse is over, so that only one tooltip is shown even where blocks
+// overlap after being enlarged to a hoverable size.
+struct HoveredBlock {
+	Block block{0, 0, nullptr};
+	float height = 0.0f;
+	bool valid = false;
+};
+
+// A block that is too small to see, enlarged and drawn on top of its
+// neighbours instead of to scale.
+struct TinyBlock {
+	gl::vec2 min;
+	gl::vec2 max;
+	ImU32 color;
+};
+
 struct DrawContext {
+	ImGuiManager& manager;
 	MSXCPUInterface& cpuInterface;
 	const CartridgeSlotManager& slotManager;
 	const MSXDevice* dummyDevice;
@@ -189,206 +199,220 @@ struct DrawContext {
 	ImU32 occupiedColor;
 	ImU32 externalColor;
 	ImU32 outlineColor;
-	float rowHeight; // one line of text plus padding
+	ImU32 textColor;
+	ImU32 dimTextColor;
+	gl::vec2 mouse;
+	HoveredBlock hovered;
 	std::vector<std::pair<gl::vec2, gl::vec2>> outlines;
-	std::vector<Segment> segments; // reused for every cell
+	std::vector<TinyBlock> tinyBlocks;
+	std::vector<Block> blocks;
+	std::vector<Block> scratch;
 };
 }
 
-static void drawCell(DrawContext& ctx, gl::vec2 min, gl::vec2 max,
-                     const MSXDevice* device, bool cartridge)
+// Below this a block can't be seen, let alone hovered. A single byte is a
+// hundredth of a pixel on a 64kB axis, so those are drawn out of scale.
+static constexpr float MIN_BLOCK_HEIGHT = 4.0f;
+
+// One slot, drawn as a continuous 0x0000-0xFFFF axis with the highest address
+// on top, so a device is a rectangle at its real position and size.
+static void drawSlot(DrawContext& ctx, int ps, int ss, bool expanded,
+                     float x0, float x1, float headerTop, float top, float bottom)
 {
-	ctx.drawList->AddRectFilled(min, max,
-		!device ? ctx.emptyColor : (cartridge ? ctx.externalColor : ctx.occupiedColor));
-	ctx.outlines.emplace_back(min, max);
-	drawCentered(device ? std::string_view(device->getName()) : "empty"sv, min, max);
+	auto cartridge = getCartridgeLetter(ctx.slotManager, ps, ss);
+	auto labelHeight = 0.5f * (top - headerTop);
+	drawText(ctx.drawList, expanded ? strCat(ps, '-', ss) : strCat(ps),
+	         gl::vec2(x0, headerTop), gl::vec2(x1, headerTop + labelHeight), ctx.textColor);
+	if (cartridge) {
+		drawText(ctx.drawList, tmpStrCat("Slot ", *cartridge),
+		         gl::vec2(x0, headerTop + labelHeight), gl::vec2(x1, top), ctx.dimTextColor);
+	}
+
+	auto height = bottom - top;
+	auto addressToY = [&](unsigned address) {
+		return bottom - height * (float(address) * (1.0f / float(ADDRESS_SPACE)));
+	};
+
+	getBlocks(ctx.blocks, ctx.scratch, ctx.cpuInterface, ctx.dummyDevice, ps, ss);
+	// Blocks come in increasing address order, so downwards on screen. Keeps
+	// enlarged blocks from covering each other.
+	auto lowestEnlarged = bottom;
+	for (const auto& block : ctx.blocks) {
+		auto blockTop = addressToY(block.end);
+		auto blockBottom = addressToY(block.begin);
+		auto blockHeight = blockBottom - blockTop;
+		auto color = !block.device ? ctx.emptyColor
+		                           : (cartridge ? ctx.externalColor : ctx.occupiedColor);
+
+		if (auto grow = 0.5f * (MIN_BLOCK_HEIGHT - blockHeight); grow > 0.0f) {
+			// Too small to draw to scale, so draw it out of scale: enlarge it
+			// around its real address, stack it on top of an earlier enlarged
+			// block if they'd overlap, and paint it over its big neighbours
+			// later on.
+			blockTop -= grow;
+			blockBottom += grow;
+			if (blockBottom > lowestEnlarged) {
+				blockTop -= blockBottom - lowestEnlarged;
+				blockBottom = lowestEnlarged;
+			}
+			lowestEnlarged = blockTop;
+			ctx.tinyBlocks.emplace_back(gl::vec2(x0, blockTop), gl::vec2(x1, blockBottom),
+			                            color);
+		} else {
+			gl::vec2 min{x0, blockTop};
+			gl::vec2 max{x1, blockBottom};
+			ctx.drawList->AddRectFilled(min, max, color);
+			ctx.outlines.emplace_back(min, max);
+			drawText(ctx.drawList, block.device ? std::string_view(block.device->getName())
+			                                    : "empty"sv,
+			         min, max, ctx.textColor);
+		}
+
+		// Hit-test what is actually drawn. The smallest block wins, so an
+		// enlarged one stays reachable between its much larger neighbours.
+		if ((x0 <= ctx.mouse.x) && (ctx.mouse.x < x1) &&
+		    (blockTop <= ctx.mouse.y) && (ctx.mouse.y < blockBottom) &&
+		    (!ctx.hovered.valid || (blockHeight < ctx.hovered.height))) {
+			ctx.hovered = HoveredBlock{block, blockHeight, true};
+		}
+	}
 }
 
-// Outlines are drawn in one go, after all the fills, so that the fill of one
-// cell can't paint over the outline of the cell next to it.
-static void flushOutlines(DrawContext& ctx)
+static void drawDeviceToolTip(DrawContext& ctx)
 {
+	const auto& [block, height_, valid_] = ctx.hovered;
+	im::Tooltip([&]{
+		im::TextWrapPos(ImGui::GetFontSize() * 35.0f, [&]{
+			if (block.device) {
+				ImGui::TextUnformatted(block.device->getName());
+				ImGui::Separator();
+			}
+			auto size = block.end - block.begin;
+			ImGui::StrCat("address: 0x", hex_string<4, HexCase::upper>(block.begin),
+			              " - 0x", hex_string<4, HexCase::upper>(block.end - 1));
+			ImGui::StrCat("size: ", (size < 1024) ? strCat(size, " bytes")
+			                                      : strCat(size / 1024, "kB"));
+			if (!block.device) return;
+
+			const auto& name = block.device->getName();
+			// Whatever the device wants to tell about itself, e.g. the mapper
+			// type of a ROM or the file it was loaded from.
+			if (auto info = ctx.manager.execute(makeTclList("machine_info", "device", name))) {
+				for (size_t i = 0; (i + 1) < info->size(); i += 2) {
+					auto key = info->getListIndexUnchecked(i).getString();
+					auto value = info->getListIndexUnchecked(i + 1).getString();
+					if (value.empty()) continue;
+					ImGui::StrCat(key, ": ", value);
+				}
+			}
+			// Devices with a debuggable of the same name (memory mappers, RAM)
+			// can also tell how much memory they actually have.
+			if (auto total = ctx.manager.execute(makeTclList("debug", "size", name))) {
+				if (auto bytes = total->getOptionalInt(); bytes && (*bytes > 0)) {
+					ImGui::StrCat("total memory: ", *bytes / 1024, "kB");
+				}
+			}
+		});
+	});
+}
+
+static void drawSlotMap(DrawContext& ctx)
+{
+	const auto& style = ImGui::GetStyle();
+	auto lineHeight = ImGui::GetTextLineHeight();
+	auto rowHeight = lineHeight + 2.0f * style.CellPadding.y;
+	auto headerHeight = 2.0f * rowHeight; // slot number, external slot name
+	auto gapX = 2.0f * style.ItemSpacing.x;
+	auto gapY = style.ItemSpacing.y;
+	// Wide enough for every label on the address axis. Letters and digits don't
+	// have the same width, so check both kinds.
+	auto labelWidth = 2.0f * style.CellPadding.x +
+		std::max({ImGui::CalcTextSize("0000"sv).x,
+		          ImGui::CalcTextSize("C000"sv).x,
+		          ImGui::CalcTextSize("FFFF"sv).x});
+	// A primary slot always gets the same width, expanded or not, so machines
+	// with a different slot layout still look alike.
+	auto minSlotWidth = 4.0f * 3.0f * lineHeight;
+	auto minMapHeight = 10.0f * rowHeight;
+
+	auto avail = gl::vec2(ImGui::GetContentRegionAvail());
+	// The labels of the lowest and highest address stick out half a line.
+	auto overhang = 0.5f * rowHeight;
+
+	// Reflow: put 4, 2 or 1 primary slots next to each other, whichever fits.
+	auto widthFor = [&](int perRow) {
+		return labelWidth + float(perRow) * minSlotWidth + float(perRow - 1) * gapX;
+	};
+	int perRow = 4;
+	if (widthFor(perRow) > avail.x) perRow = 2;
+	if ((perRow == 2) && (widthFor(perRow) > avail.x)) perRow = 1;
+	int numRows = 4 / perRow;
+
+	auto slotWidth = std::max(minSlotWidth,
+		(avail.x - labelWidth - float(perRow - 1) * gapX) / float(perRow));
+	auto mapHeight = std::max(minMapHeight,
+		(avail.y - overhang - float(numRows) * headerHeight - float(numRows - 1) * gapY) /
+		float(numRows));
+
+	auto origin = gl::vec2(ImGui::GetCursorScreenPos());
+	gl::vec2 size{labelWidth + float(perRow) * slotWidth + float(perRow - 1) * gapX,
+	              float(numRows) * (headerHeight + mapHeight) + float(numRows - 1) * gapY +
+	              overhang};
+	ImGui::Dummy(size); // reserve the space, the map itself is positioned absolutely
+
+	for (auto row : xrange(numRows)) {
+		auto headerTop = origin.y + float(row) * (headerHeight + mapHeight + gapY);
+		auto top = headerTop + headerHeight;
+		auto bottom = top + mapHeight;
+		auto addressToY = [&](unsigned address) {
+			return bottom - mapHeight * (float(address) * (1.0f / float(ADDRESS_SPACE)));
+		};
+
+		// Address axis: one label per page boundary, plus the very top, each
+		// centered on the position it marks.
+		auto drawTick = [&](unsigned address, std::string_view label) {
+			auto y = addressToY(address);
+			drawText(ctx.drawList, label,
+			         gl::vec2(origin.x, y - 0.5f * rowHeight),
+			         gl::vec2(origin.x + labelWidth, y + 0.5f * rowHeight),
+			         ctx.textColor);
+		};
+		for (auto page : xrange(4)) {
+			auto address = PAGE_SIZE * unsigned(page);
+			drawTick(address, tmpStrCat(hex_string<4, HexCase::upper>(address)));
+		}
+		drawTick(ADDRESS_SPACE, "FFFF"sv);
+
+		auto x = origin.x + labelWidth;
+		for (auto ps : xrange(row * perRow, std::min((row + 1) * perRow, 4))) {
+			if (ctx.cpuInterface.isExpanded(ps)) {
+				auto width = 0.25f * slotWidth;
+				for (auto ss : xrange(4)) {
+					auto x0 = x + float(ss) * width;
+					drawSlot(ctx, ps, ss, true, x0, x0 + width, headerTop, top, bottom);
+				}
+			} else {
+				drawSlot(ctx, ps, 0, false, x, x + slotWidth, headerTop, top, bottom);
+			}
+			x += slotWidth + gapX;
+		}
+	}
+
+	// Outlines in one go, after all the fills, so that the fill of one block
+	// can't paint over the outline of the block next to it. This is also what
+	// keeps a device that is too small to see as a rectangle visible as a line.
 	for (const auto& [min, max] : ctx.outlines) {
 		ctx.drawList->AddRect(min, max, ctx.outlineColor);
 	}
 	ctx.outlines.clear();
-}
 
-// One page that holds more than one device. Addresses run to the right in the
-// horizontal layout and upwards in the vertical one, so that's also how the
-// cell is split.
-static void drawSplitPage(DrawContext& ctx, int ps, int ss, int page, bool cartridge,
-                          gl::vec2 min, gl::vec2 max, bool vertical)
-{
-	auto drawSegment = [&](unsigned begin, unsigned end, const MSXDevice* device) {
-		gl::vec2 segMin = min;
-		gl::vec2 segMax = max;
-		if (vertical) {
-			auto scale = (max.y - min.y) * (1.0f / float(PAGE_SIZE));
-			segMin.y = max.y - scale * float(end);
-			segMax.y = max.y - scale * float(begin);
-		} else {
-			auto scale = (max.x - min.x) * (1.0f / float(PAGE_SIZE));
-			segMin.x = min.x + scale * float(begin);
-			segMax.x = min.x + scale * float(end);
-		}
-		drawCell(ctx, segMin, segMax, device, cartridge);
-	};
-
-	getSegments(ctx.segments, ctx.cpuInterface, ctx.dummyDevice, ps, ss, page);
-	unsigned pos = 0;
-	for (const auto& segment : ctx.segments) {
-		if (pos < segment.begin) drawSegment(pos, segment.begin, nullptr);
-		drawSegment(segment.begin, segment.end, segment.device);
-		pos = segment.end;
+	// Devices too small to draw to scale go last, so that they end up visible
+	// on top of the (much bigger) devices around them.
+	for (const auto& [min, max, color] : ctx.tinyBlocks) {
+		ctx.drawList->AddRectFilled(min, max, color);
+		ctx.drawList->AddRect(min, max, ctx.outlineColor);
 	}
-	if (pos < PAGE_SIZE) drawSegment(pos, PAGE_SIZE, nullptr);
-}
-
-// The grid, in either orientation. Horizontal has slots as rows and pages as
-// columns; vertical is the transpose, with the highest address on top, like
-// the memory maps in the MSX wiki and in most manuals.
-//
-// Both are laid out by hand instead of with a table, because a device covering
-// several pages is drawn as one merged cell.
-static void drawGrid(DrawContext& ctx, bool vertical)
-{
-	const auto& style = ImGui::GetStyle();
-	auto rowHeight = ctx.rowHeight;
-	// Gap between the 4 primary slots, along the slot axis.
-	auto gap = style.ItemSpacing.x;
-	// Widest label of the strip on the left.
-	auto labelWidth = ImGui::CalcTextSize(vertical ? "Page"sv : "0-0 (cart A)"sv).x
-	                + 2.0f * style.CellPadding.x;
-	// One row with the title of each strip, one with the numbers.
-	auto headerHeight = 2.0f * rowHeight;
-
-	auto origin = gl::vec2(ImGui::GetCursorScreenPos());
-	auto avail = ImGui::GetContentRegionAvail().x;
-
-	// A non-expanded slot gets the same space as 4 sub-slots, so that the
-	// layout is the same for every machine.
-	float slotExtent = 4.0f * rowHeight; // one primary slot, along the slot axis
-	float pageExtent = 0.0f;             // one page, along the page axis
-	if (vertical) {
-		slotExtent = std::max(slotExtent, 0.25f * (avail - labelWidth - 3.0f * gap));
-		pageExtent = 2.0f * rowHeight; // room to split a page and still fit text
-	} else {
-		pageExtent = std::max(6.0f * rowHeight, 0.25f * (avail - labelWidth));
-	}
-	gl::vec2 size = vertical
-		? gl::vec2(labelWidth + 4.0f * slotExtent + 3.0f * gap, headerHeight + 4.0f * pageExtent)
-		: gl::vec2(labelWidth + 4.0f * pageExtent, headerHeight + 4.0f * slotExtent + 3.0f * gap);
-	ImGui::Dummy(size); // reserve the space, the grid itself is positioned absolutely
-
-	auto gridLeft = origin.x + labelWidth;
-	auto gridTop = origin.y + headerHeight;
-
-	// Position along the page axis of the strip covering pages 'lo'..'hi'.
-	auto pagePos = [&](int page) {
-		return vertical ? gridTop + float(3 - page) * pageExtent
-		                : gridLeft + float(page) * pageExtent;
-	};
-	auto pageSpan = [&](int lo, int hi) {
-		return vertical ? std::pair{pagePos(hi), pagePos(lo) + pageExtent}
-		                : std::pair{pagePos(lo), pagePos(hi) + pageExtent};
-	};
-	auto makeRect = [&](float slotPos, float slotSize, std::pair<float, float> page) {
-		return vertical
-			? std::pair{gl::vec2(slotPos, page.first), gl::vec2(slotPos + slotSize, page.second)}
-			: std::pair{gl::vec2(page.first, slotPos), gl::vec2(page.second, slotPos + slotSize)};
-	};
-
-	// Title of the strip along the top, and the one for the strip on the left.
-	drawCentered(vertical ? "Slot"sv : "Page"sv,
-	             gl::vec2(gridLeft, origin.y),
-	             gl::vec2(origin.x + size.x, origin.y + rowHeight));
-	drawCentered(vertical ? "Page"sv : "Slot"sv,
-	             gl::vec2(origin.x, origin.y + rowHeight),
-	             gl::vec2(gridLeft, gridTop));
-
-	// Page numbers, on the left when vertical, on top when horizontal. The
-	// address range is a tooltip in both.
-	for (auto page : xrange(4)) {
-		auto [min, max] = vertical
-			? std::pair{gl::vec2(origin.x, pagePos(page)),
-			            gl::vec2(gridLeft, pagePos(page) + pageExtent)}
-			: std::pair{gl::vec2(pagePos(page), origin.y + rowHeight),
-			            gl::vec2(pagePos(page) + pageExtent, gridTop)};
-		drawCentered(strCat(page), min, max);
-		auto begin = PAGE_SIZE * unsigned(page);
-		cellToolTip(tmpStrCat("##page", page).c_str(), min, max,
-		            tmpStrCat(hex_string<4, HexCase::upper>(begin), '-',
-		                      hex_string<4, HexCase::upper>(begin + PAGE_SIZE - 1)));
-	}
-
-	for (auto ps : xrange(4)) {
-		bool expanded = ctx.cpuInterface.isExpanded(ps);
-		int numSlots = expanded ? 4 : 1;
-		auto slotSize = slotExtent / float(numSlots);
-		auto blockPos = (vertical ? gridLeft : gridTop) + float(ps) * (slotExtent + gap);
-
-		for (auto sub : xrange(numSlots)) {
-			int ss = expanded ? sub : 0;
-			auto slotPos = blockPos + float(sub) * slotSize;
-			auto cartridge = getCartridgeLetter(ctx.slotManager, ps, ss);
-
-			auto label = expanded ? strCat(ps, '-', ss) : strCat(ps);
-			if (cartridge) strAppend(label, " (cart ", *cartridge, ')');
-			auto [labelMin, labelMax] = vertical
-				? std::pair{gl::vec2(slotPos, origin.y + rowHeight),
-				            gl::vec2(slotPos + slotSize, gridTop)}
-				: std::pair{gl::vec2(origin.x, slotPos),
-				            gl::vec2(gridLeft, slotPos + slotSize)};
-			drawCentered(label, labelMin, labelMax);
-
-			// Pages covered by a single device can be merged with the next
-			// one; pages holding more than one device are drawn on their own.
-			std::array<const MSXDevice*, 4> device = {};
-			std::array<bool, 4> split = {};
-			for (auto page : xrange(4)) {
-				getSegments(ctx.segments, ctx.cpuInterface, ctx.dummyDevice, ps, ss, page);
-				if (ctx.segments.empty()) {
-					device[page] = nullptr; // whole page empty
-				} else if ((ctx.segments.size() == 1) &&
-				           (ctx.segments[0].begin == 0) &&
-				           (ctx.segments[0].end == PAGE_SIZE)) {
-					device[page] = ctx.segments[0].device;
-				} else {
-					split[page] = true;
-				}
-			}
-			int page = 0;
-			while (page < 4) {
-				if (split[page]) {
-					auto [min, max] = makeRect(slotPos, slotSize, pageSpan(page, page));
-					drawSplitPage(ctx, ps, ss, page, bool(cartridge), min, max, vertical);
-					++page;
-					continue;
-				}
-				int last = page;
-				while ((last + 1 < 4) && !split[last + 1] &&
-				       (device[last + 1] == device[page])) {
-					++last;
-				}
-				auto [min, max] = makeRect(slotPos, slotSize, pageSpan(page, last));
-				drawCell(ctx, min, max, device[page], bool(cartridge));
-				page = last + 1;
-			}
-		}
-	}
-	flushOutlines(ctx);
-	ImGui::SetCursorScreenPos(origin + gl::vec2(0.0f, size.y + style.ItemSpacing.y));
-}
-
-static void drawLegend(const char* text, ImU32 color)
-{
-	auto size = ImGui::GetFontSize();
-	ImGui::ColorButton(text, ImGui::ColorConvertU32ToFloat4(color),
-	                   ImGuiColorEditFlags_NoTooltip | ImGuiColorEditFlags_NoDragDrop,
-	                   {size, size});
-	ImGui::SameLine();
-	ImGui::TextDisabledUnformatted(text);
+	ctx.tinyBlocks.clear();
 }
 
 void ImGuiSlotMap::paint(MSXMotherBoard* motherBoard)
@@ -397,8 +421,8 @@ void ImGuiSlotMap::paint(MSXMotherBoard* motherBoard)
 	if (!motherBoard) return;
 
 	auto& cpuInterface = motherBoard->getCPUInterface();
-	const auto& style = ImGui::GetStyle();
 	DrawContext ctx{
+		.manager = manager,
 		.cpuInterface = cpuInterface,
 		.slotManager = motherBoard->getSlotManager(),
 		.dummyDevice = &cpuInterface.getDummyDevice(),
@@ -407,41 +431,21 @@ void ImGuiSlotMap::paint(MSXMotherBoard* motherBoard)
 		.occupiedColor = ImGui::GetColorU32(ImGuiCol_Header),
 		.externalColor = getColor(imColor::YELLOW_BG),
 		.outlineColor = ImGui::GetColorU32(ImGuiCol_Text),
-		.rowHeight = ImGui::GetTextLineHeight() + 2.0f * style.CellPadding.y,
+		.textColor = ImGui::GetColorU32(ImGuiCol_Text),
+		.dimTextColor = ImGui::GetColorU32(ImGuiCol_TextDisabled),
+		.mouse = gl::vec2(ImGui::GetIO().MousePos),
 	};
-	ctx.outlines.reserve(16);
+	ctx.outlines.reserve(32);
 
 	auto fontSize = ImGui::GetFontSize();
-	if (fitToContent) {
-		// The two layouts have a very different shape, so after switching,
-		// resize the window to whatever the new one needs (0 == auto-fit).
-		fitToContent = false;
-		ImGui::SetNextWindowSize(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
-	} else {
-		// Only the width is elastic, the height follows from the layout, so
-		// let it auto-fit rather than guessing a value that's wrong for one
-		// of the two layouts.
-		ImGui::SetNextWindowSize(ImVec2(64.0f * fontSize, 0.0f), ImGuiCond_FirstUseEver);
-	}
+	ImGui::SetNextWindowSize(ImVec2(64.0f * fontSize, 26.0f * fontSize), ImGuiCond_FirstUseEver);
 	im::Window("Slot map", &show, [&]{
 		ctx.drawList = ImGui::GetWindowDrawList();
-		drawGrid(ctx, vertical);
+		drawSlotMap(ctx);
 
-		int index = vertical ? 0 : 1;
-		ImGui::SetNextItemWidth(ImGui::CalcTextSize("Horizontal"sv).x +
-		                        ImGui::GetFrameHeight() + 2.0f * style.FramePadding.x);
-		if (ImGui::Combo("Layout", &index, "Vertical\0Horizontal\0")) {
-			vertical = (index == 0);
-			fitToContent = true;
+		if (ctx.hovered.valid && ImGui::IsWindowHovered()) {
+			drawDeviceToolTip(ctx);
 		}
-		ImGui::SameLine();
-		ImGui::Spacing();
-		ImGui::SameLine();
-		drawLegend("empty", ctx.emptyColor);
-		ImGui::SameLine();
-		drawLegend("device", ctx.occupiedColor);
-		ImGui::SameLine();
-		drawLegend("external cartridge", ctx.externalColor);
 	});
 }
 

--- a/src/imgui/ImGuiSlotMap.cc
+++ b/src/imgui/ImGuiSlotMap.cc
@@ -43,22 +43,6 @@ void ImGuiSlotMap::loadLine(std::string_view name, zstring_view value)
 	loadOnePersistent(name, value, *this, persistentElements);
 }
 
-// The external cartridge slot at (ps, ss), if any.
-// 'ss' must already be normalized: 0 for a non-expanded primary slot.
-[[nodiscard]] static std::optional<unsigned> findCartridgeSlot(
-	const CartridgeSlotManager& slotManager, int ps, int ss)
-{
-	for (auto slot : xrange(CartridgeSlotManager::MAX_SLOTS)) {
-		if (!slotManager.slotExists(slot)) continue;
-		auto [slotPs, slotSs] = slotManager.getPsSs(slot);
-		if (slotSs == -1) slotSs = 0; // not expanded
-		if ((slotPs == ps) && (slotSs == ss)) {
-			return slot;
-		}
-	}
-	return {};
-}
-
 // A continuous address range in one slot, covered by a single device.
 // 'device' is nullptr for the parts where nothing is mapped.
 struct Block {
@@ -205,7 +189,7 @@ static constexpr float MIN_BLOCK_HEIGHT = 4.0f;
 static void drawSlot(DrawContext& ctx, int ps, int ss, bool expanded,
                      float x0, float x1, float headerTop, float top, float bottom)
 {
-	auto cartridge = findCartridgeSlot(ctx.slotManager, ps, ss);
+	auto cartridge = ctx.slotManager.findSlot(ps, ss, true);
 	auto labelHeight = 0.5f * (top - headerTop);
 	drawText(ctx.drawList, expanded ? strCat(ps, '-', ss) : strCat(ps),
 	         gl::vec2(x0, headerTop), gl::vec2(x1, headerTop + labelHeight), ctx.textColor);

--- a/src/imgui/ImGuiSlotMap.cc
+++ b/src/imgui/ImGuiSlotMap.cc
@@ -6,6 +6,8 @@
 #include "ImGuiUtils.hh"
 
 #include "CartridgeSlotManager.hh"
+#include "Debuggable.hh"
+#include "Debugger.hh"
 #include "DummyDevice.hh"
 #include "MSXCPUInterface.hh"
 #include "MSXDevice.hh"
@@ -14,17 +16,16 @@
 #include "TclObject.hh"
 
 #include "gl_vec.hh"
+#include "static_vector.hh"
 #include "strCat.hh"
 #include "xrange.hh"
 
 #include <imgui.h>
 
 #include <algorithm>
-#include <array>
 #include <optional>
 #include <ranges>
-#include <span>
-#include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -51,49 +52,6 @@ struct Block {
 	const MSXDevice* device;
 };
 
-// Split the address space of one slot into blocks. MSXCPUInterface stores a
-// device per 16kB page, and wraps devices that cover less than a page in an
-// MSXMultiMemDevice, which knows the exact address ranges. Recombining both
-// gives the real extent of every device, so that nothing here has to care
-// about page boundaries.
-static void getBlocks(std::vector<Block>& result, std::vector<Block>& scratch,
-                      MSXCPUInterface& cpuInterface, const MSXDevice* dummyDevice,
-                      int ps, int ss)
-{
-	scratch.clear();
-	for (auto page : xrange(4)) {
-		auto pageBegin = PAGE_SIZE * unsigned(page);
-		const auto* device = cpuInterface.getMSXDevice(ps, ss, page);
-		if (!device || (device == dummyDevice)) continue;
-		if (const auto* multi = dynamic_cast<const MSXMultiMemDevice*>(device)) {
-			for (const auto& range : multi->getRanges()) {
-				auto begin = std::max(range.base, pageBegin);
-				auto end = std::min(range.base + range.size, pageBegin + PAGE_SIZE);
-				if (begin < end) scratch.emplace_back(begin, end, range.device);
-			}
-		} else {
-			scratch.emplace_back(pageBegin, pageBegin + PAGE_SIZE, device);
-		}
-	}
-	std::ranges::sort(scratch, {}, &Block::begin);
-
-	// Glue the pieces of a device that spans page boundaries back together,
-	// and fill what's left with 'empty' blocks.
-	result.clear();
-	unsigned pos = 0;
-	for (const auto& block : scratch) {
-		if (!result.empty() && (result.back().device == block.device) &&
-		    (result.back().end == block.begin)) {
-			result.back().end = block.end;
-		} else {
-			if (pos < block.begin) result.emplace_back(pos, block.begin, nullptr);
-			result.emplace_back(block.begin, block.end, block.device);
-		}
-		pos = block.end;
-	}
-	if (pos < ADDRESS_SPACE) result.emplace_back(pos, ADDRESS_SPACE, nullptr);
-}
-
 // Draw 'text' centered in the rectangle, wrapped over as many lines as fit.
 // Falls back to a single clipped line, and to nothing at all when even that
 // doesn't fit - the tooltip is what makes those cells readable.
@@ -117,22 +75,21 @@ static void drawText(ImDrawList* drawList, std::string_view text,
 	// fit' and fall back to clipping.
 	auto* font = ImGui::GetFont();
 	auto fontSize = ImGui::GetFontSize();
-	std::array<std::string_view, 16> lines;
-	size_t numLines = 0;
+	static_vector<std::string_view, 16> lines;
 	bool wrapped = true;
 	const char* pos = text.data();
 	const char* end = pos + text.size();
 	while (pos < end) {
-		if (numLines == lines.size()) { wrapped = false; break; }
+		if (lines.size() == lines.max_size()) { wrapped = false; break; }
 		const char* stop = font->CalcWordWrapPosition(fontSize, pos, end, width);
 		if ((stop == pos) || ((stop != end) && (*stop != ' '))) { wrapped = false; break; }
-		lines[numLines++] = std::string_view(pos, size_t(stop - pos));
+		lines.push_back(std::string_view(pos, size_t(stop - pos)));
 		pos = stop;
 		while ((pos < end) && (*pos == ' ')) ++pos; // eat the wrap point
 	}
-	if (wrapped && (numLines != 0) && (float(numLines) * lineHeight <= height)) {
-		auto y = min.y + 0.5f * ((max.y - min.y) - float(numLines) * lineHeight);
-		for (auto line : std::span(lines).first(numLines)) {
+	if (wrapped && !lines.empty() && (float(lines.size()) * lineHeight <= height)) {
+		auto y = min.y + 0.5f * ((max.y - min.y) - float(lines.size()) * lineHeight);
+		for (auto line : lines) {
 			draw(line, y);
 			y += lineHeight;
 		}
@@ -163,6 +120,7 @@ struct DrawContext {
 	ImGuiManager& manager;
 	MSXCPUInterface& cpuInterface;
 	const CartridgeSlotManager& slotManager;
+	Debugger& debugger;
 	const MSXDevice* dummyDevice;
 	ImDrawList* drawList;
 	ImU32 emptyColor;
@@ -173,11 +131,60 @@ struct DrawContext {
 	ImU32 dimTextColor;
 	gl::vec2 mouse;
 	HoveredBlock hovered;
-	std::vector<std::pair<gl::vec2, gl::vec2>> outlines;
+	std::vector<std::pair<gl::vec2, gl::vec2>> outlines;   // one per primary slot
+	std::vector<std::pair<gl::vec2, gl::vec2>> separators; // between the blocks
 	std::vector<TinyBlock> tinyBlocks;
 	std::vector<Block> blocks;
 	std::vector<Block> scratch;
 };
+}
+
+// Split the address space of one slot into blocks, in 'ctx.blocks'.
+// MSXCPUInterface stores a device per 16kB page, and wraps devices that cover
+// less than a page in an MSXMultiMemDevice, which knows the exact address
+// ranges. Recombining both gives the real extent of every device, so that
+// nothing here has to care about page boundaries.
+// Note: 'ctx.blocks' and 'ctx.scratch' are members rather than local variables
+//       so that this (called up to 16 times per frame) doesn't allocate.
+static void getBlocks(DrawContext& ctx, int ps, int ss)
+{
+	auto& scratch = ctx.scratch;
+	scratch.clear();
+	for (auto page : xrange(4)) {
+		auto pageBegin = PAGE_SIZE * unsigned(page);
+		const auto* device = ctx.cpuInterface.getMSXDevice(ps, ss, page);
+		if (!device || (device == ctx.dummyDevice)) continue;
+		if (const auto* multi = dynamic_cast<const MSXMultiMemDevice*>(device)) {
+			// Only these sub-ranges can be out of order: the pages themselves
+			// are visited in increasing order, so sorting per page is enough.
+			auto first = scratch.size();
+			for (const auto& range : multi->getRanges()) {
+				auto begin = std::max(range.base, pageBegin);
+				auto end = std::min(range.base + range.size, pageBegin + PAGE_SIZE);
+				if (begin < end) scratch.emplace_back(begin, end, range.device);
+			}
+			std::ranges::sort(scratch.begin() + first, scratch.end(), {}, &Block::begin);
+		} else {
+			scratch.emplace_back(pageBegin, pageBegin + PAGE_SIZE, device);
+		}
+	}
+
+	// Glue the pieces of a device that spans page boundaries back together,
+	// and fill what's left with 'empty' blocks.
+	auto& result = ctx.blocks;
+	result.clear();
+	unsigned pos = 0;
+	for (const auto& block : scratch) {
+		if (!result.empty() && (result.back().device == block.device) &&
+		    (result.back().end == block.begin)) {
+			result.back().end = block.end;
+		} else {
+			if (pos < block.begin) result.emplace_back(pos, block.begin, nullptr);
+			result.emplace_back(block.begin, block.end, block.device);
+		}
+		pos = block.end;
+	}
+	if (pos < ADDRESS_SPACE) result.emplace_back(pos, ADDRESS_SPACE, nullptr);
 }
 
 // Below this a block can't be seen, let alone hovered. A single byte is a
@@ -203,7 +210,7 @@ static void drawSlot(DrawContext& ctx, int ps, int ss, bool expanded,
 		return bottom - height * (float(address) * (1.0f / float(ADDRESS_SPACE)));
 	};
 
-	getBlocks(ctx.blocks, ctx.scratch, ctx.cpuInterface, ctx.dummyDevice, ps, ss);
+	getBlocks(ctx, ps, ss);
 	// Blocks come in increasing address order, so downwards on screen. Keeps
 	// enlarged blocks from covering each other.
 	auto lowestEnlarged = bottom;
@@ -232,7 +239,12 @@ static void drawSlot(DrawContext& ctx, int ps, int ss, bool expanded,
 			gl::vec2 min{x0, blockTop};
 			gl::vec2 max{x1, blockBottom};
 			ctx.drawList->AddRectFilled(min, max, color);
-			ctx.outlines.emplace_back(min, max);
+			// Only the line towards the next block: the outer edges belong to
+			// the outline of the slot as a whole. Drawing a rectangle per block
+			// would draw every shared edge twice.
+			if (block.end != ADDRESS_SPACE) {
+				ctx.separators.emplace_back(min, gl::vec2(x1, blockTop));
+			}
 			drawText(ctx.drawList, block.device ? std::string_view(block.device->getName())
 			                                    : "empty"sv,
 			         min, max, ctx.textColor);
@@ -279,22 +291,23 @@ static void drawDeviceToolTip(DrawContext& ctx)
 			                                      : strCat(size / 1024, "kB"));
 			if (!block.device) return;
 
-			const auto& name = block.device->getName();
 			// Whatever the device wants to tell about itself, e.g. the mapper
-			// type of a ROM or the file it was loaded from.
-			if (auto info = ctx.manager.execute(makeTclList("machine_info", "device", name))) {
-				for (size_t i = 0; (i + 1) < info->size(); i += 2) {
-					auto key = info->getListIndexUnchecked(i).getString();
-					auto value = info->getListIndexUnchecked(i + 1).getString();
-					if (value.empty()) continue;
-					ImGui::StrCat(key, ": ", value);
-				}
+			// type of a ROM or the file it was loaded from. Ask the device
+			// directly instead of going through the 'machine_info device'
+			// command: we already have the MSXDevice here.
+			TclObject info;
+			block.device->getDeviceInfo(info);
+			for (size_t i = 0; (i + 1) < info.size(); i += 2) {
+				auto key = info.getListIndexUnchecked(i).getString();
+				auto value = info.getListIndexUnchecked(i + 1).getString();
+				if (value.empty()) continue;
+				ImGui::StrCat(key, ": ", value);
 			}
 			// Devices with a debuggable of the same name (memory mappers, RAM)
 			// can also tell how much memory they actually have.
-			if (auto total = ctx.manager.execute(makeTclList("debug", "size", name))) {
-				if (auto bytes = total->getOptionalInt(); bytes && (*bytes > 0)) {
-					ImGui::StrCat("total memory: ", *bytes / 1024, "kB");
+			if (const auto* debuggable = ctx.debugger.findDebuggable(block.device->getName())) {
+				if (auto bytes = debuggable->getSize(); bytes != 0) {
+					ImGui::StrCat("total memory: ", bytes / 1024, "kB");
 				}
 			}
 		});
@@ -375,10 +388,17 @@ static void drawSlotMap(DrawContext& ctx)
 				for (auto ss : xrange(4)) {
 					auto x0 = x + float(ss) * width;
 					drawSlot(ctx, ps, ss, true, x0, x0 + width, headerTop, top, bottom);
+					// Between the sub-slots only, the outer edges are part
+					// of the outline of the primary slot.
+					if (ss != 0) {
+						ctx.separators.emplace_back(gl::vec2(x0, top),
+						                            gl::vec2(x0, bottom));
+					}
 				}
 			} else {
 				drawSlot(ctx, ps, 0, false, x, x + slotWidth, headerTop, top, bottom);
 			}
+			ctx.outlines.emplace_back(gl::vec2(x, top), gl::vec2(x + slotWidth, bottom));
 			x += slotWidth + gapX;
 		}
 	}
@@ -386,6 +406,12 @@ static void drawSlotMap(DrawContext& ctx)
 	// Outlines in one go, after all the fills, so that the fill of one block
 	// can't paint over the outline of the block next to it. This is also what
 	// keeps a device that is too small to see as a rectangle visible as a line.
+	// Each edge is drawn exactly once, otherwise the shared ones would come out
+	// twice as thick as the rest.
+	for (const auto& [p1, p2] : ctx.separators) {
+		ctx.drawList->AddLine(p1, p2, ctx.outlineColor);
+	}
+	ctx.separators.clear();
 	for (const auto& [min, max] : ctx.outlines) {
 		ctx.drawList->AddRect(min, max, ctx.outlineColor);
 	}
@@ -410,6 +436,7 @@ void ImGuiSlotMap::paint(MSXMotherBoard* motherBoard)
 		.manager = manager,
 		.cpuInterface = cpuInterface,
 		.slotManager = motherBoard->getSlotManager(),
+		.debugger = motherBoard->getDebugger(),
 		.dummyDevice = &cpuInterface.getDummyDevice(),
 		.drawList = nullptr, // only valid inside the window
 		.emptyColor = ImGui::GetColorU32(getColor(imColor::GRAY), 0.4f),
@@ -420,7 +447,8 @@ void ImGuiSlotMap::paint(MSXMotherBoard* motherBoard)
 		.dimTextColor = ImGui::GetColorU32(ImGuiCol_TextDisabled),
 		.mouse = gl::vec2(ImGui::GetIO().MousePos),
 	};
-	ctx.outlines.reserve(32);
+	ctx.outlines.reserve(4);
+	ctx.separators.reserve(64);
 
 	auto fontSize = ImGui::GetFontSize();
 	ImGui::SetNextWindowSize(ImVec2(64.0f * fontSize, 26.0f * fontSize), ImGuiCond_FirstUseEver);

--- a/src/imgui/ImGuiSlotMap.cc
+++ b/src/imgui/ImGuiSlotMap.cc
@@ -1,0 +1,448 @@
+#include "ImGuiSlotMap.hh"
+
+#include "ImGuiCpp.hh"
+#include "ImGuiUtils.hh"
+
+#include "CartridgeSlotManager.hh"
+#include "DummyDevice.hh"
+#include "MSXCPUInterface.hh"
+#include "MSXDevice.hh"
+#include "MSXMotherBoard.hh"
+#include "MSXMultiMemDevice.hh"
+
+#include "gl_vec.hh"
+#include "strCat.hh"
+#include "xrange.hh"
+
+#include <imgui.h>
+
+#include <algorithm>
+#include <array>
+#include <optional>
+#include <ranges>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace openmsx {
+
+static constexpr unsigned PAGE_SIZE = 0x4000;
+
+void ImGuiSlotMap::save(ImGuiTextBuffer& buf)
+{
+	savePersistent(buf, *this, persistentElements);
+	buf.appendf("layout=%s\n", vertical ? "vertical" : "horizontal");
+}
+
+void ImGuiSlotMap::loadLine(std::string_view name, zstring_view value)
+{
+	if (loadOnePersistent(name, value, *this, persistentElements)) {
+		// already handled
+	} else if (name == "layout") {
+		// anything else keeps the default
+		if (value == "vertical") {
+			vertical = true;
+		} else if (value == "horizontal") {
+			vertical = false;
+		}
+	}
+}
+
+// The letter of the external cartridge slot at (ps, ss), if any.
+// 'ss' must already be normalized: 0 for a non-expanded primary slot.
+[[nodiscard]] static std::optional<char> getCartridgeLetter(
+	const CartridgeSlotManager& slotManager, int ps, int ss)
+{
+	for (auto slot : xrange(CartridgeSlotManager::MAX_SLOTS)) {
+		if (!slotManager.slotExists(slot)) continue;
+		auto [slotPs, slotSs] = slotManager.getPsSs(slot);
+		if (slotSs == -1) slotSs = 0; // not expanded
+		if ((slotPs == ps) && (slotSs == ss)) {
+			return char('A' + slot);
+		}
+	}
+	return {};
+}
+
+// The part of one 16kB page that is covered by a single device, as offsets
+// relative to the start of that page.
+struct Segment {
+	unsigned begin;
+	unsigned end;
+	const MSXDevice* device;
+};
+
+// A device that covers a whole page is registered directly, a device that
+// covers less than a page is wrapped in an MSXMultiMemDevice, which knows the
+// exact address ranges. Result is sorted; gaps are left to the caller.
+static void getSegments(std::vector<Segment>& result, MSXCPUInterface& cpuInterface,
+                        const MSXDevice* dummyDevice, int ps, int ss, int page)
+{
+	result.clear();
+	const auto* device = cpuInterface.getMSXDevice(ps, ss, page);
+	if (!device || (device == dummyDevice)) return; // nothing in this page
+
+	const auto* multi = dynamic_cast<const MSXMultiMemDevice*>(device);
+	if (!multi) {
+		result.emplace_back(0u, PAGE_SIZE, device);
+		return;
+	}
+	auto pageBegin = PAGE_SIZE * unsigned(page);
+	for (const auto& range : multi->getRanges()) {
+		auto begin = std::max(range.base, pageBegin);
+		auto end = std::min(range.base + range.size, pageBegin + PAGE_SIZE);
+		if (begin < end) {
+			result.emplace_back(begin - pageBegin, end - pageBegin, range.device);
+		}
+	}
+	std::ranges::sort(result, {}, &Segment::begin);
+}
+
+// Mirror of ImGuiUtils' leftClip(): keep the start of the string and replace
+// the part that doesn't fit with an ellipsis.
+[[nodiscard]] static std::string rightClip(std::string_view s, float maxWidth)
+{
+	maxWidth -= ImGui::CalcTextSize("..."sv).x;
+	if (maxWidth <= 0.0f) return "...";
+
+	// The first length that is too wide, minus one, is the longest prefix that
+	// still fits. Length 0 always fits, so that first length is never 0.
+	auto lengths = std::views::iota(0uz, s.size() + 1);
+	auto it = std::ranges::upper_bound(lengths, maxWidth, {},
+		[&](size_t n) { return ImGui::CalcTextSize(s.substr(0, n)).x; });
+	auto num = (it == lengths.end()) ? s.size() : (*it - 1);
+	return strCat(s.substr(0, num), "...");
+}
+
+// Try to draw 'text' as a block of centered lines, wrapped at word boundaries,
+// in the rectangle [min, max). Returns false when it doesn't fit; a tall cell
+// (a device covering several pages) can hold a lot more than a single line.
+[[nodiscard]] static bool drawWrapped(std::string_view text, gl::vec2 min, gl::vec2 max)
+{
+	const auto& style = ImGui::GetStyle();
+	auto width = (max.x - min.x) - 2.0f * style.CellPadding.x;
+	auto height = (max.y - min.y) - 2.0f * style.CellPadding.y;
+	auto lineHeight = ImGui::GetTextLineHeight();
+	if ((width <= 0.0f) || (height < lineHeight)) return false;
+
+	auto* font = ImGui::GetFont();
+	auto fontSize = ImGui::GetFontSize();
+	std::array<std::string_view, 8> lines; // a cell is at most 8 lines high
+	size_t numLines = 0;
+
+	const char* pos = text.data();
+	const char* end = pos + text.size();
+	while (pos < end) {
+		if (numLines == lines.size()) return false;
+		const char* stop = font->CalcWordWrapPosition(fontSize, pos, end, width);
+		// ImGui breaks mid-word when a word is wider than the cell; that reads
+		// as garbage in a diagram, so rather fall back to a clipped single line.
+		if ((stop == pos) || ((stop != end) && (*stop != ' '))) return false;
+		lines[numLines++] = std::string_view(pos, size_t(stop - pos));
+		pos = stop;
+		while ((pos < end) && (*pos == ' ')) ++pos; // eat the wrap point
+	}
+	if ((numLines == 0) || (float(numLines) * lineHeight > height)) return false;
+
+	auto y = min.y + 0.5f * ((max.y - min.y) - float(numLines) * lineHeight);
+	for (auto line : std::span(lines).first(numLines)) {
+		auto lineWidth = ImGui::CalcTextSize(line).x;
+		ImGui::SetCursorScreenPos(gl::vec2(min.x + 0.5f * ((max.x - min.x) - lineWidth), y));
+		ImGui::TextUnformatted(line);
+		y += lineHeight;
+	}
+	return true;
+}
+
+// Make a whole cell hoverable, so a short label can still explain itself.
+static void cellToolTip(const char* id, gl::vec2 min, gl::vec2 max, std::string_view text)
+{
+	ImGui::SetCursorScreenPos(min);
+	ImGui::InvisibleButton(id, max - min);
+	simpleToolTip(text);
+}
+
+static void drawCentered(std::string_view text, gl::vec2 min, gl::vec2 max)
+{
+	if (drawWrapped(text, min, max)) return;
+
+	// Doesn't fit, not even wrapped: clip to one line, full text on hover.
+	const auto& style = ImGui::GetStyle();
+	auto avail = (max.x - min.x) - 2.0f * style.CellPadding.x;
+	auto y = min.y + 0.5f * ((max.y - min.y) - ImGui::GetTextLineHeight());
+	ImGui::SetCursorScreenPos(gl::vec2(min.x + style.CellPadding.x, y));
+	ImGui::TextUnformatted(rightClip(text, avail));
+	simpleToolTip(text);
+}
+
+// Everything the grid needs. Cells are filled and outlined with the draw list
+// rather than with a table, because a device can cover several pages (one
+// merged cell) or just a part of one page.
+namespace {
+struct DrawContext {
+	MSXCPUInterface& cpuInterface;
+	const CartridgeSlotManager& slotManager;
+	const MSXDevice* dummyDevice;
+	ImDrawList* drawList;
+	ImU32 emptyColor;
+	ImU32 occupiedColor;
+	ImU32 externalColor;
+	ImU32 outlineColor;
+	float rowHeight; // one line of text plus padding
+	std::vector<std::pair<gl::vec2, gl::vec2>> outlines;
+	std::vector<Segment> segments; // reused for every cell
+};
+}
+
+static void drawCell(DrawContext& ctx, gl::vec2 min, gl::vec2 max,
+                     const MSXDevice* device, bool cartridge)
+{
+	ctx.drawList->AddRectFilled(min, max,
+		!device ? ctx.emptyColor : (cartridge ? ctx.externalColor : ctx.occupiedColor));
+	ctx.outlines.emplace_back(min, max);
+	drawCentered(device ? std::string_view(device->getName()) : "empty"sv, min, max);
+}
+
+// Outlines are drawn in one go, after all the fills, so that the fill of one
+// cell can't paint over the outline of the cell next to it.
+static void flushOutlines(DrawContext& ctx)
+{
+	for (const auto& [min, max] : ctx.outlines) {
+		ctx.drawList->AddRect(min, max, ctx.outlineColor);
+	}
+	ctx.outlines.clear();
+}
+
+// One page that holds more than one device. Addresses run to the right in the
+// horizontal layout and upwards in the vertical one, so that's also how the
+// cell is split.
+static void drawSplitPage(DrawContext& ctx, int ps, int ss, int page, bool cartridge,
+                          gl::vec2 min, gl::vec2 max, bool vertical)
+{
+	auto drawSegment = [&](unsigned begin, unsigned end, const MSXDevice* device) {
+		gl::vec2 segMin = min;
+		gl::vec2 segMax = max;
+		if (vertical) {
+			auto scale = (max.y - min.y) * (1.0f / float(PAGE_SIZE));
+			segMin.y = max.y - scale * float(end);
+			segMax.y = max.y - scale * float(begin);
+		} else {
+			auto scale = (max.x - min.x) * (1.0f / float(PAGE_SIZE));
+			segMin.x = min.x + scale * float(begin);
+			segMax.x = min.x + scale * float(end);
+		}
+		drawCell(ctx, segMin, segMax, device, cartridge);
+	};
+
+	getSegments(ctx.segments, ctx.cpuInterface, ctx.dummyDevice, ps, ss, page);
+	unsigned pos = 0;
+	for (const auto& segment : ctx.segments) {
+		if (pos < segment.begin) drawSegment(pos, segment.begin, nullptr);
+		drawSegment(segment.begin, segment.end, segment.device);
+		pos = segment.end;
+	}
+	if (pos < PAGE_SIZE) drawSegment(pos, PAGE_SIZE, nullptr);
+}
+
+// The grid, in either orientation. Horizontal has slots as rows and pages as
+// columns; vertical is the transpose, with the highest address on top, like
+// the memory maps in the MSX wiki and in most manuals.
+//
+// Both are laid out by hand instead of with a table, because a device covering
+// several pages is drawn as one merged cell.
+static void drawGrid(DrawContext& ctx, bool vertical)
+{
+	const auto& style = ImGui::GetStyle();
+	auto rowHeight = ctx.rowHeight;
+	// Gap between the 4 primary slots, along the slot axis.
+	auto gap = style.ItemSpacing.x;
+	// Widest label of the strip on the left.
+	auto labelWidth = ImGui::CalcTextSize(vertical ? "Page"sv : "0-0 (cart A)"sv).x
+	                + 2.0f * style.CellPadding.x;
+	// One row with the title of each strip, one with the numbers.
+	auto headerHeight = 2.0f * rowHeight;
+
+	auto origin = gl::vec2(ImGui::GetCursorScreenPos());
+	auto avail = ImGui::GetContentRegionAvail().x;
+
+	// A non-expanded slot gets the same space as 4 sub-slots, so that the
+	// layout is the same for every machine.
+	float slotExtent = 4.0f * rowHeight; // one primary slot, along the slot axis
+	float pageExtent = 0.0f;             // one page, along the page axis
+	if (vertical) {
+		slotExtent = std::max(slotExtent, 0.25f * (avail - labelWidth - 3.0f * gap));
+		pageExtent = 2.0f * rowHeight; // room to split a page and still fit text
+	} else {
+		pageExtent = std::max(6.0f * rowHeight, 0.25f * (avail - labelWidth));
+	}
+	gl::vec2 size = vertical
+		? gl::vec2(labelWidth + 4.0f * slotExtent + 3.0f * gap, headerHeight + 4.0f * pageExtent)
+		: gl::vec2(labelWidth + 4.0f * pageExtent, headerHeight + 4.0f * slotExtent + 3.0f * gap);
+	ImGui::Dummy(size); // reserve the space, the grid itself is positioned absolutely
+
+	auto gridLeft = origin.x + labelWidth;
+	auto gridTop = origin.y + headerHeight;
+
+	// Position along the page axis of the strip covering pages 'lo'..'hi'.
+	auto pagePos = [&](int page) {
+		return vertical ? gridTop + float(3 - page) * pageExtent
+		                : gridLeft + float(page) * pageExtent;
+	};
+	auto pageSpan = [&](int lo, int hi) {
+		return vertical ? std::pair{pagePos(hi), pagePos(lo) + pageExtent}
+		                : std::pair{pagePos(lo), pagePos(hi) + pageExtent};
+	};
+	auto makeRect = [&](float slotPos, float slotSize, std::pair<float, float> page) {
+		return vertical
+			? std::pair{gl::vec2(slotPos, page.first), gl::vec2(slotPos + slotSize, page.second)}
+			: std::pair{gl::vec2(page.first, slotPos), gl::vec2(page.second, slotPos + slotSize)};
+	};
+
+	// Title of the strip along the top, and the one for the strip on the left.
+	drawCentered(vertical ? "Slot"sv : "Page"sv,
+	             gl::vec2(gridLeft, origin.y),
+	             gl::vec2(origin.x + size.x, origin.y + rowHeight));
+	drawCentered(vertical ? "Page"sv : "Slot"sv,
+	             gl::vec2(origin.x, origin.y + rowHeight),
+	             gl::vec2(gridLeft, gridTop));
+
+	// Page numbers, on the left when vertical, on top when horizontal. The
+	// address range is a tooltip in both.
+	for (auto page : xrange(4)) {
+		auto [min, max] = vertical
+			? std::pair{gl::vec2(origin.x, pagePos(page)),
+			            gl::vec2(gridLeft, pagePos(page) + pageExtent)}
+			: std::pair{gl::vec2(pagePos(page), origin.y + rowHeight),
+			            gl::vec2(pagePos(page) + pageExtent, gridTop)};
+		drawCentered(strCat(page), min, max);
+		auto begin = PAGE_SIZE * unsigned(page);
+		cellToolTip(tmpStrCat("##page", page).c_str(), min, max,
+		            tmpStrCat(hex_string<4, HexCase::upper>(begin), '-',
+		                      hex_string<4, HexCase::upper>(begin + PAGE_SIZE - 1)));
+	}
+
+	for (auto ps : xrange(4)) {
+		bool expanded = ctx.cpuInterface.isExpanded(ps);
+		int numSlots = expanded ? 4 : 1;
+		auto slotSize = slotExtent / float(numSlots);
+		auto blockPos = (vertical ? gridLeft : gridTop) + float(ps) * (slotExtent + gap);
+
+		for (auto sub : xrange(numSlots)) {
+			int ss = expanded ? sub : 0;
+			auto slotPos = blockPos + float(sub) * slotSize;
+			auto cartridge = getCartridgeLetter(ctx.slotManager, ps, ss);
+
+			auto label = expanded ? strCat(ps, '-', ss) : strCat(ps);
+			if (cartridge) strAppend(label, " (cart ", *cartridge, ')');
+			auto [labelMin, labelMax] = vertical
+				? std::pair{gl::vec2(slotPos, origin.y + rowHeight),
+				            gl::vec2(slotPos + slotSize, gridTop)}
+				: std::pair{gl::vec2(origin.x, slotPos),
+				            gl::vec2(gridLeft, slotPos + slotSize)};
+			drawCentered(label, labelMin, labelMax);
+
+			// Pages covered by a single device can be merged with the next
+			// one; pages holding more than one device are drawn on their own.
+			std::array<const MSXDevice*, 4> device = {};
+			std::array<bool, 4> split = {};
+			for (auto page : xrange(4)) {
+				getSegments(ctx.segments, ctx.cpuInterface, ctx.dummyDevice, ps, ss, page);
+				if (ctx.segments.empty()) {
+					device[page] = nullptr; // whole page empty
+				} else if ((ctx.segments.size() == 1) &&
+				           (ctx.segments[0].begin == 0) &&
+				           (ctx.segments[0].end == PAGE_SIZE)) {
+					device[page] = ctx.segments[0].device;
+				} else {
+					split[page] = true;
+				}
+			}
+			int page = 0;
+			while (page < 4) {
+				if (split[page]) {
+					auto [min, max] = makeRect(slotPos, slotSize, pageSpan(page, page));
+					drawSplitPage(ctx, ps, ss, page, bool(cartridge), min, max, vertical);
+					++page;
+					continue;
+				}
+				int last = page;
+				while ((last + 1 < 4) && !split[last + 1] &&
+				       (device[last + 1] == device[page])) {
+					++last;
+				}
+				auto [min, max] = makeRect(slotPos, slotSize, pageSpan(page, last));
+				drawCell(ctx, min, max, device[page], bool(cartridge));
+				page = last + 1;
+			}
+		}
+	}
+	flushOutlines(ctx);
+	ImGui::SetCursorScreenPos(origin + gl::vec2(0.0f, size.y + style.ItemSpacing.y));
+}
+
+static void drawLegend(const char* text, ImU32 color)
+{
+	auto size = ImGui::GetFontSize();
+	ImGui::ColorButton(text, ImGui::ColorConvertU32ToFloat4(color),
+	                   ImGuiColorEditFlags_NoTooltip | ImGuiColorEditFlags_NoDragDrop,
+	                   {size, size});
+	ImGui::SameLine();
+	ImGui::TextDisabledUnformatted(text);
+}
+
+void ImGuiSlotMap::paint(MSXMotherBoard* motherBoard)
+{
+	if (!show) return;
+	if (!motherBoard) return;
+
+	auto& cpuInterface = motherBoard->getCPUInterface();
+	const auto& style = ImGui::GetStyle();
+	DrawContext ctx{
+		.cpuInterface = cpuInterface,
+		.slotManager = motherBoard->getSlotManager(),
+		.dummyDevice = &cpuInterface.getDummyDevice(),
+		.drawList = nullptr, // only valid inside the window
+		.emptyColor = ImGui::GetColorU32(getColor(imColor::GRAY), 0.4f),
+		.occupiedColor = ImGui::GetColorU32(ImGuiCol_Header),
+		.externalColor = getColor(imColor::YELLOW_BG),
+		.outlineColor = ImGui::GetColorU32(ImGuiCol_Text),
+		.rowHeight = ImGui::GetTextLineHeight() + 2.0f * style.CellPadding.y,
+	};
+	ctx.outlines.reserve(16);
+
+	auto fontSize = ImGui::GetFontSize();
+	if (fitToContent) {
+		// The two layouts have a very different shape, so after switching,
+		// resize the window to whatever the new one needs (0 == auto-fit).
+		fitToContent = false;
+		ImGui::SetNextWindowSize(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
+	} else {
+		// Only the width is elastic, the height follows from the layout, so
+		// let it auto-fit rather than guessing a value that's wrong for one
+		// of the two layouts.
+		ImGui::SetNextWindowSize(ImVec2(64.0f * fontSize, 0.0f), ImGuiCond_FirstUseEver);
+	}
+	im::Window("Slot map", &show, [&]{
+		ctx.drawList = ImGui::GetWindowDrawList();
+		drawGrid(ctx, vertical);
+
+		int index = vertical ? 0 : 1;
+		ImGui::SetNextItemWidth(ImGui::CalcTextSize("Horizontal"sv).x +
+		                        ImGui::GetFrameHeight() + 2.0f * style.FramePadding.x);
+		if (ImGui::Combo("Layout", &index, "Vertical\0Horizontal\0")) {
+			vertical = (index == 0);
+			fitToContent = true;
+		}
+		ImGui::SameLine();
+		ImGui::Spacing();
+		ImGui::SameLine();
+		drawLegend("empty", ctx.emptyColor);
+		ImGui::SameLine();
+		drawLegend("device", ctx.occupiedColor);
+		ImGui::SameLine();
+		drawLegend("external cartridge", ctx.externalColor);
+	});
+}
+
+} // namespace openmsx

--- a/src/imgui/ImGuiSlotMap.cc
+++ b/src/imgui/ImGuiSlotMap.cc
@@ -53,16 +53,14 @@ struct Block {
 };
 
 // Draw 'text' centered in the rectangle, wrapped over as many lines as fit.
-// The last line ends in an ellipsis if the text needs more lines than that.
-// Falls back to a single clipped line when a word doesn't fit on a line of its
-// own, and to nothing at all when even that doesn't fit - the tooltip is what
-// makes those cells readable.
+// The last line ends in an ellipsis if the whole text doesn't fit, and nothing
+// is drawn at all when not even an ellipsis fits - the tooltip is what makes
+// those cells readable.
 static void drawText(ImDrawList* drawList, std::string_view text,
                      gl::vec2 min, gl::vec2 max, ImU32 color)
 {
 	const auto& style = ImGui::GetStyle();
-	auto width = (max.x - min.x) - 2.0f * style.CellPadding.x;
-	auto height = (max.y - min.y) - 2.0f * style.CellPadding.y;
+	auto [width, height] = (max - min) - 2.0f * gl::vec2(style.CellPadding);
 	auto lineHeight = ImGui::GetTextLineHeight();
 	if ((height < lineHeight) || (width < ImGui::CalcTextSize("..."sv).x)) return;
 
@@ -72,33 +70,33 @@ static void drawText(ImDrawList* drawList, std::string_view text,
 		                  color, line.data(), line.data() + line.size());
 	};
 
-	// Wrap at word boundaries. ImGui breaks mid-word when a word is wider than
-	// the cell, which reads as garbage in a diagram, so treat that as 'doesn't
-	// fit' and fall back to clipping.
+	// Wrap at word boundaries for as long as that works, then put what is left
+	// on the last line, clipped. Wrapping stops for one of two reasons: there
+	// is no room for another line, or the next word doesn't fit on a line of
+	// its own. In the latter case CalcWordWrapPosition() would break inside the
+	// word, which reads as garbage in a diagram. Both cases end the same way,
+	// so a name is either fully wrapped or ends in an ellipsis.
 	auto* font = ImGui::GetFont();
 	auto fontSize = ImGui::GetFontSize();
 	static_vector<std::string_view, 16> lines;
 	auto maxLines = std::min(size_t(height / lineHeight), lines.max_size());
-	std::string_view rest; // what didn't fit, goes on the last line
-	bool wrapped = true;
+	std::string_view rest;
 	const char* pos = text.data();
 	const char* end = pos + text.size();
 	while (pos < end) {
-		if ((lines.size() + 1) == maxLines) {
-			// Nowhere left to wrap to, so the last line takes the remainder.
-			rest = std::string_view(pos, size_t(end - pos));
+		auto remainder = std::string_view(pos, size_t(end - pos));
+		if ((lines.size() + 1) == maxLines) { rest = remainder; break; }
+		const char* stop = font->CalcWordWrapPosition(fontSize, pos, end, width);
+		if ((stop == pos) ||                     // not even one word fits
+		    ((stop != end) && (*stop != ' '))) { // would break inside a word
+			rest = remainder;
 			break;
 		}
-		const char* stop = font->CalcWordWrapPosition(fontSize, pos, end, width);
-		if ((stop == pos) || ((stop != end) && (*stop != ' '))) { wrapped = false; break; }
 		lines.push_back(std::string_view(pos, size_t(stop - pos)));
 		pos = stop;
 		while ((pos < end) && (*pos == ' ')) ++pos; // eat the wrap point
 	}
-	if (!wrapped) {
-		draw(ImGui::rightClip(text, width), min.y + 0.5f * ((max.y - min.y) - lineHeight));
-		return;
-	}
+
 	auto numLines = lines.size() + (rest.empty() ? 0 : 1);
 	auto y = min.y + 0.5f * ((max.y - min.y) - float(numLines) * lineHeight);
 	for (auto line : lines) {
@@ -127,12 +125,25 @@ struct TinyBlock {
 	ImU32 color;
 };
 
+// Everything that only depends on the font and the style, so the same for the
+// whole frame.
+struct Metrics {
+	float rowHeight;
+	float headerHeight;
+	float labelWidth;
+	float minSlotWidth;
+	float minMapHeight;
+	gl::vec2 gap;
+	float overhang;
+};
+
 struct DrawContext {
 	ImGuiManager& manager;
 	MSXCPUInterface& cpuInterface;
 	const CartridgeSlotManager& slotManager;
 	Debugger& debugger;
 	const MSXDevice* dummyDevice;
+	Metrics metrics;
 	ImDrawList* drawList;
 	ImU32 emptyColor;
 	ImU32 occupiedColor;
@@ -155,8 +166,9 @@ struct DrawContext {
 // less than a page in an MSXMultiMemDevice, which knows the exact address
 // ranges. Recombining both gives the real extent of every device, so that
 // nothing here has to care about page boundaries.
-// Note: 'ctx.blocks' and 'ctx.scratch' are members rather than local variables
-//       so that this (called up to 16 times per frame) doesn't allocate.
+// Note: 'ctx.blocks' and 'ctx.scratch' live in the DrawContext instead of being
+//       local variables, so that the (up to) 16 calls in one frame share a
+//       single buffer.
 static void getBlocks(DrawContext& ctx, int ps, int ss)
 {
 	auto& scratch = ctx.scratch;
@@ -196,20 +208,6 @@ static void getBlocks(DrawContext& ctx, int ps, int ss)
 		pos = block.end;
 	}
 	if (pos < ADDRESS_SPACE) result.emplace_back(pos, ADDRESS_SPACE, nullptr);
-}
-
-namespace {
-// Everything that only depends on the font and the style, shared by the layout
-// and by the default size of the window.
-struct Metrics {
-	float rowHeight;
-	float headerHeight;
-	float labelWidth;
-	float minSlotWidth;
-	float minMapHeight;
-	gl::vec2 gap;
-	float overhang;
-};
 }
 
 static Metrics getMetrics()
@@ -293,9 +291,10 @@ static void drawSlot(DrawContext& ctx, int ps, int ss, bool expanded,
 			ctx.drawList->AddRectFilled(min, max, color);
 			// Only the line towards the next block: the outer edges belong to
 			// the outline of the slot as a whole. Drawing a rectangle per block
-			// would draw every shared edge twice.
+			// would draw every shared edge twice. See the note on 'separators'
+			// for why this stops one pixel short of x1.
 			if (block.end != ADDRESS_SPACE) {
-				ctx.separators.emplace_back(min, gl::vec2(x1, blockTop));
+				ctx.separators.emplace_back(min, gl::vec2(x1 - 1.0f, blockTop));
 			}
 			drawText(ctx.drawList, block.device ? std::string_view(block.device->getName())
 			                                    : "empty"sv,
@@ -338,7 +337,8 @@ static void drawDeviceToolTip(DrawContext& ctx)
 			if (header) ImGui::Separator();
 			// Below 1kB the size in kB would round down to 0.
 			auto printSize = [](std::string_view label, unsigned bytes) {
-				ImGui::StrCat(label, ": ", (bytes < 1024) ? strCat(bytes, " bytes")
+				auto unit = (bytes == 1) ? " byte"sv : " bytes"sv;
+				ImGui::StrCat(label, ": ", (bytes < 1024) ? strCat(bytes, unit)
 				                                          : strCat(bytes / 1024, "kB"));
 			};
 			ImGui::StrCat("address: 0x", hex_string<4, HexCase::upper>(block.begin),
@@ -372,7 +372,7 @@ static void drawDeviceToolTip(DrawContext& ctx)
 static void drawSlotMap(DrawContext& ctx)
 {
 	auto [rowHeight, headerHeight, labelWidth, minSlotWidth, minMapHeight, gap, overhang] =
-		getMetrics();
+		ctx.metrics;
 	auto avail = gl::vec2(ImGui::GetContentRegionAvail());
 
 	// Reflow: put 4, 2 or 1 primary slots next to each other, whichever fits.
@@ -430,7 +430,7 @@ static void drawSlotMap(DrawContext& ctx)
 					// of the outline of the primary slot.
 					if (ss != 0) {
 						ctx.separators.emplace_back(gl::vec2(x0, top),
-						                            gl::vec2(x0, bottom));
+						                            gl::vec2(x0, bottom - 1.0f));
 					}
 				}
 			} else {
@@ -446,6 +446,10 @@ static void drawSlotMap(DrawContext& ctx)
 	// keeps a device that is too small to see as a rectangle visible as a line.
 	// Each edge is drawn exactly once, otherwise the shared ones would come out
 	// twice as thick as the rest.
+	// Note: AddRect() treats 'max' as exclusive (it strokes half a pixel inside
+	//       it, like AddRectFilled() fills up to just before it), while both end
+	//       points of AddLine() are inclusive. So a separator has to stop one
+	//       pixel short to end where the outline around it is, see drawSlot().
 	for (const auto& [p1, p2] : ctx.separators) {
 		ctx.drawList->AddLine(p1, p2, ctx.outlineColor);
 	}
@@ -466,10 +470,9 @@ static void drawSlotMap(DrawContext& ctx)
 
 // Big enough for a 2x2 layout: room for three primary slots next to each other,
 // while the reflow needs room for four before it puts them in a single row.
-static gl::vec2 defaultWindowSize()
+static gl::vec2 defaultWindowSize(const Metrics& m)
 {
 	const auto& style = ImGui::GetStyle();
-	auto m = getMetrics();
 	gl::vec2 content{m.labelWidth + 3.0f * (m.minSlotWidth + m.gap.x),
 	                 2.0f * (m.headerHeight + m.minMapHeight) + m.gap.y + m.overhang};
 	return content + 2.0f * gl::vec2(style.WindowPadding) +
@@ -488,6 +491,7 @@ void ImGuiSlotMap::paint(MSXMotherBoard* motherBoard)
 		.slotManager = motherBoard->getSlotManager(),
 		.debugger = motherBoard->getDebugger(),
 		.dummyDevice = &cpuInterface.getDummyDevice(),
+		.metrics = getMetrics(),
 		.drawList = nullptr, // only valid inside the window
 		.emptyColor = ImGui::GetColorU32(getColor(imColor::GRAY), 0.4f),
 		.occupiedColor = ImGui::GetColorU32(ImGuiCol_Header),
@@ -496,11 +500,19 @@ void ImGuiSlotMap::paint(MSXMotherBoard* motherBoard)
 		.textColor = ImGui::GetColorU32(ImGuiCol_Text),
 		.dimTextColor = ImGui::GetColorU32(ImGuiCol_TextDisabled),
 		.mouse = gl::vec2(ImGui::GetIO().MousePos),
+		// Default initialization is what we want for the rest, but spell it out
+		// to keep gcc's -Wmissing-field-initializers quiet.
+		.hovered = {},
+		.outlines = {},
+		.separators = {},
+		.tinyBlocks = {},
+		.blocks = {},
+		.scratch = {},
 	};
 	ctx.outlines.reserve(4);
 	ctx.separators.reserve(64);
 
-	ImGui::SetNextWindowSize(defaultWindowSize(), ImGuiCond_FirstUseEver);
+	ImGui::SetNextWindowSize(defaultWindowSize(ctx.metrics), ImGuiCond_FirstUseEver);
 	im::Window("Slot map", &show, [&]{
 		ctx.drawList = ImGui::GetWindowDrawList();
 		drawSlotMap(ctx);

--- a/src/imgui/ImGuiSlotMap.cc
+++ b/src/imgui/ImGuiSlotMap.cc
@@ -48,7 +48,7 @@ void ImGuiSlotMap::loadLine(std::string_view name, zstring_view value)
 // 'device' is nullptr for the parts where nothing is mapped.
 struct Block {
 	unsigned begin;
-	unsigned end;
+	unsigned end; // exclusive
 	const MSXDevice* device;
 };
 
@@ -153,7 +153,7 @@ static void getBlocks(DrawContext& ctx, int ps, int ss)
 	for (auto page : xrange(4)) {
 		auto pageBegin = PAGE_SIZE * unsigned(page);
 		const auto* device = ctx.cpuInterface.getMSXDevice(ps, ss, page);
-		if (!device || (device == ctx.dummyDevice)) continue;
+		if (device == ctx.dummyDevice) continue;
 		if (const auto* multi = dynamic_cast<const MSXMultiMemDevice*>(device)) {
 			// Only these sub-ranges can be out of order: the pages themselves
 			// are visited in increasing order, so sorting per page is enough.
@@ -180,7 +180,7 @@ static void getBlocks(DrawContext& ctx, int ps, int ss)
 			result.back().end = block.end;
 		} else {
 			if (pos < block.begin) result.emplace_back(pos, block.begin, nullptr);
-			result.emplace_back(block.begin, block.end, block.device);
+			result.push_back(block);
 		}
 		pos = block.end;
 	}
@@ -284,11 +284,14 @@ static void drawDeviceToolTip(DrawContext& ctx)
 				header = true;
 			}
 			if (header) ImGui::Separator();
-			auto size = block.end - block.begin;
+			// Below 1kB the size in kB would round down to 0.
+			auto printSize = [](std::string_view label, unsigned bytes) {
+				ImGui::StrCat(label, ": ", (bytes < 1024) ? strCat(bytes, " bytes")
+				                                          : strCat(bytes / 1024, "kB"));
+			};
 			ImGui::StrCat("address: 0x", hex_string<4, HexCase::upper>(block.begin),
 			              " - 0x", hex_string<4, HexCase::upper>(block.end - 1));
-			ImGui::StrCat("size: ", (size < 1024) ? strCat(size, " bytes")
-			                                      : strCat(size / 1024, "kB"));
+			printSize("size", block.end - block.begin);
 			if (!block.device) return;
 
 			// Whatever the device wants to tell about itself, e.g. the mapper
@@ -307,7 +310,7 @@ static void drawDeviceToolTip(DrawContext& ctx)
 			// can also tell how much memory they actually have.
 			if (const auto* debuggable = ctx.debugger.findDebuggable(block.device->getName())) {
 				if (auto bytes = debuggable->getSize(); bytes != 0) {
-					ImGui::StrCat("total memory: ", bytes / 1024, "kB");
+					printSize("total memory", bytes);
 				}
 			}
 		});

--- a/src/imgui/ImGuiSlotMap.hh
+++ b/src/imgui/ImGuiSlotMap.hh
@@ -1,0 +1,33 @@
+#ifndef IMGUI_SLOTMAP_HH
+#define IMGUI_SLOTMAP_HH
+
+#include "ImGuiPart.hh"
+
+namespace openmsx {
+
+class ImGuiSlotMap final : public ImGuiPart
+{
+public:
+	using ImGuiPart::ImGuiPart;
+
+	[[nodiscard]] zstring_view iniName() const override { return "slot-map"; }
+	void save(ImGuiTextBuffer& buf) override;
+	void loadLine(std::string_view name, zstring_view value) override;
+	void paint(MSXMotherBoard* motherBoard) override;
+
+public:
+	bool show = false;
+
+private:
+	bool vertical = true; // pages as rows, like the memory maps in most manuals
+	bool fitToContent = false; // resize the window after switching layout
+
+	// 'vertical' is saved separately, as a "layout=vertical|horizontal" line.
+	static constexpr auto persistentElements = std::tuple{
+		PersistentElement{"show", &ImGuiSlotMap::show}
+	};
+};
+
+} // namespace openmsx
+
+#endif

--- a/src/imgui/ImGuiSlotMap.hh
+++ b/src/imgui/ImGuiSlotMap.hh
@@ -19,10 +19,6 @@ public:
 	bool show = false;
 
 private:
-	bool vertical = true; // pages as rows, like the memory maps in most manuals
-	bool fitToContent = false; // resize the window after switching layout
-
-	// 'vertical' is saved separately, as a "layout=vertical|horizontal" line.
 	static constexpr auto persistentElements = std::tuple{
 		PersistentElement{"show", &ImGuiSlotMap::show}
 	};

--- a/src/imgui/ImGuiTools.cc
+++ b/src/imgui/ImGuiTools.cc
@@ -10,6 +10,7 @@
 #include "ImGuiMsxMusicViewer.hh"
 #include "ImGuiPlotterViewer.hh"
 #include "ImGuiSCCViewer.hh"
+#include "ImGuiSlotMap.hh"
 #include "ImGuiTrainer.hh"
 #include "ImGuiUtils.hh"
 #include "ImGuiWaveViewer.hh"
@@ -146,6 +147,9 @@ void ImGuiTools::showMenu(MSXMotherBoard* motherBoard)
 		ImGui::MenuItem("Audio channel viewer", nullptr, &manager.waveViewer->show);
 		ImGui::MenuItem("Plotter viewer", nullptr, &manager.plotterViewer->show);
 		simpleToolTip("The plotter should be plugged into the printer port");
+		ImGui::MenuItem("Slot map", nullptr, &manager.slotMap->show);
+		simpleToolTip("Show which devices are visible in which slot/page. "
+		              "Same information as the 'slotmap' console command.");
 		ImGui::Separator();
 
 		im::Menu("Toys", [&]{

--- a/src/imgui/ImGuiUtils.hh
+++ b/src/imgui/ImGuiUtils.hh
@@ -66,6 +66,25 @@ inline std::string leftClip(std::string_view s, float maxWidth)
 	return strCat("...", s.substr(len - num));
 }
 
+// Mirror of leftClip(): keep the start of the string and replace the part that
+// doesn't fit with an ellipsis.
+inline std::string rightClip(std::string_view s, float maxWidth)
+{
+	auto fullWidth = ImGui::CalcTextSize(s).x;
+	if (fullWidth <= maxWidth) return std::string(s);
+
+	maxWidth -= ImGui::CalcTextSize("..."sv).x;
+	if (maxWidth <= 0.0f) return "...";
+
+	// The first length that is too wide, minus one, is the longest prefix that
+	// still fits. Length 0 always fits, so that first length is never 0.
+	auto lengths = std::views::iota(0uz, s.size() + 1);
+	auto it = std::ranges::upper_bound(lengths, maxWidth, {},
+		[&](size_t n) { return ImGui::CalcTextSize(s.substr(0, n)).x; });
+	auto num = (it == lengths.end()) ? s.size() : (*it - 1);
+	return strCat(s.substr(0, num), "...");
+}
+
 template<typename... Ts>
 void StrCat(Ts&& ...ts)
 {


### PR DESCRIPTION
Adds a graphical version of the 'slotmap' console command, requested in issue #1659.

The window shows a grid of slots against the four 16kB pages, in two layouts, switchable with a dropdown and remembered in imgui.ini:

- vertical (default): pages as rows with the highest address on top and slots as columns, matching the memory maps in the MSX wiki and in most manuals
- horizontal: the transpose, slots as rows and pages as columns

The layout is fixed at 4x4 slots, so a non-expanded primary slot takes the same space as four sub-slots and machines with different slot layouts still look alike. Cells are colored empty / occupied / external cartridge slot, a device covering several pages is drawn as one merged cell, and long device names wrap over the taller cells (falling back to an ellipsis plus a tooltip when even that doesn't fit).

MSXCPUInterface registers a device that covers less than a whole page through an MSXMultiMemDevice, which knows the exact address ranges. Add an accessor for those ranges so such a page can be split proportionally, e.g. the 8kB RAM at 0xE000 of a Casio PV-7 only fills the upper half of its page instead of the whole page as 'slotmap' reports it.

Vertical:
<img width="1143" height="249" alt="image" src="https://github.com/user-attachments/assets/082e8281-7715-458d-b01e-a77e8da5285a" />

Horizontal:
<img width="1150" height="411" alt="image" src="https://github.com/user-attachments/assets/e1bf199c-5fbb-4963-9c63-3a2f33e4bec5" />
