### PR TITLE
Add debug_log / debug_log_read utility functions

### DIFF
--- a/share/scripts/_utils.tcl
+++ b/share/scripts/_utils.tcl
@@ -168,6 +168,25 @@ namespace export file_completion
 namespace export filename_clean
 namespace export get_next_numbered_filename
 
+#
+# debug_log / debug_log_read
+#
+# Accumulates debug messages in a buffer that can be read via
+# debug_log_read. This is useful for sending diagnostic output
+# through the MCP server, which cannot see puts/stderr output.
+#
+variable _debug_log {}
+proc debug_log {msg} {
+	variable _debug_log
+	lappend _debug_log $msg
+}
+proc debug_log_read {} {
+	variable _debug_log
+	set result [join $_debug_log "\n"]
+	set _debug_log {}
+	return $result
+}
+
 } ;# namespace utils
 
 # Don't import in global namespace, these are only useful in other scripts.


### PR DESCRIPTION
Add a simple debug message buffer to the utils namespace for use by Tcl scripts that need to send diagnostic output through the MCP server. Standard puts/stderr output is not visible to the MCP tools, so these functions accumulate messages in a buffer that can be read and cleared via `utils::debug_log` and `utils::debug_log_read`.