### PR TITLE
Add 'I/O ports' window to the Tools menu

### DIFF
--- a/build/msvc/openmsx.vcxproj
+++ b/build/msvc/openmsx.vcxproj
@@ -504,6 +504,7 @@
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiDisassembly.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiDiskManipulator.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiHelp.cc" />
+    <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiIoPorts.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiKeyboard.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiLayer.cc" />
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiMachine.cc" />
@@ -1108,6 +1109,7 @@
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiDisassembly.hh" />
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiDiskManipulator.hh" />
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiHelp.hh" />
+    <None Include="$(OpenMSXSrcDir)\imgui\ImGuiIoPorts.hh" />
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiKeyboard.hh" />
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiLayer.hh" />
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiMachine.hh" />

--- a/build/msvc/openmsx.vcxproj.filters
+++ b/build/msvc/openmsx.vcxproj.filters
@@ -576,6 +576,9 @@
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiHelp.cc">
       <Filter>imgui</Filter>
     </ClCompile>
+    <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiIoPorts.cc">
+      <Filter>imgui</Filter>
+    </ClCompile>
     <ClCompile Include="$(OpenMSXSrcDir)\imgui\ImGuiKeyboard.cc">
       <Filter>imgui</Filter>
     </ClCompile>
@@ -2113,6 +2116,9 @@
       <Filter>imgui</Filter>
     </None>
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiHelp.hh">
+      <Filter>imgui</Filter>
+    </None>
+    <None Include="$(OpenMSXSrcDir)\imgui\ImGuiIoPorts.hh">
       <Filter>imgui</Filter>
     </None>
     <None Include="$(OpenMSXSrcDir)\imgui\ImGuiKeyboard.hh">

--- a/src/cpu/MSXCPUInterface.hh
+++ b/src/cpu/MSXCPUInterface.hh
@@ -329,6 +329,22 @@ public:
 	[[nodiscard]] MSXDevice* getMSXDevice(int ps, int ss, int page);
 	[[nodiscard]] MSXDevice* getVisibleMSXDevice(int page) { return visibleDevices[page]; }
 
+	/** Returns the device registered on the given IO port, looking through
+	  * the watchpoint and VDP-delay wrapper devices. Returns the
+	  * DummyDevice when no device is registered on this port.
+	  */
+	[[nodiscard]] MSXDevice* getIODevice(uint8_t port, bool isIn) {
+		return getDevicePtr(port, isIn);
+	}
+
+	/**
+	 * Read a byte from the given IO-port without side effects.
+	 * @see MSXDevice::peekIO()
+	 */
+	[[nodiscard]] uint8_t peekIO(uint16_t port, EmuTime time) const {
+		return IO_In[port & 0xFF]->peekIO(port, time);
+	}
+
 	template<typename Archive>
 	void serialize(Archive& ar, unsigned version);
 

--- a/src/imgui/ImGuiIoPorts.cc
+++ b/src/imgui/ImGuiIoPorts.cc
@@ -29,18 +29,6 @@ namespace openmsx {
 
 using namespace std::literals;
 
-static constexpr auto OVERLAP_TOOLTIP =
-	"These ports are shared with another device. Reading such a port returns "
-	"the bitwise AND of all values, writing goes to every device."sv;
-
-static constexpr int TABLE_FLAGS =
-	ImGuiTableFlags_RowBg |
-	ImGuiTableFlags_BordersInnerV |
-	ImGuiTableFlags_Resizable |
-	ImGuiTableFlags_Reorderable |
-	ImGuiTableFlags_Hideable |
-	ImGuiTableFlags_ContextMenuInBody;
-
 /** A maximal range of ports with the same device(s) in the same direction(s).
   */
 struct Row {
@@ -200,7 +188,15 @@ static void drawTable(ImFont* fontMono, MSXCPUInterface& cpuInterface,
 	};
 	auto arrowWidth = ImGui::GetFontSize() + style.ItemInnerSpacing.x;
 
-	im::Table("ports", 4, TABLE_FLAGS | ImGuiTableFlags_Sortable, [&]{
+	static constexpr int TABLE_FLAGS =
+		ImGuiTableFlags_RowBg |
+		ImGuiTableFlags_BordersInnerV |
+		ImGuiTableFlags_Resizable |
+		ImGuiTableFlags_Reorderable |
+		ImGuiTableFlags_Hideable |
+		ImGuiTableFlags_ContextMenuInBody |
+		ImGuiTableFlags_Sortable;
+	im::Table("ports", 4, TABLE_FLAGS, [&]{
 		// 'Value' is hidden by default: the hex editor on the 'ioports'
 		// debuggable already shows these values. Un-hide it via the
 		// right-click context menu on the table header.
@@ -240,7 +236,12 @@ static void drawTable(ImFont* fontMono, MSXCPUInterface& cpuInterface,
 				im::StyleColor(conflict, ImGuiCol_Text, getColor(imColor::YELLOW), [&]{
 					ImGui::TextUnformatted(row.device);
 				});
-				if (conflict) simpleToolTip(OVERLAP_TOOLTIP);
+				if (conflict) {
+					simpleToolTip(
+						"These ports are shared with another device. Reading "
+						"such a port returns the bitwise AND of all values, "
+						"writing goes to every device."sv);
+				}
 			}
 			if (ImGui::TableNextColumn()) { // value(s)
 				drawValue(fontMono, cpuInterface, row, time);

--- a/src/imgui/ImGuiIoPorts.cc
+++ b/src/imgui/ImGuiIoPorts.cc
@@ -157,60 +157,6 @@ std::vector<ImGuiIoPorts::Row> ImGuiIoPorts::getRows(MSXCPUInterface& cpuInterfa
 	return result;
 }
 
-std::vector<ImGuiIoPorts::Group> ImGuiIoPorts::getGroups(MSXCPUInterface& cpuInterface)
-{
-	auto names = collectNames(cpuInterface);
-	const auto& in = names.in;
-	const auto& out = names.out;
-
-	// Per device, which ports it occupies (bit 0 = input, bit 1 = output).
-	struct Acc {
-		std::string_view device;
-		std::array<uint8_t, 256> mask = {};
-	};
-	std::vector<Acc> accs;
-	auto mark = [&](std::string_view device, unsigned port, uint8_t bit) {
-		auto it = std::ranges::find(accs, device, &Acc::device);
-		if (it == accs.end()) {
-			accs.push_back(Acc{.device = device});
-			it = accs.end() - 1;
-		}
-		it->mask[port] |= bit;
-	};
-	// Ports are visited in ascending order, so the devices end up ordered by
-	// their lowest port. That keeps the grouped view roughly address ordered.
-	for (auto port : xrange(256)) {
-		for (const auto& device : in [port]) mark(device, port, 1);
-		for (const auto& device : out[port]) mark(device, port, 2);
-	}
-
-	std::vector<Group> result;
-	for (const auto& acc : accs) {
-		Group group{.device = std::string(acc.device)};
-		unsigned port = 0;
-		while (port < 256) {
-			if (acc.mask[port] == 0) { ++port; continue; }
-			unsigned end = port + 1;
-			while ((end < 256) && (acc.mask[end] == acc.mask[port])) ++end;
-			bool isIn  = (acc.mask[port] & 1) != 0;
-			bool isOut = (acc.mask[port] & 2) != 0;
-			bool shared = std::ranges::any_of(xrange(port, end), [&](unsigned p) {
-				return (isIn  && (in [p].size() > 1)) ||
-				       (isOut && (out[p].size() > 1));
-			});
-			group.ranges.push_back(Row{
-				.begin = narrow<uint8_t>(port),
-				.end = narrow<uint8_t>(end - 1),
-				.in = isIn,
-				.out = isOut,
-				.overlap = shared});
-			port = end;
-		}
-		result.push_back(std::move(group));
-	}
-	return result;
-}
-
 void ImGuiIoPorts::drawValue(MSXCPUInterface& cpuInterface, const Row& row, EmuTime time)
 {
 	im::ScopedFont sf(manager.fontMono);
@@ -236,11 +182,11 @@ void ImGuiIoPorts::drawValue(MSXCPUInterface& cpuInterface, const Row& row, EmuT
 	}
 }
 
-void ImGuiIoPorts::drawFlat(MSXCPUInterface& cpuInterface, bool warnOverlap, EmuTime time)
+void ImGuiIoPorts::drawTable(MSXCPUInterface& cpuInterface, bool warnOverlap, EmuTime time)
 {
-	// A sorted column also draws a sort arrow next to its name. Reserve room
-	// for that in the default width, otherwise the header of the (narrow)
-	// 'Ports' and 'Dir' columns gets clipped to "..." once you sort on them.
+	// 'Ports' and 'Dir' have a fixed width, so their width must fit the header
+	// including the sort arrow that appears next to it once you sort on them.
+	// Otherwise those (narrow) headers would stay clipped to "...".
 	const auto& style = ImGui::GetStyle();
 	auto arrowWidth = ImGui::GetFontSize() + style.ItemInnerSpacing.x;
 	auto monoWidth = [&](std::string_view s) {
@@ -252,16 +198,22 @@ void ImGuiIoPorts::drawFlat(MSXCPUInterface& cpuInterface, bool warnOverlap, Emu
 		       2.0f * style.CellPadding.x;
 	};
 
-	im::Table("flat", 4, TABLE_FLAGS | ImGuiTableFlags_Sortable, [&]{
+	im::Table("ports", 4, TABLE_FLAGS | ImGuiTableFlags_Sortable, [&]{
 		// 'Value' is hidden by default: the hex editor on the 'ioports'
 		// debuggable already shows these values. Un-hide it via the
 		// right-click context menu on the table header.
 		// It's also not sortable: the values change while the emulation
 		// runs, so sorting on them would reshuffle the rows every frame.
+		//
+		// 'Ports' and 'Dir' hold at most 5 resp. 3 characters, so there is
+		// nothing to gain by resizing them: keep them at their content width
+		// and let all remaining space go to 'Device'.
 		ImGui::TableSetupColumn("Ports", ImGuiTableColumnFlags_WidthFixed |
+		                                 ImGuiTableColumnFlags_NoResize |
 		                                 ImGuiTableColumnFlags_DefaultSort,
 		                        sortableWidth("Ports", monoWidth("FF-FF")));
-		ImGui::TableSetupColumn("Dir", ImGuiTableColumnFlags_WidthFixed,
+		ImGui::TableSetupColumn("Dir", ImGuiTableColumnFlags_WidthFixed |
+		                               ImGuiTableColumnFlags_NoResize,
 		                        sortableWidth("Dir", ImGui::CalcTextSize("I/O"sv).x));
 		ImGui::TableSetupColumn("Device", ImGuiTableColumnFlags_WidthStretch);
 		ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthFixed |
@@ -293,47 +245,6 @@ void ImGuiIoPorts::drawFlat(MSXCPUInterface& cpuInterface, bool warnOverlap, Emu
 	});
 }
 
-void ImGuiIoPorts::drawGrouped(MSXCPUInterface& cpuInterface, bool warnOverlap, EmuTime time)
-{
-	// Size to content: the tree column is the first one, stretching it would
-	// push 'Dir' all the way to the right edge.
-	im::Table("grouped", 3, TABLE_FLAGS | ImGuiTableFlags_SizingFixedFit, [&]{
-		ImGui::TableSetupColumn("Device / ports", ImGuiTableColumnFlags_WidthFixed |
-		                                          ImGuiTableColumnFlags_NoHide);
-		ImGui::TableSetupColumn("Dir", ImGuiTableColumnFlags_WidthFixed);
-		ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthFixed |
-		                                 ImGuiTableColumnFlags_DefaultHide);
-		ImGui::TableHeadersRow();
-
-		for (const auto& group : getGroups(cpuInterface)) {
-			ImGui::TableNextRow();
-			ImGui::TableNextColumn();
-			im::TreeNode(group.device.c_str(),
-			             ImGuiTreeNodeFlags_DefaultOpen |
-			             ImGuiTreeNodeFlags_SpanFullWidth, [&]{
-				for (const auto& range : group.ranges) {
-					ImGui::TableNextRow();
-					if (ImGui::TableNextColumn()) { // ports
-						bool conflict = range.overlap && warnOverlap;
-						im::ScopedFont sf(manager.fontMono);
-						im::StyleColor(conflict, ImGuiCol_Text,
-						               getColor(imColor::YELLOW), [&]{
-							ImGui::TextUnformatted(portsText(range));
-						});
-						if (conflict) simpleToolTip(OVERLAP_TOOLTIP);
-					}
-					if (ImGui::TableNextColumn()) { // direction
-						ImGui::TextUnformatted(dirText(range));
-					}
-					if (ImGui::TableNextColumn()) { // value(s)
-						drawValue(cpuInterface, range, time);
-					}
-				}
-			});
-		}
-	});
-}
-
 void ImGuiIoPorts::save(ImGuiTextBuffer& buf)
 {
 	savePersistent(buf, *this, persistentElements);
@@ -357,18 +268,11 @@ void ImGuiIoPorts::paint(MSXMotherBoard* motherBoard)
 	auto fontSize = ImGui::GetFontSize();
 	ImGui::SetNextWindowSize(ImVec2(46.0f * fontSize, 26.0f * fontSize), ImGuiCond_FirstUseEver);
 	im::Window("I/O ports", &show, [&]{
-		ImGui::Checkbox("Group by device", &groupByDevice);
-		simpleToolTip("A device doesn't necessarily occupy a contiguous range of "
-		              "ports. Group by device to see all ports of one device "
-		              "together instead of sorted by port number.");
-
-		auto& cpuInterface = motherBoard->getCPUInterface();
-		auto time = motherBoard->getCurrentTime();
-		if (groupByDevice) {
-			drawGrouped(cpuInterface, warnOverlap, time);
-		} else {
-			drawFlat(cpuInterface, warnOverlap, time);
-		}
+		// A device doesn't necessarily occupy a contiguous range of ports
+		// (e.g. the Philips NMS-1205). Sort on 'Device' to see all ports of
+		// one device together instead of ordered by port number.
+		drawTable(motherBoard->getCPUInterface(), warnOverlap,
+		          motherBoard->getCurrentTime());
 	});
 }
 

--- a/src/imgui/ImGuiIoPorts.cc
+++ b/src/imgui/ImGuiIoPorts.cc
@@ -4,85 +4,89 @@
 #include "ImGuiManager.hh"
 #include "ImGuiUtils.hh"
 
+#include "DummyDevice.hh"
+#include "EmuTime.hh"
 #include "HardwareConfig.hh"
 #include "MSXCPUInterface.hh"
+#include "MSXDevice.hh"
 #include "MSXMotherBoard.hh"
 #include "MSXMultiIODevice.hh"
 
+#include "join.hh"
 #include "narrow.hh"
 #include "strCat.hh"
 #include "xrange.hh"
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
+#include <ranges>
+#include <string>
 #include <string_view>
+#include <vector>
 
 namespace openmsx {
 
 using namespace std::literals;
-
-// Only this many port values are shown inline, the rest is in the tooltip.
-static constexpr unsigned MAX_SHOWN_VALUES = 8;
 
 static constexpr auto OVERLAP_TOOLTIP =
 	"These ports are shared with another device. Reading such a port returns "
 	"the bitwise AND of all values, writing goes to every device."sv;
 
 static constexpr int TABLE_FLAGS =
+	ImGuiTableFlags_RowBg |
 	ImGuiTableFlags_BordersInnerV |
 	ImGuiTableFlags_Resizable |
 	ImGuiTableFlags_Reorderable |
 	ImGuiTableFlags_Hideable |
 	ImGuiTableFlags_ContextMenuInBody;
 
-using Names = std::vector<std::string_view>;
-
-// Collect the name(s) of the device(s) on one port. This mirrors
-// 'machine_info input_port/output_port', on which the 'iomap' script is
-// built: an unused port yields an empty list (the DummyDevice has an empty
-// name), a port with conflicting devices yields one name per device.
-[[nodiscard]] static Names getNames(MSXCPUInterface& cpuInterface, uint8_t port, bool isIn)
-{
-	Names result;
-	auto add = [&](const std::string& name) {
-		if (!name.empty()) result.emplace_back(name);
-	};
-	auto* device = cpuInterface.getIODevice(port, isIn);
-	if (auto* multi = dynamic_cast<MSXMultiIODevice*>(device)) {
-		for (const auto* dev : multi->getDevices()) {
-			add(dev->getName());
-		}
-	} else {
-		add(device->getName());
-	}
-	return result;
-}
-
-struct PortNames {
-	std::array<Names, 256> in;
-	std::array<Names, 256> out;
+/** A maximal range of ports with the same device(s) in the same direction(s).
+  */
+struct Row {
+	uint8_t begin; // inclusive
+	uint8_t end;   // inclusive
+	bool in;
+	bool out;
+	bool overlap;       // these ports are shared with another device
+	std::string device; // comma separated name(s)
 };
-[[nodiscard]] static PortNames collectNames(MSXCPUInterface& cpuInterface)
+
+using Devices = MSXMultiIODevice::Devices;
+
+// Collect the device(s) on one port. This mirrors 'machine_info
+// input_port/output_port', on which the 'iomap' script is built: an unused
+// port yields an empty list, a port with conflicting devices one entry per
+// device.
+[[nodiscard]] static Devices getDevices(MSXCPUInterface& cpuInterface, uint8_t port, bool isIn)
 {
-	PortNames result;
+	auto* device = cpuInterface.getIODevice(port, isIn);
+	const MSXDevice* dummy = &cpuInterface.getDummyDevice();
+	if (device == dummy) return {}; // unused port
+	if (auto* multi = dynamic_cast<MSXMultiIODevice*>(device)) {
+		// A sub-device is never the DummyDevice: register_IO() only wraps
+		// devices in a MSXMultiIODevice once a real device is registered,
+		// and unregister_IO() unwraps again when one device is left.
+		return multi->getDevices();
+	}
+	return {device};
+}
+
+struct PortDevices {
+	std::array<Devices, 256> in;
+	std::array<Devices, 256> out;
+};
+[[nodiscard]] static PortDevices collectDevices(MSXCPUInterface& cpuInterface)
+{
+	PortDevices result;
 	for (auto port : xrange(256)) {
-		result.in [port] = getNames(cpuInterface, narrow<uint8_t>(port), true);
-		result.out[port] = getNames(cpuInterface, narrow<uint8_t>(port), false);
+		result.in [port] = getDevices(cpuInterface, narrow<uint8_t>(port), true);
+		result.out[port] = getDevices(cpuInterface, narrow<uint8_t>(port), false);
 	}
 	return result;
 }
 
-[[nodiscard]] static std::string join(const Names& names)
-{
-	std::string result;
-	for (const auto& name : names) {
-		if (!result.empty()) strAppend(result, ", ");
-		strAppend(result, name);
-	}
-	return result;
-}
-
-std::string ImGuiIoPorts::portsText(const Row& row)
+[[nodiscard]] static std::string portsText(const Row& row)
 {
 	if (row.begin == row.end) {
 		return strCat(hex_string<2, HexCase::upper>(row.begin));
@@ -91,12 +95,12 @@ std::string ImGuiIoPorts::portsText(const Row& row)
 	              hex_string<2, HexCase::upper>(row.end));
 }
 
-std::string_view ImGuiIoPorts::dirText(const Row& row)
+[[nodiscard]] static std::string_view dirText(const Row& row)
 {
 	return row.in ? (row.out ? "I/O"sv : "I"sv) : "O"sv;
 }
 
-void ImGuiIoPorts::sortRows(std::vector<Row>& rows)
+static void sortRows(std::vector<Row>& rows)
 {
 	// Note: unlike the other views in openMSX, 'rows' is rebuilt from scratch
 	// every frame. So (re)apply the sort unconditionally instead of only when
@@ -105,28 +109,28 @@ void ImGuiIoPorts::sortRows(std::vector<Row>& rows)
 	if (!sortSpecs || (sortSpecs->SpecsCount == 0)) return;
 	assert(sortSpecs->Specs);
 
-	// 'rows' is generated in ascending port order, and all sorts below are
-	// stable. So e.g. sorting on device keeps each device's ports ordered.
+	bool descending = sortSpecs->Specs->SortDirection == ImGuiSortDirection_Descending;
 	switch (sortSpecs->Specs->ColumnIndex) {
-	case 0: // ports
-		sortUpDown_T(rows, sortSpecs, &Row::begin);
+	case 0: // ports: 'rows' is already generated in ascending port order
+		if (descending) std::ranges::reverse(rows);
 		break;
-	case 1: // direction
-		sortUpDown_String(rows, sortSpecs, [](const Row& row) { return dirText(row); });
-		break;
-	case 2: // device
+	case 2: // device: stable, so each device keeps its ports port-ordered
 		sortUpDown_String(rows, sortSpecs, &Row::device);
 		break;
 	default:
-		UNREACHABLE;
+		// 'Dir' and 'Value' are NoSort, but Dear ImGui still restores a sort
+		// on such a column from imgui.ini (TableSortSpecsSanitize() only
+		// clears it for hidden columns). So don't assume this can't happen,
+		// just keep the rows in ascending port order.
+		break;
 	}
 }
 
-std::vector<ImGuiIoPorts::Row> ImGuiIoPorts::getRows(MSXCPUInterface& cpuInterface)
+[[nodiscard]] static std::vector<Row> getRows(MSXCPUInterface& cpuInterface)
 {
-	auto names = collectNames(cpuInterface);
-	const auto& in = names.in;
-	const auto& out = names.out;
+	auto devices = collectDevices(cpuInterface);
+	const auto& in = devices.in;
+	const auto& out = devices.out;
 
 	std::vector<Row> result;
 	unsigned port = 0;
@@ -136,15 +140,15 @@ std::vector<ImGuiIoPorts::Row> ImGuiIoPorts::getRows(MSXCPUInterface& cpuInterfa
 		while ((end < 256) && (in[end] == in[port]) && (out[end] == out[port])) {
 			++end;
 		}
-		auto add = [&](const Names& n, bool isIn, bool isOut) {
-			if (n.empty()) return;
+		auto add = [&](const Devices& devs, bool isIn, bool isOut) {
+			if (devs.empty()) return;
 			result.push_back(Row{
 				.begin = narrow<uint8_t>(port),
 				.end = narrow<uint8_t>(end - 1),
 				.in = isIn,
 				.out = isOut,
-				.overlap = n.size() > 1,
-				.device = join(n)});
+				.overlap = devs.size() > 1,
+				.device = join(std::views::transform(devs, &MSXDevice::getName), ", ")});
 		};
 		if (in[port] == out[port]) {
 			add(in[port], true, true);
@@ -157,46 +161,44 @@ std::vector<ImGuiIoPorts::Row> ImGuiIoPorts::getRows(MSXCPUInterface& cpuInterfa
 	return result;
 }
 
-void ImGuiIoPorts::drawValue(MSXCPUInterface& cpuInterface, const Row& row, EmuTime time)
+static void drawValue(ImFont* fontMono, MSXCPUInterface& cpuInterface,
+                      const Row& row, EmuTime time)
 {
-	im::ScopedFont sf(manager.fontMono);
+	im::ScopedFont sf(fontMono);
 	if (!row.in) {
 		// Peeking would read the input side, which has nothing to do with
 		// the (output-only) device on this row.
 		ImGui::TextUnformatted("-"sv);
 		return;
 	}
-	auto num = unsigned(row.end) - row.begin + 1;
+	// Draw all values and let Dear ImGui clip them. Only the gfx9000 has more
+	// than a handful of ports, and this column is hidden by default anyway.
 	std::string values;
-	for (auto i : xrange(num)) {
-		if (i) strAppend(values, ' ');
+	for (auto port : xrange(unsigned(row.begin), unsigned(row.end) + 1)) {
+		if (!values.empty()) strAppend(values, ' ');
 		strAppend(values, hex_string<2, HexCase::upper>(
-			cpuInterface.peekIO(narrow<uint16_t>(row.begin + i), time)));
+			cpuInterface.peekIO(narrow<uint16_t>(port), time)));
 	}
-	if (num <= MAX_SHOWN_VALUES) {
-		ImGui::TextUnformatted(values);
-	} else {
-		// every value takes 3 characters ("XX "), minus the trailing space
-		ImGui::StrCat(std::string_view(values).substr(0, MAX_SHOWN_VALUES * 3 - 1), " ...");
-		simpleToolTip(values);
-	}
+	ImGui::TextUnformatted(values);
 }
 
-void ImGuiIoPorts::drawTable(MSXCPUInterface& cpuInterface, bool warnOverlap, EmuTime time)
+static void drawTable(ImFont* fontMono, MSXCPUInterface& cpuInterface,
+                      bool warnOverlap, EmuTime time)
 {
-	// 'Ports' and 'Dir' have a fixed width, so their width must fit the header
-	// including the sort arrow that appears next to it once you sort on them.
-	// Otherwise those (narrow) headers would stay clipped to "...".
+	// 'Ports' and 'Dir' have a fixed width, so it must fit both the content
+	// and the header. 'Ports' is sortable, and a sorted column also draws a
+	// sort arrow next to its name, otherwise that header would be clipped to
+	// "..." as soon as you sort on it.
 	const auto& style = ImGui::GetStyle();
-	auto arrowWidth = ImGui::GetFontSize() + style.ItemInnerSpacing.x;
+	auto textWidth = [](std::string_view s) { return ImGui::CalcTextSize(s).x; };
 	auto monoWidth = [&](std::string_view s) {
-		im::ScopedFont sf(manager.fontMono);
+		im::ScopedFont sf(fontMono);
 		return ImGui::CalcTextSize(s).x;
 	};
-	auto sortableWidth = [&](std::string_view header, float contentWidth) {
-		return std::max(ImGui::CalcTextSize(header).x + arrowWidth, contentWidth) +
-		       2.0f * style.CellPadding.x;
+	auto columnWidth = [&](float header, float content) {
+		return std::max(header, content) + 2.0f * style.CellPadding.x;
 	};
+	auto arrowWidth = ImGui::GetFontSize() + style.ItemInnerSpacing.x;
 
 	im::Table("ports", 4, TABLE_FLAGS | ImGuiTableFlags_Sortable, [&]{
 		// 'Value' is hidden by default: the hex editor on the 'ioports'
@@ -205,18 +207,20 @@ void ImGuiIoPorts::drawTable(MSXCPUInterface& cpuInterface, bool warnOverlap, Em
 		// It's also not sortable: the values change while the emulation
 		// runs, so sorting on them would reshuffle the rows every frame.
 		//
-		// 'Ports' and 'Dir' hold at most 5 resp. 3 characters, so there is
-		// nothing to gain by resizing them: keep them at their content width
-		// and let all remaining space go to 'Device'.
+		// 'Ports' and 'Dir' hold at most 5 resp. 3 characters, so resizing
+		// them can only take space away from the other two. Those stretch
+		// instead, so widening the window widens both.
 		ImGui::TableSetupColumn("Ports", ImGuiTableColumnFlags_WidthFixed |
 		                                 ImGuiTableColumnFlags_NoResize |
 		                                 ImGuiTableColumnFlags_DefaultSort,
-		                        sortableWidth("Ports", monoWidth("FF-FF")));
+		                        columnWidth(textWidth("Ports"sv) + arrowWidth,
+		                                    monoWidth("FF-FF"sv)));
 		ImGui::TableSetupColumn("Dir", ImGuiTableColumnFlags_WidthFixed |
-		                               ImGuiTableColumnFlags_NoResize,
-		                        sortableWidth("Dir", ImGui::CalcTextSize("I/O"sv).x));
+		                               ImGuiTableColumnFlags_NoResize |
+		                               ImGuiTableColumnFlags_NoSort,
+		                        columnWidth(textWidth("Dir"sv), textWidth("I/O"sv)));
 		ImGui::TableSetupColumn("Device", ImGuiTableColumnFlags_WidthStretch);
-		ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthFixed |
+		ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch |
 		                                 ImGuiTableColumnFlags_DefaultHide |
 		                                 ImGuiTableColumnFlags_NoSort);
 		ImGui::TableHeadersRow();
@@ -225,7 +229,7 @@ void ImGuiIoPorts::drawTable(MSXCPUInterface& cpuInterface, bool warnOverlap, Em
 		sortRows(rows);
 		for (const auto& row : rows) {
 			if (ImGui::TableNextColumn()) { // ports
-				im::ScopedFont sf(manager.fontMono);
+				im::ScopedFont sf(fontMono);
 				ImGui::TextUnformatted(portsText(row));
 			}
 			if (ImGui::TableNextColumn()) { // direction
@@ -239,7 +243,7 @@ void ImGuiIoPorts::drawTable(MSXCPUInterface& cpuInterface, bool warnOverlap, Em
 				if (conflict) simpleToolTip(OVERLAP_TOOLTIP);
 			}
 			if (ImGui::TableNextColumn()) { // value(s)
-				drawValue(cpuInterface, row, time);
+				drawValue(fontMono, cpuInterface, row, time);
 			}
 		}
 	});
@@ -271,8 +275,8 @@ void ImGuiIoPorts::paint(MSXMotherBoard* motherBoard)
 		// A device doesn't necessarily occupy a contiguous range of ports
 		// (e.g. the Philips NMS-1205). Sort on 'Device' to see all ports of
 		// one device together instead of ordered by port number.
-		drawTable(motherBoard->getCPUInterface(), warnOverlap,
-		          motherBoard->getCurrentTime());
+		drawTable(manager.fontMono, motherBoard->getCPUInterface(),
+		          warnOverlap, motherBoard->getCurrentTime());
 	});
 }
 

--- a/src/imgui/ImGuiIoPorts.cc
+++ b/src/imgui/ImGuiIoPorts.cc
@@ -96,6 +96,32 @@ std::string_view ImGuiIoPorts::dirText(const Row& row)
 	return row.in ? (row.out ? "I/O"sv : "I"sv) : "O"sv;
 }
 
+void ImGuiIoPorts::sortRows(std::vector<Row>& rows)
+{
+	// Note: unlike the other views in openMSX, 'rows' is rebuilt from scratch
+	// every frame. So (re)apply the sort unconditionally instead of only when
+	// 'SpecsDirty' is set.
+	const auto* sortSpecs = ImGui::TableGetSortSpecs();
+	if (!sortSpecs || (sortSpecs->SpecsCount == 0)) return;
+	assert(sortSpecs->Specs);
+
+	// 'rows' is generated in ascending port order, and all sorts below are
+	// stable. So e.g. sorting on device keeps each device's ports ordered.
+	switch (sortSpecs->Specs->ColumnIndex) {
+	case 0: // ports
+		sortUpDown_T(rows, sortSpecs, &Row::begin);
+		break;
+	case 1: // direction
+		sortUpDown_String(rows, sortSpecs, [](const Row& row) { return dirText(row); });
+		break;
+	case 2: // device
+		sortUpDown_String(rows, sortSpecs, &Row::device);
+		break;
+	default:
+		UNREACHABLE;
+	}
+}
+
 std::vector<ImGuiIoPorts::Row> ImGuiIoPorts::getRows(MSXCPUInterface& cpuInterface)
 {
 	auto names = collectNames(cpuInterface);
@@ -212,18 +238,40 @@ void ImGuiIoPorts::drawValue(MSXCPUInterface& cpuInterface, const Row& row, EmuT
 
 void ImGuiIoPorts::drawFlat(MSXCPUInterface& cpuInterface, bool warnOverlap, EmuTime time)
 {
-	im::Table("flat", 4, TABLE_FLAGS, [&]{
+	// A sorted column also draws a sort arrow next to its name. Reserve room
+	// for that in the default width, otherwise the header of the (narrow)
+	// 'Ports' and 'Dir' columns gets clipped to "..." once you sort on them.
+	const auto& style = ImGui::GetStyle();
+	auto arrowWidth = ImGui::GetFontSize() + style.ItemInnerSpacing.x;
+	auto monoWidth = [&](std::string_view s) {
+		im::ScopedFont sf(manager.fontMono);
+		return ImGui::CalcTextSize(s).x;
+	};
+	auto sortableWidth = [&](std::string_view header, float contentWidth) {
+		return std::max(ImGui::CalcTextSize(header).x + arrowWidth, contentWidth) +
+		       2.0f * style.CellPadding.x;
+	};
+
+	im::Table("flat", 4, TABLE_FLAGS | ImGuiTableFlags_Sortable, [&]{
 		// 'Value' is hidden by default: the hex editor on the 'ioports'
 		// debuggable already shows these values. Un-hide it via the
 		// right-click context menu on the table header.
-		ImGui::TableSetupColumn("Ports", ImGuiTableColumnFlags_WidthFixed);
-		ImGui::TableSetupColumn("Dir", ImGuiTableColumnFlags_WidthFixed);
+		// It's also not sortable: the values change while the emulation
+		// runs, so sorting on them would reshuffle the rows every frame.
+		ImGui::TableSetupColumn("Ports", ImGuiTableColumnFlags_WidthFixed |
+		                                 ImGuiTableColumnFlags_DefaultSort,
+		                        sortableWidth("Ports", monoWidth("FF-FF")));
+		ImGui::TableSetupColumn("Dir", ImGuiTableColumnFlags_WidthFixed,
+		                        sortableWidth("Dir", ImGui::CalcTextSize("I/O"sv).x));
 		ImGui::TableSetupColumn("Device", ImGuiTableColumnFlags_WidthStretch);
 		ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthFixed |
-		                                 ImGuiTableColumnFlags_DefaultHide);
+		                                 ImGuiTableColumnFlags_DefaultHide |
+		                                 ImGuiTableColumnFlags_NoSort);
 		ImGui::TableHeadersRow();
 
-		for (const auto& row : getRows(cpuInterface)) {
+		auto rows = getRows(cpuInterface);
+		sortRows(rows);
+		for (const auto& row : rows) {
 			if (ImGui::TableNextColumn()) { // ports
 				im::ScopedFont sf(manager.fontMono);
 				ImGui::TextUnformatted(portsText(row));

--- a/src/imgui/ImGuiIoPorts.cc
+++ b/src/imgui/ImGuiIoPorts.cc
@@ -1,0 +1,327 @@
+#include "ImGuiIoPorts.hh"
+
+#include "ImGuiCpp.hh"
+#include "ImGuiManager.hh"
+#include "ImGuiUtils.hh"
+
+#include "HardwareConfig.hh"
+#include "MSXCPUInterface.hh"
+#include "MSXMotherBoard.hh"
+#include "MSXMultiIODevice.hh"
+
+#include "narrow.hh"
+#include "strCat.hh"
+#include "xrange.hh"
+
+#include <algorithm>
+#include <array>
+#include <string_view>
+
+namespace openmsx {
+
+using namespace std::literals;
+
+// Only this many port values are shown inline, the rest is in the tooltip.
+static constexpr unsigned MAX_SHOWN_VALUES = 8;
+
+static constexpr auto OVERLAP_TOOLTIP =
+	"These ports are shared with another device. Reading such a port returns "
+	"the bitwise AND of all values, writing goes to every device."sv;
+
+static constexpr int TABLE_FLAGS =
+	ImGuiTableFlags_BordersInnerV |
+	ImGuiTableFlags_Resizable |
+	ImGuiTableFlags_Reorderable |
+	ImGuiTableFlags_Hideable |
+	ImGuiTableFlags_ContextMenuInBody;
+
+using Names = std::vector<std::string_view>;
+
+// Collect the name(s) of the device(s) on one port. This mirrors
+// 'machine_info input_port/output_port', on which the 'iomap' script is
+// built: an unused port yields an empty list (the DummyDevice has an empty
+// name), a port with conflicting devices yields one name per device.
+[[nodiscard]] static Names getNames(MSXCPUInterface& cpuInterface, uint8_t port, bool isIn)
+{
+	Names result;
+	auto add = [&](const std::string& name) {
+		if (!name.empty()) result.emplace_back(name);
+	};
+	auto* device = cpuInterface.getIODevice(port, isIn);
+	if (auto* multi = dynamic_cast<MSXMultiIODevice*>(device)) {
+		for (const auto* dev : multi->getDevices()) {
+			add(dev->getName());
+		}
+	} else {
+		add(device->getName());
+	}
+	return result;
+}
+
+struct PortNames {
+	std::array<Names, 256> in;
+	std::array<Names, 256> out;
+};
+[[nodiscard]] static PortNames collectNames(MSXCPUInterface& cpuInterface)
+{
+	PortNames result;
+	for (auto port : xrange(256)) {
+		result.in [port] = getNames(cpuInterface, narrow<uint8_t>(port), true);
+		result.out[port] = getNames(cpuInterface, narrow<uint8_t>(port), false);
+	}
+	return result;
+}
+
+[[nodiscard]] static std::string join(const Names& names)
+{
+	std::string result;
+	for (const auto& name : names) {
+		if (!result.empty()) strAppend(result, ", ");
+		strAppend(result, name);
+	}
+	return result;
+}
+
+std::string ImGuiIoPorts::portsText(const Row& row)
+{
+	if (row.begin == row.end) {
+		return strCat(hex_string<2, HexCase::upper>(row.begin));
+	}
+	return strCat(hex_string<2, HexCase::upper>(row.begin), '-',
+	              hex_string<2, HexCase::upper>(row.end));
+}
+
+std::string_view ImGuiIoPorts::dirText(const Row& row)
+{
+	return row.in ? (row.out ? "I/O"sv : "I"sv) : "O"sv;
+}
+
+std::vector<ImGuiIoPorts::Row> ImGuiIoPorts::getRows(MSXCPUInterface& cpuInterface)
+{
+	auto names = collectNames(cpuInterface);
+	const auto& in = names.in;
+	const auto& out = names.out;
+
+	std::vector<Row> result;
+	unsigned port = 0;
+	while (port < 256) {
+		// coalesce consecutive ports with identical input and output device(s)
+		unsigned end = port + 1;
+		while ((end < 256) && (in[end] == in[port]) && (out[end] == out[port])) {
+			++end;
+		}
+		auto add = [&](const Names& n, bool isIn, bool isOut) {
+			if (n.empty()) return;
+			result.push_back(Row{
+				.begin = narrow<uint8_t>(port),
+				.end = narrow<uint8_t>(end - 1),
+				.in = isIn,
+				.out = isOut,
+				.overlap = n.size() > 1,
+				.device = join(n)});
+		};
+		if (in[port] == out[port]) {
+			add(in[port], true, true);
+		} else {
+			add(in [port], true, false);
+			add(out[port], false, true);
+		}
+		port = end;
+	}
+	return result;
+}
+
+std::vector<ImGuiIoPorts::Group> ImGuiIoPorts::getGroups(MSXCPUInterface& cpuInterface)
+{
+	auto names = collectNames(cpuInterface);
+	const auto& in = names.in;
+	const auto& out = names.out;
+
+	// Per device, which ports it occupies (bit 0 = input, bit 1 = output).
+	struct Acc {
+		std::string_view device;
+		std::array<uint8_t, 256> mask = {};
+	};
+	std::vector<Acc> accs;
+	auto mark = [&](std::string_view device, unsigned port, uint8_t bit) {
+		auto it = std::ranges::find(accs, device, &Acc::device);
+		if (it == accs.end()) {
+			accs.push_back(Acc{.device = device});
+			it = accs.end() - 1;
+		}
+		it->mask[port] |= bit;
+	};
+	// Ports are visited in ascending order, so the devices end up ordered by
+	// their lowest port. That keeps the grouped view roughly address ordered.
+	for (auto port : xrange(256)) {
+		for (const auto& device : in [port]) mark(device, port, 1);
+		for (const auto& device : out[port]) mark(device, port, 2);
+	}
+
+	std::vector<Group> result;
+	for (const auto& acc : accs) {
+		Group group{.device = std::string(acc.device)};
+		unsigned port = 0;
+		while (port < 256) {
+			if (acc.mask[port] == 0) { ++port; continue; }
+			unsigned end = port + 1;
+			while ((end < 256) && (acc.mask[end] == acc.mask[port])) ++end;
+			bool isIn  = (acc.mask[port] & 1) != 0;
+			bool isOut = (acc.mask[port] & 2) != 0;
+			bool shared = std::ranges::any_of(xrange(port, end), [&](unsigned p) {
+				return (isIn  && (in [p].size() > 1)) ||
+				       (isOut && (out[p].size() > 1));
+			});
+			group.ranges.push_back(Row{
+				.begin = narrow<uint8_t>(port),
+				.end = narrow<uint8_t>(end - 1),
+				.in = isIn,
+				.out = isOut,
+				.overlap = shared});
+			port = end;
+		}
+		result.push_back(std::move(group));
+	}
+	return result;
+}
+
+void ImGuiIoPorts::drawValue(MSXCPUInterface& cpuInterface, const Row& row, EmuTime time)
+{
+	im::ScopedFont sf(manager.fontMono);
+	if (!row.in) {
+		// Peeking would read the input side, which has nothing to do with
+		// the (output-only) device on this row.
+		ImGui::TextUnformatted("-"sv);
+		return;
+	}
+	auto num = unsigned(row.end) - row.begin + 1;
+	std::string values;
+	for (auto i : xrange(num)) {
+		if (i) strAppend(values, ' ');
+		strAppend(values, hex_string<2, HexCase::upper>(
+			cpuInterface.peekIO(narrow<uint16_t>(row.begin + i), time)));
+	}
+	if (num <= MAX_SHOWN_VALUES) {
+		ImGui::TextUnformatted(values);
+	} else {
+		// every value takes 3 characters ("XX "), minus the trailing space
+		ImGui::StrCat(std::string_view(values).substr(0, MAX_SHOWN_VALUES * 3 - 1), " ...");
+		simpleToolTip(values);
+	}
+}
+
+void ImGuiIoPorts::drawFlat(MSXCPUInterface& cpuInterface, bool warnOverlap, EmuTime time)
+{
+	im::Table("flat", 4, TABLE_FLAGS, [&]{
+		// 'Value' is hidden by default: the hex editor on the 'ioports'
+		// debuggable already shows these values. Un-hide it via the
+		// right-click context menu on the table header.
+		ImGui::TableSetupColumn("Ports", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("Dir", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("Device", ImGuiTableColumnFlags_WidthStretch);
+		ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthFixed |
+		                                 ImGuiTableColumnFlags_DefaultHide);
+		ImGui::TableHeadersRow();
+
+		for (const auto& row : getRows(cpuInterface)) {
+			if (ImGui::TableNextColumn()) { // ports
+				im::ScopedFont sf(manager.fontMono);
+				ImGui::TextUnformatted(portsText(row));
+			}
+			if (ImGui::TableNextColumn()) { // direction
+				ImGui::TextUnformatted(dirText(row));
+			}
+			if (ImGui::TableNextColumn()) { // device(s)
+				bool conflict = row.overlap && warnOverlap;
+				im::StyleColor(conflict, ImGuiCol_Text, getColor(imColor::YELLOW), [&]{
+					ImGui::TextUnformatted(row.device);
+				});
+				if (conflict) simpleToolTip(OVERLAP_TOOLTIP);
+			}
+			if (ImGui::TableNextColumn()) { // value(s)
+				drawValue(cpuInterface, row, time);
+			}
+		}
+	});
+}
+
+void ImGuiIoPorts::drawGrouped(MSXCPUInterface& cpuInterface, bool warnOverlap, EmuTime time)
+{
+	// Size to content: the tree column is the first one, stretching it would
+	// push 'Dir' all the way to the right edge.
+	im::Table("grouped", 3, TABLE_FLAGS | ImGuiTableFlags_SizingFixedFit, [&]{
+		ImGui::TableSetupColumn("Device / ports", ImGuiTableColumnFlags_WidthFixed |
+		                                          ImGuiTableColumnFlags_NoHide);
+		ImGui::TableSetupColumn("Dir", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthFixed |
+		                                 ImGuiTableColumnFlags_DefaultHide);
+		ImGui::TableHeadersRow();
+
+		for (const auto& group : getGroups(cpuInterface)) {
+			ImGui::TableNextRow();
+			ImGui::TableNextColumn();
+			im::TreeNode(group.device.c_str(),
+			             ImGuiTreeNodeFlags_DefaultOpen |
+			             ImGuiTreeNodeFlags_SpanFullWidth, [&]{
+				for (const auto& range : group.ranges) {
+					ImGui::TableNextRow();
+					if (ImGui::TableNextColumn()) { // ports
+						bool conflict = range.overlap && warnOverlap;
+						im::ScopedFont sf(manager.fontMono);
+						im::StyleColor(conflict, ImGuiCol_Text,
+						               getColor(imColor::YELLOW), [&]{
+							ImGui::TextUnformatted(portsText(range));
+						});
+						if (conflict) simpleToolTip(OVERLAP_TOOLTIP);
+					}
+					if (ImGui::TableNextColumn()) { // direction
+						ImGui::TextUnformatted(dirText(range));
+					}
+					if (ImGui::TableNextColumn()) { // value(s)
+						drawValue(cpuInterface, range, time);
+					}
+				}
+			});
+		}
+	});
+}
+
+void ImGuiIoPorts::save(ImGuiTextBuffer& buf)
+{
+	savePersistent(buf, *this, persistentElements);
+}
+
+void ImGuiIoPorts::loadLine(std::string_view name, zstring_view value)
+{
+	loadOnePersistent(name, value, *this, persistentElements);
+}
+
+void ImGuiIoPorts::paint(MSXMotherBoard* motherBoard)
+{
+	if (!show || !motherBoard) return;
+
+	// Machines can explicitly declare that overlapping I/O ports are
+	// intentional, in that case don't flag them.
+	const auto* config = motherBoard->getMachineConfig();
+	bool warnOverlap = !config ||
+		config->getDevicesElem().getAttributeValueAsBool("overlap_warning", true);
+
+	auto fontSize = ImGui::GetFontSize();
+	ImGui::SetNextWindowSize(ImVec2(46.0f * fontSize, 26.0f * fontSize), ImGuiCond_FirstUseEver);
+	im::Window("I/O ports", &show, [&]{
+		ImGui::Checkbox("Group by device", &groupByDevice);
+		simpleToolTip("A device doesn't necessarily occupy a contiguous range of "
+		              "ports. Group by device to see all ports of one device "
+		              "together instead of sorted by port number.");
+
+		auto& cpuInterface = motherBoard->getCPUInterface();
+		auto time = motherBoard->getCurrentTime();
+		if (groupByDevice) {
+			drawGrouped(cpuInterface, warnOverlap, time);
+		} else {
+			drawFlat(cpuInterface, warnOverlap, time);
+		}
+	});
+}
+
+} // namespace openmsx

--- a/src/imgui/ImGuiIoPorts.hh
+++ b/src/imgui/ImGuiIoPorts.hh
@@ -51,6 +51,7 @@ private:
 	[[nodiscard]] static std::vector<Group> getGroups(MSXCPUInterface& cpuInterface);
 	[[nodiscard]] static std::string portsText(const Row& row);
 	[[nodiscard]] static std::string_view dirText(const Row& row);
+	static void sortRows(std::vector<Row>& rows);
 
 	void drawFlat(MSXCPUInterface& cpuInterface, bool warnOverlap, EmuTime time);
 	void drawGrouped(MSXCPUInterface& cpuInterface, bool warnOverlap, EmuTime time);

--- a/src/imgui/ImGuiIoPorts.hh
+++ b/src/imgui/ImGuiIoPorts.hh
@@ -38,30 +38,18 @@ private:
 		bool in;
 		bool out;
 		bool overlap;       // these ports are shared with another device
-		std::string device; // comma separated name(s), only in the flat view
-	};
-	/** All port ranges of a single device. Devices don't necessarily occupy
-	  * a contiguous range (e.g. the Philips NMS-1205).
-	  */
-	struct Group {
-		std::string device;
-		std::vector<Row> ranges;
+		std::string device; // comma separated name(s)
 	};
 	[[nodiscard]] static std::vector<Row> getRows(MSXCPUInterface& cpuInterface);
-	[[nodiscard]] static std::vector<Group> getGroups(MSXCPUInterface& cpuInterface);
 	[[nodiscard]] static std::string portsText(const Row& row);
 	[[nodiscard]] static std::string_view dirText(const Row& row);
 	static void sortRows(std::vector<Row>& rows);
 
-	void drawFlat(MSXCPUInterface& cpuInterface, bool warnOverlap, EmuTime time);
-	void drawGrouped(MSXCPUInterface& cpuInterface, bool warnOverlap, EmuTime time);
+	void drawTable(MSXCPUInterface& cpuInterface, bool warnOverlap, EmuTime time);
 	void drawValue(MSXCPUInterface& cpuInterface, const Row& row, EmuTime time);
 
-	bool groupByDevice = false;
-
 	static constexpr auto persistentElements = std::tuple{
-		PersistentElement{"show", &ImGuiIoPorts::show},
-		PersistentElement{"groupByDevice", &ImGuiIoPorts::groupByDevice}
+		PersistentElement{"show", &ImGuiIoPorts::show}
 	};
 };
 

--- a/src/imgui/ImGuiIoPorts.hh
+++ b/src/imgui/ImGuiIoPorts.hh
@@ -3,15 +3,7 @@
 
 #include "ImGuiPart.hh"
 
-#include "EmuTime.hh"
-
-#include <cstdint>
-#include <string>
-#include <vector>
-
 namespace openmsx {
-
-class MSXCPUInterface;
 
 class ImGuiIoPorts final : public ImGuiPart
 {
@@ -29,25 +21,6 @@ public:
 	bool show = false;
 
 private:
-	/** A maximal range of ports with the same device(s) in the same
-	  * direction(s).
-	  */
-	struct Row {
-		uint8_t begin; // inclusive
-		uint8_t end;   // inclusive
-		bool in;
-		bool out;
-		bool overlap;       // these ports are shared with another device
-		std::string device; // comma separated name(s)
-	};
-	[[nodiscard]] static std::vector<Row> getRows(MSXCPUInterface& cpuInterface);
-	[[nodiscard]] static std::string portsText(const Row& row);
-	[[nodiscard]] static std::string_view dirText(const Row& row);
-	static void sortRows(std::vector<Row>& rows);
-
-	void drawTable(MSXCPUInterface& cpuInterface, bool warnOverlap, EmuTime time);
-	void drawValue(MSXCPUInterface& cpuInterface, const Row& row, EmuTime time);
-
 	static constexpr auto persistentElements = std::tuple{
 		PersistentElement{"show", &ImGuiIoPorts::show}
 	};

--- a/src/imgui/ImGuiIoPorts.hh
+++ b/src/imgui/ImGuiIoPorts.hh
@@ -1,0 +1,69 @@
+#ifndef IMGUI_IOPORTS_HH
+#define IMGUI_IOPORTS_HH
+
+#include "ImGuiPart.hh"
+
+#include "EmuTime.hh"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace openmsx {
+
+class MSXCPUInterface;
+
+class ImGuiIoPorts final : public ImGuiPart
+{
+public:
+	using ImGuiPart::ImGuiPart;
+
+	// Note: not "ioports", that's already taken by the hex editor on the
+	// 'ioports' debuggable (DebuggableEditor::iniName() returns its title).
+	[[nodiscard]] zstring_view iniName() const override { return "io ports"; }
+	void save(ImGuiTextBuffer& buf) override;
+	void loadLine(std::string_view name, zstring_view value) override;
+	void paint(MSXMotherBoard* motherBoard) override;
+
+public:
+	bool show = false;
+
+private:
+	/** A maximal range of ports with the same device(s) in the same
+	  * direction(s).
+	  */
+	struct Row {
+		uint8_t begin; // inclusive
+		uint8_t end;   // inclusive
+		bool in;
+		bool out;
+		bool overlap;       // these ports are shared with another device
+		std::string device; // comma separated name(s), only in the flat view
+	};
+	/** All port ranges of a single device. Devices don't necessarily occupy
+	  * a contiguous range (e.g. the Philips NMS-1205).
+	  */
+	struct Group {
+		std::string device;
+		std::vector<Row> ranges;
+	};
+	[[nodiscard]] static std::vector<Row> getRows(MSXCPUInterface& cpuInterface);
+	[[nodiscard]] static std::vector<Group> getGroups(MSXCPUInterface& cpuInterface);
+	[[nodiscard]] static std::string portsText(const Row& row);
+	[[nodiscard]] static std::string_view dirText(const Row& row);
+
+	void drawFlat(MSXCPUInterface& cpuInterface, bool warnOverlap, EmuTime time);
+	void drawGrouped(MSXCPUInterface& cpuInterface, bool warnOverlap, EmuTime time);
+	void drawValue(MSXCPUInterface& cpuInterface, const Row& row, EmuTime time);
+
+	bool groupByDevice = false;
+
+	static constexpr auto persistentElements = std::tuple{
+		PersistentElement{"show", &ImGuiIoPorts::show},
+		PersistentElement{"groupByDevice", &ImGuiIoPorts::groupByDevice}
+	};
+};
+
+} // namespace openmsx
+
+#endif

--- a/src/imgui/ImGuiManager.cc
+++ b/src/imgui/ImGuiManager.cc
@@ -8,6 +8,7 @@
 #include "ImGuiDebugger.hh"
 #include "ImGuiDiskManipulator.hh"
 #include "ImGuiHelp.hh"
+#include "ImGuiIoPorts.hh"
 #include "ImGuiKeyboard.hh"
 #include "ImGuiMachine.hh"
 #include "ImGuiMedia.hh"
@@ -174,6 +175,7 @@ ImGuiManager::ImGuiManager(Reactor& reactor_)
 	symbols = std::make_unique<ImGuiSymbols>(*this);
 	watchExpr = std::make_unique<ImGuiWatchExpr>(*this);
 	traceViewer = std::make_unique<ImGuiTraceViewer>(*this);
+	ioPorts = std::make_unique<ImGuiIoPorts>(*this);
 	vdpRegs = std::make_unique<ImGuiVdpRegs>(*this);
 	palette = std::make_unique<ImGuiPalette>(*this);
 	plotterViewer = std::make_unique<ImGuiPlotterViewer>(*this);

--- a/src/imgui/ImGuiManager.hh
+++ b/src/imgui/ImGuiManager.hh
@@ -37,6 +37,7 @@ class ImGuiConsole;
 class ImGuiDebugger;
 class ImGuiDiskManipulator;
 class ImGuiHelp;
+class ImGuiIoPorts;
 class ImGuiKeyboard;
 class ImGuiMachine;
 class ImGuiMedia;
@@ -160,6 +161,7 @@ public:
 	std::unique_ptr<ImGuiSymbols> symbols;
 	std::unique_ptr<ImGuiWatchExpr> watchExpr;
 	std::unique_ptr<ImGuiTraceViewer> traceViewer;
+	std::unique_ptr<ImGuiIoPorts> ioPorts;
 	std::unique_ptr<ImGuiVdpRegs> vdpRegs;
 	std::unique_ptr<ImGuiPalette> palette;
 	std::unique_ptr<ImGuiPlotterViewer> plotterViewer;

--- a/src/imgui/ImGuiTools.cc
+++ b/src/imgui/ImGuiTools.cc
@@ -4,6 +4,7 @@
 #include "ImGuiConsole.hh"
 #include "ImGuiCpp.hh"
 #include "ImGuiDiskManipulator.hh"
+#include "ImGuiIoPorts.hh"
 #include "ImGuiKeyboard.hh"
 #include "ImGuiManager.hh"
 #include "ImGuiMessages.hh"
@@ -150,6 +151,8 @@ void ImGuiTools::showMenu(MSXMotherBoard* motherBoard)
 		ImGui::MenuItem("Slot map", nullptr, &manager.slotMap->show);
 		simpleToolTip("Show which devices are visible in which slot/page. "
 		              "Same information as the 'slotmap' console command.");
+		ImGui::MenuItem("I/O ports", nullptr, &manager.ioPorts->show);
+		simpleToolTip("Shows which device is connected to which I/O port");
 		ImGui::Separator();
 
 		im::Menu("Toys", [&]{


### PR DESCRIPTION
Shows which device is connected to which I/O port, the equivalent of the 'iomap' script but always up to date and without leaving the GUI.

Two views: flat, sorted by port number with consecutive ports of the same device(s) coalesced into one range; and grouped per device, because a device doesn't necessarily occupy a contiguous range (e.g. the Philips NMS-1205). Ports shared between devices are highlighted in yellow, unless the machine sets <devices overlap_warning="false">, matching what MSXCPUInterface already does for its startup warning.

The optional 'Value' column peeks the input ports, so opening the window doesn't change emulation state. It's hidden by default since the hex editor on the 'ioports' debuggable already shows those values.

<img width="501" height="595" alt="image" src="https://github.com/user-attachments/assets/85189298-0a23-4798-a27e-cab2d1de9123" />
<img width="495" height="597" alt="image" src="https://github.com/user-attachments/assets/b541418d-93ff-4e25-a332-16bd33fdbc96" />

Solves issue #2170