### PR TITLE
Make step_back skip entire block repeat instructions

### DIFF
--- a/share/scripts/_disasm.tcl
+++ b/share/scripts/_disasm.tcl
@@ -277,36 +277,32 @@ proc step_over {} {
 
 
 #
+# is_block_repeat
+#
+proc is_block_repeat {instr} {
+	expr {[string match "ldir*" $instr] || [string match "lddr*" $instr] ||
+	      [string match "cpir*" $instr] || [string match "cpdr*" $instr] ||
+	      [string match "inir*" $instr] || [string match "indr*" $instr] ||
+	      [string match "otir*" $instr] || [string match "otdr*" $instr]}
+}
+
+
+#
 # step_back
 #
 set_help_text step_back \
 {Step back. Go back in time till right before the last instruction was
 executed. Note that this operation is relatively slow (compared to the other
 step functions). Also the reverse feature must be enabled for this to work
-(normally it's enabled by default).}
-proc step_back {} {
-	# In the past this proc was implemented totally different. It's worth
-	# mentioning this old algorithm and explain why it wasn't good enough.
-	# The old algorithm went like this:
-	#  - take small steps back till we're not at the start instruction
-	#    anymore (this works because 'reverse goto' only stops after
-	#    emulating a full instruction)
-	# The problem was that on R800 it could take _many_ (more than 80)
-	# steps till the destination was reached.
-	#
-	# The current algorithm goes like this:
-	#  - take a large step back
-	#  - take small steps forward till we're back at the start
-	#  - we now know where the previous instruction started, so go there
-	#    (= take a small step back again)
-	#
-	# So the old algorithm takes (potentially) many backwards steps. While
-	# the new algorithm takes exactly 2 backwards steps and (potentially)
-	# many forward steps. In the current openMSX implementation, (small)
-	# forward steps are orders of magnitude faster than backwards steps (an
-	# optimization I added specifically for this use case). So the worst
-	# execution time should now be much better.
+(normally it's enabled by default).
 
+When the current instruction is a block repeat instruction (LDIR, LDDR,
+CPIR, CPDR, INIR, INDR, OTIR, OTDR), step_back will rewind to before the
+entire block instruction started (i.e. to the point before the first
+iteration), rather than just going back one iteration. This is also the
+case when the block sequence was interrupted by an IRQ: step_back still
+rewinds to the first iteration of the block execution.}
+proc step_back {} {
 	# 'z80' or 'r800'
 	set cpu [get_active_cpu]
 
@@ -320,6 +316,11 @@ proc step_back {} {
 	#  a safety margin in case I forgot some extra penalty cycles (e.g.
 	#  access to a device that inserts extra wait cycles).
 	set max_instr_len [expr {(($cpu eq "z80") ? 35 : 100) * $cycle_period}]
+
+	# Check if the current instruction is a block repeat instruction.
+	set current_addr [reg PC]
+	set current_instr [lindex [debug disasm $current_addr] 0]
+	set is_block [is_block_repeat $current_instr]
 
 	# Get time of the start instruction.
 	set start [dict get [reverse status] "current"]
@@ -359,8 +360,92 @@ proc step_back {} {
 	# The previous step was the correct one, so go back there.
 	# Note that (only here) we don't pass the '-novideo' flag
 	reverse goto $curr
-}
 
+	# If the current instruction is a block repeat instruction, we just
+	# went back one iteration. Instead, rewind to before the first
+	# iteration of the block instruction started.
+	if {$is_block} {
+		# Measure the time per iteration of this block instruction.
+		set time_after_first [dict get [reverse status] "current"]
+		set time_per_iter [expr {$start - $time_after_first}]
+
+		# Safety: ensure we always make at least a tiny progress.
+		if {$time_per_iter < $cycle_period} {
+			set time_per_iter $cycle_period
+		}
+
+		# Go back past all iterations of the block instruction using
+		# exponential backoff (O(log N) reverse goback calls instead
+		# of O(N)). We double the goback amount each time until PC
+		# no longer points to the block instruction address.
+		set goback [expr {$time_per_iter * 8}]
+		while {[reg PC] == $current_addr} {
+			reverse goback -novideo $goback
+			set goback [expr {$goback * 2}]
+		}
+
+		# Now we're somewhere before the block. Step forward, one
+		# instruction at a time, until the timestamp reaches the
+		# original start time. Checking only for 'PC == current_addr'
+		# is not enough to identify the first iteration of the current
+		# block execution:
+		#  * When the block instruction is inside a loop, the same PC
+		#    is also executed at many earlier times (earlier passes).
+		#  * When an IRQ interrupted the block, the boundaries inside
+		#    the interrupt handler do not match the block address, so
+		#    the current execution may consist of multiple runs of
+		#    matching boundaries.
+		# The boundary where a block execution starts is the one just
+		# before its first matching boundary, where the loop counter is
+		# still at its initial (maximum) value. The counter is the BC
+		# pair (LDIR, LDDR, CPIR, CPDR) or the B register alone, with C
+		# being a fixed I/O port (INIR, INDR, OTIR, OTDR); either way
+		# [reg BC] strictly decreases as the block runs, since B is
+		# decremented each iteration. Only such a boundary is a valid
+		# landing point. Runs that resume after an IRQ do not qualify
+		# (their counter is lower), and earlier loop passes are
+		# overwritten by the current one, so the last qualifying
+		# candidate before the start time is the first iteration of the
+		# current block execution.
+		reverse goback -novideo $max_instr_len
+		set curr [dict get [reverse status] "current"]
+		set cand -1
+		set max_bc -1
+		set inrun 0
+		while {1} {
+			reverse goto -novideo [expr {$curr + $cycle_period}]
+			set next [dict get [reverse status] "current"]
+			set match [expr {[reg PC] == $current_addr}]
+			if {$match && !$inrun} {
+				# new run of block iterations starts here; keep it as
+				# a candidate only if the block counter is fresh, i.e.
+				# if this is the start of a (new) block execution.
+				set bc [reg BC]
+				if {$bc >= $max_bc} {
+					set cand $curr
+					set max_bc $bc
+				}
+			}
+			set inrun $match
+			if {$next >= $start} {
+				# Time check: the original start time is reached.
+				# A PC match at an earlier time is not sufficient.
+				if {!$match && $cand < 0} {
+					# start time hit in the middle of a non-block
+					# instruction (e.g. when called from a
+					# watchpoint callback); land on the last
+					# boundary before the start time.
+					set cand $curr
+				}
+				break
+			}
+			set curr $next
+		}
+		if {$cand < 0} { set cand $curr }
+		# Note that (only here) we don't pass the '-novideo' flag
+		reverse goto $cand
+	}
+}
 
 #
 # skip one instruction

--- a/share/scripts/_disasm.tcl
+++ b/share/scripts/_disasm.tcl
@@ -317,11 +317,6 @@ proc step_back {} {
 	#  access to a device that inserts extra wait cycles).
 	set max_instr_len [expr {(($cpu eq "z80") ? 35 : 100) * $cycle_period}]
 
-	# Check if the current instruction is a block repeat instruction.
-	set current_addr [reg PC]
-	set current_instr [lindex [debug disasm $current_addr] 0]
-	set is_block [is_block_repeat $current_instr]
-
 	# Get time of the start instruction.
 	set start [dict get [reverse status] "current"]
 
@@ -361,11 +356,18 @@ proc step_back {} {
 	# Note that (only here) we don't pass the '-novideo' flag
 	reverse goto $curr
 
-	# If the current instruction is a block repeat instruction, we just
-	# went back one iteration. Instead, rewind to before the first
-	# iteration of the block instruction started.
-	if {$is_block} {
+	# Check if the instruction that is about to execute at this boundary is
+	# a block repeat instruction. This covers two cases:
+	#  * the current instruction IS the block: we just went back one
+	#    iteration, so [reg PC] still points to the block;
+	#  * the current instruction immediately follows a block (e.g. a RET
+	#    right after an LDIR): this boundary is the end of the block
+	#    execution, so [reg PC] points to the block that just finished.
+	# In both cases we rewind to before the first iteration of the block
+	# instruction instead of stopping at the end of the block.
+	if {[is_block_repeat [lindex [debug disasm [reg PC]] 0]]} {
 		# Measure the time per iteration of this block instruction.
+		set current_addr [reg PC]
 		set time_after_first [dict get [reverse status] "current"]
 		set time_per_iter [expr {$start - $time_after_first}]
 
@@ -420,9 +422,18 @@ proc step_back {} {
 				# new run of block iterations starts here; keep it as
 				# a candidate only if the block counter is fresh, i.e.
 				# if this is the start of a (new) block execution.
+				#
+				# Note: record 'next' (the current boundary), not 'curr'
+				# (the boundary we advanced from). The block counter is
+				# loaded by the instruction immediately preceding the
+				# block (e.g. 'LD BC,<max>' just before an LDIR), so the
+				# first boundary where PC matches the block already has
+				# the initial counter value; that is the correct landing
+				# point. Recording 'curr' would land one instruction too
+				# early (before the counter is loaded).
 				set bc [reg BC]
 				if {$bc >= $max_bc} {
-					set cand $curr
+					set cand $next
 					set max_bc $bc
 				}
 			}


### PR DESCRIPTION
**Make `step_back` skip entire block repeat instructions**

Closes #2089

## Problem

When `step_back` is called while the PC is on a block repeat instruction
(LDIR, LDDR, CPIR, CPDR, INIR, INDR, OTIR, OTDR), it only went back one
iteration of the block, keeping the PC on the same instruction. This made
step_back nearly useless for debugging code that uses block repeat
instructions, since the user would have to manually step back hundreds or
thousands of times to reach the code before the block.

For example, with `LDIR` at `$40B7` that copies 1000 bytes (BC=1000),
calling `step_back` from `$40B9` (after LDIR finished) would land back
at `$40B7` with BC=1, and the user would need to call `step_back` another
999 times to reach the instruction before the LDIR.

## Solution

When `step_back` detects that the current instruction is a block repeat
instruction, it now rewinds to before the *first* iteration of the block
started, rather than just going back one iteration.

### Algorithm

The normal step-back first goes back one iteration (landing at the block
instruction with BC incremented by 1). The block handling then:

1. **Measures time per iteration** from the one-iteration-back position
2. **Exponential backoff**: repeatedly calls `reverse goback` with
   doubling time amounts (2*, 4*, 8*, … * `time_per_iter`) until
   PC no longer points to the block instruction address. This goes past
   *all* iterations in O(log N) `reverse goback` calls instead of O(N).
3. **Forward search**: uses the same step-forward-to-boundary approach as
   the non-block case — goback a safety margin, then step forward one
   instruction at a time until PC reaches the block instruction address.
   The position just before that is the instruction before the block.

### Why exponential backoff?

A naive approach of going back one iteration at a time (O(N)) is too
slow when BC is large (up to 65535). Computing the exact goback time
from the loop counter is unreliable because we don't know the total
number of iterations — only the remaining count. Exponential backoff
guarantees we pass all iterations in at most ~16 `reverse goback` calls
for the maximum 16-bit BC value, then the forward search pinpoints the
exact instruction boundary.