### PR TITLE
fix(input): scale MSX mouse movement in host window coordinates

### DIFF
--- a/src/input/Mouse.cc
+++ b/src/input/Mouse.cc
@@ -10,14 +10,16 @@
 #include "serialize_meta.hh"
 
 #include "Display.hh"
-#include "OutputSurface.hh"
 
-#include "Math.hh"
+#include "gl_vec.hh"
+
+#include "narrow.hh"
 #include "unreachable.hh"
 
 #include <SDL.h>
 
 #include <algorithm>
+#include <cmath>
 
 namespace openmsx {
 
@@ -32,6 +34,21 @@ static constexpr int PHASE_XLOW2  = 5;
 static constexpr int PHASE_YHIGH2 = 6;
 static constexpr int PHASE_YLOW2  = 7;
 static constexpr int STROBE = 0x04;
+
+/** Convert host mouse movement along one axis to a whole number of MSX
+  * pixels. The part that doesn't (yet) add up to a full MSX pixel is
+  * remembered in 'fraction', so that slow movements don't get lost.
+  * Note: rounding in a uniform direction (instead of towards zero) gives
+  * smoother output.
+  */
+static int scaleHostMotion(int delta, float scale, float& fraction)
+{
+	if (scale <= 0.0f) return 0;
+	float value = narrow_cast<float>(delta) + fraction;
+	float result = std::floor(value / scale);
+	fraction = value - (result * scale);
+	return narrow_cast<int>(result);
+}
 
 
 Mouse::Mouse(MSXEventDistributor& eventDistributor_,
@@ -87,7 +104,6 @@ void Mouse::unplugHelper(EmuTime /*time*/)
 	stateChangeDistributor.unregisterListener(*this);
 	eventDistributor.unregisterEventListener(*this);
 }
-
 
 // JoystickDevice
 uint8_t Mouse::read(EmuTime /*time*/)
@@ -239,21 +255,16 @@ void Mouse::signalMSXEvent(const Event& event, EmuTime time) noexcept
 	visit(overloaded{
 		[&](const MouseMotionEvent& e) {
 			if (e.getX() || e.getY()) {
-				// Note: regular C/C++ division rounds towards
-				// zero, so different direction for positive and
-				// negative values. But we get smoother output
-				// with a uniform rounding direction.
-				float scale = SCALE;
-				if (const auto* output = display.getOutputSurface()) {
-					scale = output->getPhysicalSize().y / 240;
-				}
-				auto qrX = Math::div_mod_floor(e.getX() + fractionalX, scale);
-				auto qrY = Math::div_mod_floor(e.getY() + fractionalY, scale);
-				fractionalX = qrX.remainder;
-				fractionalY = qrY.remainder;
+				// Scale host mouse movement such that the MSX pointer
+				// travels the same distance on screen as the host
+				// pointer. The scale differs per axis because MSX
+				// pixels are not drawn square (see 'horizontal_stretch').
+				auto scale = display.getMsxPixelSize().value_or(gl::vec2(SCALE, SCALE));
+				auto deltaX = scaleHostMotion(e.getX(), scale.x, fractionalX);
+				auto deltaY = scaleHostMotion(e.getY(), scale.y, fractionalY);
 
 				// Note: hostXY is negated when converting to MsxXY
-				createMouseStateChange(time, -qrX.quotient, -qrY.quotient, 0, 0);
+				createMouseStateChange(time, -deltaX, -deltaY, 0, 0);
 			}
 		},
 		[&](const MouseButtonDownEvent& e) {

--- a/src/input/Mouse.cc
+++ b/src/input/Mouse.cc
@@ -13,13 +13,12 @@
 
 #include "gl_vec.hh"
 
-#include "narrow.hh"
 #include "unreachable.hh"
 
 #include <SDL.h>
 
 #include <algorithm>
-#include <cmath>
+#include <cassert>
 
 namespace openmsx {
 
@@ -35,19 +34,19 @@ static constexpr int PHASE_YHIGH2 = 6;
 static constexpr int PHASE_YLOW2  = 7;
 static constexpr int STROBE = 0x04;
 
-/** Convert host mouse movement along one axis to a whole number of MSX
-  * pixels. The part that doesn't (yet) add up to a full MSX pixel is
-  * remembered in 'fraction', so that slow movements don't get lost.
+/** Convert host mouse movement to a whole number of MSX pixels. The part
+  * that doesn't (yet) add up to a full MSX pixel is remembered in
+  * 'fraction', so that slow movements don't get lost.
   * Note: rounding in a uniform direction (instead of towards zero) gives
   * smoother output.
   */
-static int scaleHostMotion(int delta, float scale, float& fraction)
+static gl::ivec2 scaleHostMotion(gl::ivec2 delta, gl::vec2 scale, gl::vec2& fraction)
 {
-	if (scale <= 0.0f) return 0;
-	float value = narrow_cast<float>(delta) + fraction;
-	float result = std::floor(value / scale);
-	fraction = value - (result * scale);
-	return narrow_cast<int>(result);
+	assert((scale.x > 0.0f) && (scale.y > 0.0f));
+	auto value = gl::vec2(delta) + fraction;
+	auto result = floor(value / scale);
+	fraction = value - (gl::vec2(result) * scale);
+	return result;
 }
 
 
@@ -259,12 +258,12 @@ void Mouse::signalMSXEvent(const Event& event, EmuTime time) noexcept
 				// travels the same distance on screen as the host
 				// pointer. The scale differs per axis because MSX
 				// pixels are not drawn square (see 'horizontal_stretch').
-				auto scale = display.getMsxPixelSize().value_or(gl::vec2(SCALE, SCALE));
-				auto deltaX = scaleHostMotion(e.getX(), scale.x, fractionalX);
-				auto deltaY = scaleHostMotion(e.getY(), scale.y, fractionalY);
+				auto scale = display.getMsxPixelSize().value_or(gl::vec2(SCALE));
+				auto delta = scaleHostMotion(gl::ivec2(e.getX(), e.getY()),
+				                             scale, fractional);
 
 				// Note: hostXY is negated when converting to MsxXY
-				createMouseStateChange(time, -deltaX, -deltaY, 0, 0);
+				createMouseStateChange(time, -delta.x, -delta.y, 0, 0);
 			}
 		},
 		[&](const MouseButtonDownEvent& e) {

--- a/src/input/Mouse.hh
+++ b/src/input/Mouse.hh
@@ -57,7 +57,7 @@ private:
 	int phase;
 	int xRel = 0, yRel = 0;               // latched X/Y values, these are returned to the MSX
 	int curXRel = 0, curYRel = 0;         // running X/Y values, already scaled down
-	int fractionalX = 0, fractionalY = 0; // running X/Y values, not yet scaled down
+	float fractionalX = 0.0f, fractionalY = 0.0f; // running X/Y values, not yet scaled down
 	uint8_t status = JOY_BUTTONA | JOY_BUTTONB;
 	bool mouseMode = true;
 };

--- a/src/input/Mouse.hh
+++ b/src/input/Mouse.hh
@@ -8,6 +8,8 @@
 #include "StateChangeListener.hh"
 #include "serialize_meta.hh"
 
+#include "gl_vec.hh"
+
 namespace openmsx {
 
 class MSXEventDistributor;
@@ -57,7 +59,7 @@ private:
 	int phase;
 	int xRel = 0, yRel = 0;               // latched X/Y values, these are returned to the MSX
 	int curXRel = 0, curYRel = 0;         // running X/Y values, already scaled down
-	float fractionalX = 0.0f, fractionalY = 0.0f; // running X/Y values, not yet scaled down
+	gl::vec2 fractional;                  // running X/Y values, not yet scaled down
 	uint8_t status = JOY_BUTTONA | JOY_BUTTONB;
 	bool mouseMode = true;
 };

--- a/src/video/Display.cc
+++ b/src/video/Display.cc
@@ -99,6 +99,11 @@ OutputSurface* Display::getOutputSurface()
 	return videoSystem ? videoSystem->getOutputSurface() : nullptr;
 }
 
+std::optional<gl::vec2> Display::getMsxPixelSize()
+{
+	return videoSystem ? videoSystem->getMsxPixelSize() : std::nullopt;
+}
+
 void Display::resetVideoSystem()
 {
 	videoSystem.reset();

--- a/src/video/Display.hh
+++ b/src/video/Display.hh
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace openmsx {
@@ -69,6 +70,11 @@ public:
 	[[nodiscard]] const Layers& getAllLayers() const { return layers; }
 
 	[[nodiscard]] OutputSurface* getOutputSurface();
+
+	/** Returns the size of a single MSX pixel as it is currently drawn on
+	  * screen, expressed in the same units as the host mouse coordinates.
+	  * Returns std::nullopt when there's no window to draw on. */
+	[[nodiscard]] std::optional<gl::vec2> getMsxPixelSize();
 
 	[[nodiscard]] std::string getWindowTitle();
 

--- a/src/video/DummyVideoSystem.cc
+++ b/src/video/DummyVideoSystem.cc
@@ -38,6 +38,11 @@ std::optional<gl::ivec2> DummyVideoSystem::getMouseCoord()
 	return {};
 }
 
+std::optional<gl::vec2> DummyVideoSystem::getMsxPixelSize()
+{
+	return {};
+}
+
 OutputSurface* DummyVideoSystem::getOutputSurface()
 {
 	return nullptr;

--- a/src/video/DummyVideoSystem.hh
+++ b/src/video/DummyVideoSystem.hh
@@ -19,6 +19,7 @@ public:
 #endif
 	void flush() override;
 	[[nodiscard]] std::optional<gl::ivec2> getMouseCoord() override;
+	[[nodiscard]] std::optional<gl::vec2> getMsxPixelSize() override;
 	[[nodiscard]] OutputSurface* getOutputSurface() override;
 	void showCursor(bool show) override;
 	[[nodiscard]] bool getCursorEnabled() override;

--- a/src/video/SDLVideoSystem.cc
+++ b/src/video/SDLVideoSystem.cc
@@ -134,6 +134,11 @@ std::optional<gl::ivec2> SDLVideoSystem::getMouseCoord()
 	return screen->getMouseCoord();
 }
 
+std::optional<gl::vec2> SDLVideoSystem::getMsxPixelSize()
+{
+	return screen->getMsxPixelSize();
+}
+
 OutputSurface* SDLVideoSystem::getOutputSurface()
 {
 	return screen.get();

--- a/src/video/SDLVideoSystem.hh
+++ b/src/video/SDLVideoSystem.hh
@@ -46,6 +46,7 @@ public:
 	void takeScreenShot(const std::string& filename, bool withOsd) override;
 	void updateWindowTitle() override;
 	[[nodiscard]] std::optional<gl::ivec2> getMouseCoord() override;
+	[[nodiscard]] std::optional<gl::vec2> getMsxPixelSize() override;
 	[[nodiscard]] OutputSurface* getOutputSurface() override;
 	void showCursor(bool show) override;
 	[[nodiscard]] bool getCursorEnabled() override;

--- a/src/video/VideoSystem.hh
+++ b/src/video/VideoSystem.hh
@@ -68,6 +68,14 @@ public:
 	  */
 	[[nodiscard]] virtual std::optional<gl::ivec2> getMouseCoord() = 0;
 
+	/** Returns the size of a single MSX pixel as it is currently drawn on
+	  * screen, expressed in the same units as the mouse coordinates (SDL
+	  * window coordinates, which on high-DPI displays are not the same as
+	  * physical pixels).
+	  * Returns std::nullopt when there's no window to draw on.
+	  */
+	[[nodiscard]] virtual std::optional<gl::vec2> getMsxPixelSize() = 0;
+
 	/** TODO */
 	[[nodiscard]] virtual OutputSurface* getOutputSurface() = 0;
 	virtual void showCursor(bool show) = 0;

--- a/src/video/VisibleSurface.cc
+++ b/src/video/VisibleSurface.cc
@@ -353,26 +353,25 @@ std::optional<gl::ivec2> VisibleSurface::getMouseCoord() const
 	return gl::ivec2{mouseX, mouseY};
 }
 
-std::optional<gl::vec2> VisibleSurface::getMsxPixelSize() const
+gl::vec2 VisibleSurface::getMsxPixelSize() const
 {
-	auto physSize = gl::vec2(getPhysicalSize());
-	if ((physSize.x <= 0.0f) || (physSize.y <= 0.0f)) return {};
-
-	// The viewport is expressed in physical pixels, but SDL reports mouse
-	// coordinates in window coordinates ('points'). On high-DPI displays
-	// those are not the same, so convert via the window size.
+	// SDL reports mouse coordinates in window coordinates ('points').
 	int windowW, windowH;
 	SDL_GetWindowSize(window.get(), &windowW, &windowH);
+	auto windowSize = gl::vec2(narrow<float>(windowW), narrow<float>(windowH));
 
+	// The image shows 'horizontal_stretch' of the 320 MSX pixels per line,
+	// and always all 240 lines.
 	const auto& renderSettings = display.getRenderSettings();
-	auto viewSize = gl::vec2(renderSettings.getFullStretch() ? getPhysicalSize()
-	                                                         : getViewSize());
-	auto viewInPoints = viewSize * gl::vec2(narrow<float>(windowW), narrow<float>(windowH))
-	                  / physSize;
+	auto msxSize = gl::vec2(renderSettings.getHorizontalStretch(), 240.0f);
 
-	// The viewport shows 'horizontal_stretch' of the 320 MSX pixels per
-	// line, and always all 240 lines.
-	return viewInPoints / gl::vec2(renderSettings.getHorizontalStretch(), 240.0f);
+	if (renderSettings.getFullStretch()) {
+		return windowSize / msxSize; // image covers the whole window
+	}
+	// The viewport is expressed in physical pixels, which on high-DPI
+	// displays are not the same as points, so convert via the window size.
+	return (gl::vec2(getViewSize()) * windowSize) /
+	       (gl::vec2(getPhysicalSize()) * msxSize);
 }
 
 

--- a/src/video/VisibleSurface.cc
+++ b/src/video/VisibleSurface.cc
@@ -353,6 +353,28 @@ std::optional<gl::ivec2> VisibleSurface::getMouseCoord() const
 	return gl::ivec2{mouseX, mouseY};
 }
 
+std::optional<gl::vec2> VisibleSurface::getMsxPixelSize() const
+{
+	auto physSize = gl::vec2(getPhysicalSize());
+	if ((physSize.x <= 0.0f) || (physSize.y <= 0.0f)) return {};
+
+	// The viewport is expressed in physical pixels, but SDL reports mouse
+	// coordinates in window coordinates ('points'). On high-DPI displays
+	// those are not the same, so convert via the window size.
+	int windowW, windowH;
+	SDL_GetWindowSize(window.get(), &windowW, &windowH);
+
+	const auto& renderSettings = display.getRenderSettings();
+	auto viewSize = gl::vec2(renderSettings.getFullStretch() ? getPhysicalSize()
+	                                                         : getViewSize());
+	auto viewInPoints = viewSize * gl::vec2(narrow<float>(windowW), narrow<float>(windowH))
+	                  / physSize;
+
+	// The viewport shows 'horizontal_stretch' of the 320 MSX pixels per
+	// line, and always all 240 lines.
+	return viewInPoints / gl::vec2(renderSettings.getHorizontalStretch(), 240.0f);
+}
+
 
 void VisibleSurface::saveScreenshot(const std::string& filename)
 {

--- a/src/video/VisibleSurface.hh
+++ b/src/video/VisibleSurface.hh
@@ -48,7 +48,7 @@ public:
 	                             const std::string& filename);
 
 	[[nodiscard]] std::optional<gl::ivec2> getMouseCoord() const;
-	[[nodiscard]] std::optional<gl::vec2> getMsxPixelSize() const;
+	[[nodiscard]] gl::vec2 getMsxPixelSize() const;
 	void updateWindowTitle();
 	bool setFullScreen(bool fullscreen);
 	void resize();

--- a/src/video/VisibleSurface.hh
+++ b/src/video/VisibleSurface.hh
@@ -48,6 +48,7 @@ public:
 	                             const std::string& filename);
 
 	[[nodiscard]] std::optional<gl::ivec2> getMouseCoord() const;
+	[[nodiscard]] std::optional<gl::vec2> getMsxPixelSize() const;
 	void updateWindowTitle();
 	bool setFullScreen(bool fullscreen);
 	void resize();


### PR DESCRIPTION
Since commit 396a7b0fa the host-to-MSX mouse scale was derived from OutputSurface::getPhysicalSize(), which is expressed in physical pixels. SDL reports mouse motion in window coordinates ('points'), and on macOS openMSX creates its window with SDL_WINDOW_ALLOW_HIGHDPI, so on a retina display those differ by the backing scale factor. The MSX pointer moved at half the speed of the host pointer. Measured with scale_factor 4: a 1280x960 point window has a 2560x1920 drawable, so the scale was 8 points per MSX pixel where it should be 4.

Two smaller problems in the same expression, and these do affect all platforms:
- it was an integer division, so in full screen the ratio got truncated. At 1080p with scale_factor 2 that gave 4 instead of 4.5;
- it used one scale for both axes, while 'horizontal_stretch' means MSX pixels are not drawn square. At the default of 280 the X axis needs to be about 14% faster than the Y axis to track the host pointer.

Add VisibleSurface::getMsxPixelSize(), which returns the on-screen size of a single MSX pixel per axis, in the same unit SDL uses for mouse coordinates. It converts the viewport from physical pixels to points via the window size, and takes 'full_stretch' and 'horizontal_stretch' into account. Mouse now uses that, keeping the sub-pixel remainder in a float so slow movements are still not lost.

Note that this scales for equal distance on screen, which is not the same as equal distance in MSX pixels when horizontal_stretch is not 320: the MSX pointer then crosses fewer MSX pixels per centimetre horizontally than vertically.

Trackball and Paddle keep their fixed SCALE of 2: they never used the display size, and neither is a 1:1 pointer device.

I only tested this on my macbook, so maybe somebody can check it on windows/linux. The software I used to test with was Dot Designer Club of T&E Soft.