### PR TITLE
Fix the unittest build on macOS

### DIFF
--- a/src/unittest/FixedPoint_test.cc
+++ b/src/unittest/FixedPoint_test.cc
@@ -3,7 +3,7 @@
 
 #include "narrow.hh"
 
-using namespace openmsx;
+namespace openmsx {
 
 template<unsigned BITS>
 static void check(const FixedPoint<BITS>& fp, int expectedRaw)
@@ -79,3 +79,5 @@ TEST_CASE("FixedPoint")
 	b.addQuantum(); check(b,  15);
 	c.addQuantum(); check(c, -46);
 }
+
+} // namespace openmsx

--- a/src/utils/StringOp.cc
+++ b/src/utils/StringOp.cc
@@ -8,6 +8,10 @@
 #include <bit>
 #include <cstdlib>
 
+#ifdef __APPLE__
+#include <CoreFoundation/CoreFoundation.h>
+#endif
+
 namespace StringOp {
 
 bool stringToBool(std::string_view str)

--- a/src/utils/StringOp.hh
+++ b/src/utils/StringOp.hh
@@ -18,7 +18,12 @@
 #include <utility>
 
 #ifdef __APPLE__
-#include <CoreFoundation/CoreFoundation.h>
+// Only forward declare 'CFStringRef' (for fromCFString() below). Including
+// <CoreFoundation/CoreFoundation.h> here would drag it into the ~75% of all
+// translation units that (indirectly) include this header, and it declares a
+// lot of names in the global namespace. E.g. MacTypes.h declares a global
+// 'FixedPoint', which clashes with openmsx::FixedPoint.
+using CFStringRef = const struct __CFString*;
 #endif
 
 namespace StringOp


### PR DESCRIPTION
The unittest flavour didn't compile on macOS. make OPENMSX_FLAVOUR=unittest fails with 7 errors, all in FixedPoint_test.cc:

error: reference to 'FixedPoint' is ambiguous
  note: candidate found by name lookup is 'FixedPoint'          <SDK>/usr/include/MacTypes.h:562
  note: candidate found by name lookup is 'openmsx::FixedPoint'  src/utils/FixedPoint.hh:16

Cause. MacTypes.h declares typedef struct FixedPoint FixedPoint; in the global namespace, and it reaches the test via:

FixedPoint_test.cc -> FixedPoint.hh -> serialize.hh -> StringOp.hh
  -> CoreFoundation.h -> CFBase.h -> MacTypes.h

The test has using namespace openmsx; at global scope, which puts openmsx::FixedPoint at the same lookup level as the global one, so every unqualified use is ambiguous. Normal code is unaffected because it uses FixedPoint from inside namespace openmsx, where lookup stops before reaching the global namespace.

Two commits:

1. unittest: fix FixedPoint_test build on macOS — put the test in namespace openmsx { … } rather than using a global using, like MemoryBufferFile.cc already does. This alone makes the suite build and pass.
2. StringOp: don't include all of CoreFoundation in the header — the underlying reason CoreFoundation is in that include chain at all. StringOp.hh only needs the CFStringRef type name for the fromCFString() declaration, so forward declare it and move the real include into StringOp.cc, which is what actually uses the CF functions. On macOS that header is included (indirectly) by 440 of 581 translation units, and it was dropping the whole global-namespace contents of CoreFoundation into each one. #include "FixedPoint.hh" now pulls 1444 headers instead of 1621.

The forward declaration is compatible with the real typedef in both C++ and Objective-C++ (checked, since FileOperationsMac.mm exists).

Tested on macOS (arm64): normal build unchanged, unittest build clean, and

All tests passed (14544438 assertions in 198 test cases)

Only the second commit touches non-test code, so it can be dropped if you'd rather fix just the test for now.