### PR TITLE
Fix saving a setup for machines with a '/' in their name (#2071)

### DIFF
--- a/src/file/FileOperations.cc
+++ b/src/file/FileOperations.cc
@@ -281,6 +281,28 @@ std::string_view stem(std::string_view path)
 	return path.substr(pos2 + 1, pos1 - pos2 - 1);
 }
 
+// Characters that are not allowed (or not desirable) in a filename.
+// Keep in sync with 'utils::filename_clean' in share/scripts/_utils.tcl.
+static constexpr std::string_view disallowedInFilename =
+#ifdef _WIN32
+	R"(/\?*:|"<>+[])";
+#else
+	"/";
+#endif
+
+std::string cleanFilename(std::string_view filename)
+{
+	std::string result{filename};
+	std::ranges::replace_if(result, [](char c) {
+		// UNIX does allow 0x01-0x1f and 0x7f, but we consider them
+		// undesirable. Note that bytes >= 0x80 are left alone, so
+		// UTF-8 multi-byte sequences pass through unchanged.
+		auto u = static_cast<unsigned char>(c);
+		return (u < 0x20) || (u == 0x7f) || disallowedInFilename.contains(c);
+	}, '_');
+	return result;
+}
+
 std::string join(std::string_view part1, std::string_view part2)
 {
 	if (part1.empty() || isAbsolutePath(part2)) {

--- a/src/file/FileOperations.hh
+++ b/src/file/FileOperations.hh
@@ -151,6 +151,21 @@ namespace openmsx::FileOperations {
 	 */
 	 [[nodiscard]] std::string_view stem(std::string_view path);
 
+	/**
+	 * Replace characters that are not allowed (or not desirable) in a
+	 * filename by '_'. The result is a single path component: path
+	 * separators are replaced as well, so this is not suitable to clean
+	 * a whole path.
+	 * Mostly useful to turn free-form text (e.g. an MSX machine display
+	 * name or a guessed software title) into something that can be used
+	 * as a filename.
+	 * This is the C++ equivalent of the Tcl proc 'utils::filename_clean'
+	 * (see share/scripts/_utils.tcl), keep the two in sync.
+	 * @param filename The filename to clean
+	 * @result The cleaned filename, always the same length as the input.
+	 */
+	[[nodiscard]] std::string cleanFilename(std::string_view filename);
+
 	/** Join two paths.
 	 * Returns the equivalent of 'path1 + '/' + path2'. If 'part2' is an
 	 * absolute path, that path is returned ('part1' is ignored). If

--- a/src/imgui/ImGuiMachine.cc
+++ b/src/imgui/ImGuiMachine.cc
@@ -12,6 +12,7 @@
 #include "Debuggable.hh"
 #include "Debugger.hh"
 #include "FileException.hh"
+#include "FileOperations.hh"
 #include "GlobalSettings.hh"
 #include "HardwareConfig.hh"
 #include "MSXCommandController.hh"
@@ -208,7 +209,11 @@ void ImGuiMachine::showMenu(MSXMotherBoard* motherBoard)
 					// on each re-open of this menu, create a suggestion for a name
 					auto configName = motherBoard->getMachineName();
 					const auto* info = findMachineInfo(configName);
-					auto initialSaveSetupName = info ? info->displayName : configName;
+					// The display name is free-form text, it can contain
+					// characters that are invalid in a filename, e.g.
+					// "Philips VG 8235/39".
+					auto initialSaveSetupName = FileOperations::cleanFilename(
+						info ? info->displayName : configName);
 					saveSetupName = initialSaveSetupName;
 					if (exists()) {
 						saveSetupName = FileOperations::stem(FileOperations::getNextNumberedFileName(
@@ -223,13 +228,18 @@ void ImGuiMachine::showMenu(MSXMotherBoard* motherBoard)
 
 					auto action = [this, motherBoard] {
 						if (motherBoard) {
-							// pass full filename
-							auto filename = FileOperations::parseCommandFileArgument(
-								saveSetupName, Reactor::SETUP_DIR, "", Reactor::SETUP_EXTENSION);
-							motherBoard->storeAsSetup(filename, saveSetupDepth);
-							manager.getCliComm().printInfo(strCat("Setup saved to ", saveSetupName));
-							if (setSetupAsDefault) {
-								manager.getReactor().getDefaultSetupSetting().setString(saveSetupName);
+							try {
+								// pass full filename
+								auto filename = FileOperations::parseCommandFileArgument(
+									saveSetupName, Reactor::SETUP_DIR, "", Reactor::SETUP_EXTENSION);
+								motherBoard->storeAsSetup(filename, saveSetupDepth);
+								manager.getCliComm().printInfo(strCat("Setup saved to ", filename));
+								if (setSetupAsDefault) {
+									manager.getReactor().getDefaultSetupSetting().setString(saveSetupName);
+								}
+							} catch (MSXException& e) {
+								manager.getCliComm().printError(
+									"Couldn't save setup: ", e.getMessage());
 							}
 							setSetupAsDefault = false;
 						}

--- a/src/imgui/ImGuiReverseBar.cc
+++ b/src/imgui/ImGuiReverseBar.cc
@@ -122,10 +122,14 @@ void ImGuiReverseBar::showMenu(MSXMotherBoard* motherBoard)
 			if (!saveStateOpen) {
 				// on each re-open of this menu, create a suggestion for a name
 				if (auto result = manager.execute(makeTclList("guess_title", "savestate"))) {
-					saveStateName = result->getString();
+					// 'guess_title' returns free-form text read from the MSX
+					// software, it can contain characters that are invalid in
+					// a filename.
+					auto title = FileOperations::cleanFilename(result->getString());
+					saveStateName = title;
 					if (exists()) {
 						saveStateName = FileOperations::stem(FileOperations::getNextNumberedFileName(
-							STATE_DIR, result->getString(), STATE_EXTENSION, true));
+							STATE_DIR, title, STATE_EXTENSION, true));
 					}
 				}
 			}
@@ -166,10 +170,14 @@ void ImGuiReverseBar::showMenu(MSXMotherBoard* motherBoard)
 			if (!saveReplayOpen) {
 				// on each re-open of this menu, create a suggestion for a name
 				if (auto result = manager.execute(makeTclList("guess_title", "replay"))) {
-					saveReplayName = result->getString();
+					// 'guess_title' returns free-form text read from the MSX
+					// software, it can contain characters that are invalid in
+					// a filename.
+					auto title = FileOperations::cleanFilename(result->getString());
+					saveReplayName = title;
 					if (exists()) {
 						saveReplayName = FileOperations::stem(FileOperations::getNextNumberedFileName(
-							ReverseManager::REPLAY_DIR, result->getString(), ReverseManager::REPLAY_EXTENSION, true));
+							ReverseManager::REPLAY_DIR, title, ReverseManager::REPLAY_EXTENSION, true));
 					}
 				}
 			}

--- a/src/imgui/ImGuiTools.cc
+++ b/src/imgui/ImGuiTools.cc
@@ -191,7 +191,9 @@ bool ImGuiTools::screenshotNameExists() const
 void ImGuiTools::generateScreenshotName()
 {
 	if (auto result = manager.execute(makeTclList("guess_title", "openmsx"))) {
-		screenshotName = result->getString();
+		// 'guess_title' returns free-form text read from the MSX software,
+		// it can contain characters that are invalid in a filename.
+		screenshotName = FileOperations::cleanFilename(result->getString());
 	}
 	if (screenshotName.empty()) {
 		screenshotName = "openmsx";

--- a/src/unittest/FileOperations_test.cc
+++ b/src/unittest/FileOperations_test.cc
@@ -32,3 +32,56 @@ TEST_CASE("stem")
 	check("path/.");
 	check("path/..");
 }
+
+TEST_CASE("cleanFilename")
+{
+	// Characters that are valid on every platform are left alone.
+	CHECK(cleanFilename("") == "");
+	CHECK(cleanFilename("openmsx") == "openmsx");
+	CHECK(cleanFilename("Philips NMS 8250") == "Philips NMS 8250");
+	CHECK(cleanFilename("setup-1.oms") == "setup-1.oms");
+
+	// Path separators are always replaced, this is the actual bug.
+	CHECK(cleanFilename("Philips VG 8235/39") == "Philips VG 8235_39");
+	CHECK(cleanFilename("/") == "_");
+	CHECK(cleanFilename("a/b/c") == "a_b_c");
+
+	// Control characters and DEL are always replaced.
+	CHECK(cleanFilename("a\tb") == "a_b");
+	CHECK(cleanFilename("a\nb") == "a_b");
+	CHECK(cleanFilename("a\x7f" "b") == "a_b");
+
+	// Non-ASCII (UTF-8) is left alone: only bytes < 0x80 are considered.
+	CHECK(cleanFilename("caf\xc3\xa9") == "caf\xc3\xa9");
+	CHECK(cleanFilename("\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e") ==
+	                    "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e"); // 日本語
+	// A real YEN SIGN is a valid filename character and must be kept. Note
+	// that on a Japanese Windows the path separator is *displayed* as a yen
+	// sign, but it is the ordinary backslash (0x5c), which is handled above.
+	CHECK(cleanFilename("a\xc2\xa5" "b") == "a\xc2\xa5" "b");         // U+00A5 ¥
+	CHECK(cleanFilename("a\xef\xbf\xa5" "b") == "a\xef\xbf\xa5" "b"); // U+FFE5 ￥
+	// U+8868 is 0x95 0x5c in Shift-JIS: scanning *those* bytes for a
+	// backslash would corrupt it. openMSX filenames are UTF-8 (0xe8 0xa1
+	// 0xa8 here), so no such trailing byte can occur.
+	CHECK(cleanFilename("\xe8\xa1\xa8") == "\xe8\xa1\xa8");           // U+8868 表
+
+	// The result always has the same length as the input.
+	auto checkLen = [](std::string_view input) {
+		CHECK(cleanFilename(input).size() == input.size());
+	};
+	checkLen("Yamaha CX5MII/128");
+	checkLen("Mitsubishi ML-G30/model 1");
+	checkLen("caf\xc3\xa9/\xe6\x97\xa5\xe6\x9c\xac");
+
+#ifdef _WIN32
+	CHECK(cleanFilename(R"(a\b)") == "a_b");
+	CHECK(cleanFilename("C:foo") == "C_foo");
+	CHECK(cleanFilename("a?b*c") == "a_b_c");
+	CHECK(cleanFilename("a[b]c") == "a_b_c");
+#else
+	// These are legal on UNIX and must be preserved.
+	CHECK(cleanFilename(R"(a\b)") == R"(a\b)");
+	CHECK(cleanFilename("a:b") == "a:b");
+	CHECK(cleanFilename("a[b]c") == "a[b]c");
+#endif
+}


### PR DESCRIPTION
Fixes #2071 

- added FileOperations::cleanFilename(), the C++ counterpart of the existing Tcl utils::filename_clean, mirroring its per-platform disallowed sets so both halves of openMSX produce the same filename for the same text. Only bytes < 0x80 are touched, so UTF-8 passes through unchanged.
- Applied to the four generated name suggestions: the setup name in ImGuiMachine, and the three guess_title suggestions in ImGuiTools (screenshot) and ImGuiReverseBar (save state, save replay). The latter three already had the cleaning step in their Tcl equivalents; the GUI just never got it.
- Caught the save exception in ImGuiMachine, like the Load setup button already does.

What the user types is deliberately left alone, these boxes accept a path on purpose which is why the fix is a cleaned suggestion plus an error report, not validation of the input.

Cleaning is applied where initialSaveSetupName is created rather than to the copy in the text box, which also fixes a second bug: the raw name reaching getNextNumberedFileName() made stem() split on the / and silently truncate the suggestion to 39 0001.

