### PR TITLE
CI: fix and split the 3rdparty cache

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -49,7 +49,7 @@ runs:
         path: |
           derived/3rdparty
           derived/*/3rdparty
-        key: ${{ github.ref }}-${{ inputs.os }}-${{ inputs.cpu }}-${{ inputs.flavour }}-${{ hashFiles('build/packages.py') }}
+        key: ${{ github.ref }}-${{ inputs.os }}-${{ inputs.cpu }}-${{ inputs.flavour }}-${{ hashFiles('build/packages.py', 'build/3rdparty.mk') }}
     - name: Download 3rd party packages for Windows VC build
       if: ${{ inputs.os == 'windows-vc' && steps.cache-3rdparty.outputs.cache-hit != 'true' }}
       shell: pwsh


### PR DESCRIPTION
The key hashed only packages.py, not 3rdparty.mk, creating builds using stale 3rd party files.