### PR TITLE
VisibleSurface: register observers only after init can't throw

### DIFF
--- a/src/video/VisibleSurface.cc
+++ b/src/video/VisibleSurface.cc
@@ -58,18 +58,6 @@ VisibleSurface::VisibleSurface(
 {
 	auto& renderSettings = display.getRenderSettings();
 
-	inputEventGenerator.getGrabInput().attach(*this);
-	renderSettings.getPointerHideDelaySetting().attach(*this);
-	renderSettings.getFullScreenSetting().attach(*this);
-	pauseSetting.attach(*this);
-
-	for (auto type : {EventType::MOUSE_MOTION,
-	                  EventType::MOUSE_BUTTON_DOWN,
-	                  EventType::MOUSE_BUTTON_UP,
-	                  EventType::IMGUI_ACTIVE}) {
-		eventDistributor.registerEventListener(type, *this);
-	}
-
 	updateCursor();
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 0);
@@ -156,6 +144,19 @@ VisibleSurface::VisibleSurface(
 	glBindVertexArray(vao);
 #endif
 	inputEventGenerator.initializeGrab();
+
+	// Keep last: if the ctor throws, ~VisibleSurface won't run to detach.
+	inputEventGenerator.getGrabInput().attach(*this);
+	renderSettings.getPointerHideDelaySetting().attach(*this);
+	renderSettings.getFullScreenSetting().attach(*this);
+	pauseSetting.attach(*this);
+
+	for (auto type : {EventType::MOUSE_MOTION,
+	                  EventType::MOUSE_BUTTON_DOWN,
+	                  EventType::MOUSE_BUTTON_UP,
+	                  EventType::IMGUI_ACTIVE}) {
+		eventDistributor.registerEventListener(type, *this);
+	}
 }
 
 VisibleSurface::~VisibleSurface()


### PR DESCRIPTION
Full disclosure: this change was authored with assistance of Claude Code.

I ran into this crash while working on getting openMSX to run on iOS. It seems a legit problem with the VisibleSurface error path.

The constructor attached *this to several long-lived Settings (grab-input, pointer-hide-delay, full-screen, pause) and registered event listeners at the very top, before the initialization that can fail: GL context creation, ImGui backend setup, the GLEW version checks.

If any of that throws, ~VisibleSurface never runs, so the matching detach() and unregisterEventListener() calls in the destructor are skipped. The Settings and the EventDistributor are then left holding a dangling pointer into the destroyed surface. This is not merely a shutdown problem: Display::doRendererSwitch catches the exception and retries with a lower scale factor, so the program keeps running with the stale registrations, and the next mouse event or setting change already calls into freed memory.

Move the registrations to the end of the constructor, after everything that can throw. A failed construction now leaves nothing attached. Behaviour is otherwise unchanged: none of those settings is consulted through a callback during construction, and event delivery only happens from deliverEvents on the main thread, so nothing can dispatch mid-construction.