### PR TITLE
Guard against getpwuid() returning nullptr in CliServer

### DIFF
--- a/src/events/CliServer.cc
+++ b/src/events/CliServer.cc
@@ -30,7 +30,7 @@ namespace openmsx {
 	return "default";
 #else
 	const struct passwd* pw = getpwuid(getuid());
-	return pw->pw_name ? pw->pw_name : std::string{};
+	return (pw && pw->pw_name) ? pw->pw_name : std::string{};
 #endif
 }
 


### PR DESCRIPTION
getUserName() dereferenced the result of getpwuid() without checking it. getpwuid() can return nullptr when the uid has no passwd entry, for example in a container or sandbox. Found while porting to iOS.