### PR TITLE
Report applied IPS patches from cart<slot> query

### DIFF
--- a/src/CartridgeSlotManager.cc
+++ b/src/CartridgeSlotManager.cc
@@ -19,6 +19,8 @@
 #include <array>
 #include <cassert>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace openmsx {
 
@@ -379,6 +381,27 @@ void CartridgeSlotManager::removeCartridge(std::string_view cartName)
 	}
 }
 
+std::vector<std::string> CartridgeSlotManager::getCartRomState(
+	std::string_view cartName) const
+{
+	std::vector<std::string> result;
+	const auto* extConf = getExtensionConfig(cartName);
+	if (!extConf || (extConf->getType() != HardwareConfig::Type::ROM)) {
+		return result;
+	}
+	// A ROM cartridge, peek into the (auto-generated) config for the
+	// applied IPS patches.
+	const auto& romConfig = extConf->getConfig()
+		.getChild("devices").getChild("primary").getChild("secondary")
+		.getChild("ROM").getChild("rom");
+	if (const auto* patchesElem = romConfig.findChild("patches")) {
+		for (const auto* p : patchesElem->getChildren("ips")) {
+			result.emplace_back(p->getData());
+		}
+	}
+	return result;
+}
+
 // CartCmd
 CartridgeSlotManager::CartCmd::CartCmd(
 		CartridgeSlotManager& manager_, MSXMotherBoard& motherBoard_,
@@ -420,6 +443,14 @@ void CartridgeSlotManager::CartCmd::execute(
 		if (!extConf) {
 			TclObject options = makeTclList("empty");
 			result.addListElement(options);
+		} else if (extConf->getType() == HardwareConfig::Type::ROM) {
+			// also report the applied IPS patches
+			auto patches = manager.getCartRomState(cartName);
+			TclObject patchesList;
+			for (const auto& p : patches) {
+				patchesList.addListElement(p);
+			}
+			result.addListElement(patchesList);
 		}
 	} else if (tokens[1] == one_of("eject", "-eject")) {
 		// remove cartridge (or extension)

--- a/src/CartridgeSlotManager.hh
+++ b/src/CartridgeSlotManager.hh
@@ -13,7 +13,9 @@
 #include <array>
 #include <cassert>
 #include <optional>
+#include <string>
 #include <string_view>
+#include <vector>
 
 namespace openmsx {
 
@@ -92,6 +94,7 @@ private:
 	[[nodiscard]] unsigned getSlot(int ps, int ss) const;
 	std::string insertCartridge(std::string_view cartName, std::string_view romName, std::span<const TclObject> options);
 	void removeCartridge(std::string_view cartName);
+	[[nodiscard]] std::vector<std::string> getCartRomState(std::string_view cartName) const;
 
 private:
 	MSXMotherBoard& motherBoard;


### PR DESCRIPTION
Currently the no-argument form of the cartridge commands (`cart`, `carta`, `cartb`, `cartc`, ...) reports only the inserted cartridge name:

```
carta
carta: /path/to/rom.rom
```
When a ROM cartridge has IPS patches applied (e.g. `carta <rom> -ips patch1.ips` `-ips patch2.ips`), there is no way to see that from the emulator state — the applied patches only live in the internal auto-generated config.

This PR makes the plain query also report the list of applied IPS patch files, so the full media state is verifiable:
```
> carta
carta: /path/to/rom.rom {patch.ips}
```
For a ROM cartridge with no patches an empty list is reported:
```
> carta
carta: /path/to/rom.rom {}
```

For compatibility, the `empty` response was maintained when no cart is found, like in:
```
carta: {} empty
```
This request completes the tool set of MCP servers that need to expose an IPS patch interface to AI agents to both apply patches (`carta <rom> -ips <file>`) and query the current patch state of a cartridge so the agent can inspect what was applied, round-trip the state across sessions, or clean up the list of applied patches.